### PR TITLE
:white_check_mark: Added test to validate that re-indexing updates ES data when providing same UUID

### DIFF
--- a/src/woo_search/search_index/tests/test_tasks.py
+++ b/src/woo_search/search_index/tests/test_tasks.py
@@ -66,3 +66,57 @@ class DocumentTaskTest(VCRMixin, ElasticSearchTestCase):
             doc.laatst_gewijzigd_datum,
             datetime(2026, 1, 5, 12, 0, 0, tzinfo=timezone.utc),
         )
+
+        with self.subTest("re-indexing data with same UUID updates values"):
+            index_document(
+                uuid=document_uuid,
+                publicatie="CHANGED",
+                publisher={
+                    "uuid": "CHANGED",
+                    "naam": "Amsterdam",
+                },
+                identifier="https://www.example.com/999",
+                officiele_titel="CHANGED TITLE",
+                verkorte_titel="CHANGED",
+                omschrijving="CHANGED OMSCHRIJVING",
+                creatiedatum=date(2030, 1, 1),
+                registratiedatum=datetime(2030, 1, 5, 12, 0, 0, tzinfo=timezone.utc),
+                laatst_gewijzigd_datum=datetime(
+                    2030, 1, 5, 12, 0, 0, tzinfo=timezone.utc
+                ),
+            )
+
+            with get_client() as client:
+                updated_doc = Document.get(
+                    using=client,
+                    id=document_uuid,
+                )
+
+            assert isinstance(updated_doc, Document), "Expected doc to be indexed"
+            # Assert the provided data is indexed properly.
+            self.assertEqual(updated_doc.uuid, "0095704d-4216-4de3-83d2-20dba551b0dc")
+            self.assertEqual(updated_doc.publicatie, "CHANGED")
+            self.assertEqual(
+                updated_doc.publisher,
+                {
+                    "uuid": "CHANGED",
+                    "naam": "Amsterdam",
+                },
+            )
+            self.assertEqual(updated_doc.identifier, "https://www.example.com/999")
+            self.assertEqual(updated_doc.officiele_titel, "CHANGED TITLE")
+            self.assertEqual(updated_doc.verkorte_titel, "CHANGED")
+            self.assertEqual(updated_doc.omschrijving, "CHANGED OMSCHRIJVING")
+            # date -> converted to naive datetime
+            self.assertEqual(
+                updated_doc.creatiedatum,
+                datetime(2030, 1, 1, 0, 0, 0, tzinfo=TIMEZONE_AMS),
+            )
+            self.assertEqual(
+                updated_doc.registratiedatum,
+                datetime(2030, 1, 5, 12, 0, 0, tzinfo=timezone.utc),
+            )
+            self.assertEqual(
+                updated_doc.laatst_gewijzigd_datum,
+                datetime(2030, 1, 5, 12, 0, 0, tzinfo=timezone.utc),
+            )

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/DocumentTaskTest/test_index_document_roundtrip.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/DocumentTaskTest/test_index_document_roundtrip.yaml
@@ -59,4 +59,60 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: '{"uuid":"0095704d-4216-4de3-83d2-20dba551b0dc","publicatie":"CHANGED","publisher":{"uuid":"CHANGED","naam":"Amsterdam"},"identifier":"https://www.example.com/999","officiele_titel":"CHANGED
+      TITLE","verkorte_titel":"CHANGED","omschrijving":"CHANGED OMSCHRIJVING","creatiedatum":"2030-01-01T00:00:00+01:00","registratiedatum":"2030-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2030-01-05T12:00:00+00:00"}'
+    headers:
+      accept:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      connection:
+      - keep-alive
+      content-type:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      user-agent:
+      - elasticsearch-dsl-py/8.17.1
+      x-elastic-client-meta:
+      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+    method: PUT
+    uri: http://localhost:9201/document/_doc/0095704d-4216-4de3-83d2-20dba551b0dc
+  response:
+    body:
+      string: '{"_index":"document","_id":"0095704d-4216-4de3-83d2-20dba551b0dc","_version":2,"result":"updated","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}'
+    headers:
+      X-elastic-product:
+      - Elasticsearch
+      content-length:
+      - '176'
+      content-type:
+      - application/vnd.elasticsearch+json;compatible-with=8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      accept:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      connection:
+      - keep-alive
+      user-agent:
+      - elasticsearch-dsl-py/8.17.1
+      x-elastic-client-meta:
+      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+    method: GET
+    uri: http://localhost:9201/document/_doc/0095704d-4216-4de3-83d2-20dba551b0dc
+  response:
+    body:
+      string: '{"_index":"document","_id":"0095704d-4216-4de3-83d2-20dba551b0dc","_version":2,"_seq_no":1,"_primary_term":1,"found":true,"_source":{"uuid":"0095704d-4216-4de3-83d2-20dba551b0dc","publicatie":"CHANGED","publisher":{"uuid":"CHANGED","naam":"Amsterdam"},"identifier":"https://www.example.com/999","officiele_titel":"CHANGED
+        TITLE","verkorte_titel":"CHANGED","omschrijving":"CHANGED OMSCHRIJVING","creatiedatum":"2030-01-01T00:00:00+01:00","registratiedatum":"2030-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2030-01-05T12:00:00+00:00"}}'
+    headers:
+      X-elastic-product:
+      - Elasticsearch
+      content-length:
+      - '538'
+      content-type:
+      - application/vnd.elasticsearch+json;compatible-with=8
+    status:
+      code: 200
+      message: OK
 version: 1


### PR DESCRIPTION
Fixes #10

**Changes**

Extended test on Document task to test if indexing the data again updates the information
