### PR TITLE
Support filtering on information categories

### DIFF
--- a/src/woo_search/api/openapi.yaml
+++ b/src/woo_search/api/openapi.yaml
@@ -167,6 +167,12 @@ components:
         publicatie:
           type: string
           description: The unique identifier of the publication.
+        informatieCategorieen:
+          type: array
+          items:
+            $ref: '#/components/schemas/InformatieCategorie'
+          description: The information categories present on the publication that
+            the document belongs to.
         publisher:
           allOf:
           - $ref: '#/components/schemas/Publisher'
@@ -205,6 +211,7 @@ components:
             in the GPP-Publicatiebank.
       required:
       - creatiedatum
+      - informatieCategorieen
       - laatstGewijzigdDatum
       - officieleTitel
       - publicatie
@@ -229,6 +236,25 @@ components:
           type: string
           maxLength: 255
       required:
+      - naam
+      - uuid
+    InformationCategoryBucket:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          description: Unique ID identifying the information category in GPP-publicatiebank.
+        naam:
+          type: string
+          description: Name of the information category.
+        count:
+          type: integer
+          minimum: 0
+          title: Amount of hits
+          description: The amount of search results sharing this category.
+      required:
+      - count
       - naam
       - uuid
     NaamEnum:
@@ -425,6 +451,15 @@ components:
             title: Publisher UUID
           description: Filter results published by (one of) the given publishers'
             `uuid`.
+        informatieCategorieen:
+          type: array
+          items:
+            type: string
+            format: uuid
+            title: Category UUID
+          title: Information categories
+          description: Filter results published by (one of) the given categories'
+            `uuid`.
     SearchFacets:
       type: object
       properties:
@@ -436,7 +471,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PublisherBucket'
+        informatieCategorieen:
+          type: array
+          items:
+            $ref: '#/components/schemas/InformationCategoryBucket'
       required:
+      - informatieCategorieen
       - publishers
       - resultTypes
     SearchResponse:

--- a/src/woo_search/search_index/api/serializers/publications.py
+++ b/src/woo_search/search_index/api/serializers/publications.py
@@ -18,6 +18,14 @@ class DocumentSerializer(serializers.Serializer):
     publicatie = serializers.CharField(
         help_text=_("The unique identifier of the publication."),
     )
+    informatie_categorieen = InformatieCategorieSerializer(
+        help_text=_(
+            "The information categories present on the publication that the document "
+            "belongs to."
+        ),
+        required=True,
+        many=True,
+    )
     publisher = PublisherSerializer(
         help_text=_(
             "The organisation which publishes the publication of this document."

--- a/src/woo_search/search_index/api/views.py
+++ b/src/woo_search/search_index/api/views.py
@@ -27,7 +27,7 @@ class SearchView(APIView):
         search_results = get_search_results(
             query=params["query"],
             publishers=params["publishers"],
-            information_categories=[],
+            information_categories=params["informatie_categorieen"],
             result_type=rt if (rt := params["result_type"]) != "*" else None,
             registration_date_from=params["registratiedatum_vanaf"],
             registration_date_to=params["registratiedatum_tot"],

--- a/src/woo_search/search_index/api/viewsets.py
+++ b/src/woo_search/search_index/api/viewsets.py
@@ -37,6 +37,7 @@ class DocumentViewSet(viewsets.ViewSet):
         save_document_task = index_document.delay(
             uuid=validated_data["uuid"],
             publicatie=validated_data["publicatie"],
+            informatie_categorieen=validated_data["informatie_categorieen"],
             publisher=validated_data["publisher"],
             identifier=validated_data["identifier"],
             officiele_titel=validated_data["officiele_titel"],

--- a/src/woo_search/search_index/documents/publications.py
+++ b/src/woo_search/search_index/documents/publications.py
@@ -31,6 +31,9 @@ class Document(ES_Document):
     # for typing support.
     uuid: M[str] = mapped_field(Text(required=True))
     publicatie: M[str] = mapped_field(Text(required=True))
+    informatie_categorieen: M[List[InformatieCategorieType]] = mapped_field(
+        Nested(InformatieCategorie, required=True)
+    )
     publisher: M[PublisherType] = mapped_field(Object(Publisher, required=True))
     identifier: M[str] = mapped_field(Text(required=True))
     officiele_titel: M[str] = mapped_field(Text(required=True))

--- a/src/woo_search/search_index/tasks.py
+++ b/src/woo_search/search_index/tasks.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 def index_document(
     uuid: str,
     publicatie: str,
+    informatie_categorieen: list[InformatieCategorieType],
     publisher: PublisherType,
     identifier: str,
     officiele_titel: str,
@@ -31,6 +32,7 @@ def index_document(
         _id=uuid,
         uuid=uuid,
         publicatie=publicatie,
+        informatie_categorieen=informatie_categorieen,
         publisher=publisher,
         identifier=identifier,
         officiele_titel=officiele_titel,

--- a/src/woo_search/search_index/tests/factories.py
+++ b/src/woo_search/search_index/tests/factories.py
@@ -11,6 +11,14 @@ class PublisherFactory(factory.Factory):
         model = dict
 
 
+class InformationCategoryFactory(factory.Factory):
+    uuid = factory.Faker("uuid4", cast_to=str)
+    naam = factory.Faker("sentence", nb_words=3)
+
+    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+        model = dict
+
+
 class IndexDocumentFactory(factory.Factory):
     uuid = factory.Faker("uuid4", cast_to=str)
     publicatie = factory.Faker("uuid4", cast_to=str)
@@ -26,13 +34,19 @@ class IndexDocumentFactory(factory.Factory):
     class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
         model = dict
 
-
-class InformationCategoryFactory(factory.Factory):
-    uuid = factory.Faker("uuid4", cast_to=str)
-    naam = factory.Faker("sentence", nb_words=3)
-
-    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
-        model = dict
+    @factory.post_generation
+    def informatie_categorieen(
+        self: dict[str, Any],  # pyright: ignore[reportGeneralTypeIssues]
+        create,
+        extracted,
+        **kwargs,
+    ):
+        if extracted:
+            self["informatie_categorieen"] = extracted
+        else:
+            size = kwargs.pop("size", 1)
+            categories = InformationCategoryFactory.create_batch(size, **kwargs)
+            self["informatie_categorieen"] = categories
 
 
 class IndexPublicationFactory(factory.Factory):

--- a/src/woo_search/search_index/tests/test_publications_api.py
+++ b/src/woo_search/search_index/tests/test_publications_api.py
@@ -37,6 +37,9 @@ class DocumentAPITests(TokenAuthMixin, APITestCase):
         data = {
             "uuid": "0c5730c7-17ed-42a7-bc3b-5ee527ef3326",
             "publicatie": "e28fba05-14b3-4d9f-94c1-de95b60cc5b3",
+            "informatieCategorieen": [
+                {"uuid": "cd26d21a-8c49-4dff-ae82-20f4e28dfbaf", "naam": "WOO"}
+            ],
             "publisher": {
                 "uuid": "f8b2b355-1d6e-4c1a-ba18-565f422997da",
                 "naam": "Utrecht",
@@ -58,6 +61,9 @@ class DocumentAPITests(TokenAuthMixin, APITestCase):
         snake_case_data = {
             "uuid": "0c5730c7-17ed-42a7-bc3b-5ee527ef3326",
             "publicatie": "e28fba05-14b3-4d9f-94c1-de95b60cc5b3",
+            "informatie_categorieen": [
+                {"uuid": "cd26d21a-8c49-4dff-ae82-20f4e28dfbaf", "naam": "WOO"}
+            ],
             "publisher": {
                 "uuid": "f8b2b355-1d6e-4c1a-ba18-565f422997da",
                 "naam": "Utrecht",
@@ -107,6 +113,9 @@ class DocumentApiE2ETest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
         data = {
             "uuid": "0c5730c7-17ed-42a7-bc3b-5ee527ef3326",
             "publicatie": "e28fba05-14b3-4d9f-94c1-de95b60cc5b3",
+            "informatieCategorieen": [
+                {"uuid": "cd26d21a-8c49-4dff-ae82-20f4e28dfbaf", "naam": "WOO"}
+            ],
             "publisher": {
                 "uuid": "f8b2b355-1d6e-4c1a-ba18-565f422997da",
                 "naam": "Utrecht",

--- a/src/woo_search/search_index/tests/test_search_api.py
+++ b/src/woo_search/search_index/tests/test_search_api.py
@@ -43,6 +43,9 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
         index_document(
             uuid="525747fd-7e58-4005-8efa-59bcf4403385",
             publicatie="6dae9be7-4f93-4aad-b56a-10b683b16dcc",
+            informatie_categorieen=[
+                {"uuid": "2ff3d47c-7945-4267-b3b2-e63aca280b8d", "naam": "WOO"}
+            ],
             publisher={
                 "uuid": "2f809be7-b585-4cb8-8010-9682c4281aec",
                 "naam": "Utrecht",
@@ -74,6 +77,9 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
                 "record": {
                     "uuid": "525747fd-7e58-4005-8efa-59bcf4403385",
                     "publicatie": "6dae9be7-4f93-4aad-b56a-10b683b16dcc",
+                    "informatieCategorieen": [
+                        {"uuid": "2ff3d47c-7945-4267-b3b2-e63aca280b8d", "naam": "WOO"}
+                    ],
                     "publisher": {
                         "uuid": "2f809be7-b585-4cb8-8010-9682c4281aec",
                         "naam": "Utrecht",
@@ -129,6 +135,9 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
         index_document(
             uuid="85a095ea-e1fa-438c-9e05-1862874f57a0",
             publicatie="6dae9be7-4f93-4aad-b56a-10b683b16dcc",
+            informatie_categorieen=[
+                {"uuid": "2ff3d47c-7945-4267-b3b2-e63aca280b8d", "naam": "WOO"}
+            ],
             publisher={
                 "uuid": "2f809be7-b585-4cb8-8010-9682c4281aec",
                 "naam": "Utrecht",
@@ -174,6 +183,9 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
         index_document(
             uuid="48981334-b480-4e7d-8c8d-925bbc67a969",
             publicatie="6dae9be7-4f93-4aad-b56a-10b683b16dcc",
+            informatie_categorieen=[
+                {"uuid": "2ff3d47c-7945-4267-b3b2-e63aca280b8d", "naam": "WOO"}
+            ],
             publisher={
                 "uuid": "2f809be7-b585-4cb8-8010-9682c4281aec",
                 "naam": "Utrecht",
@@ -219,6 +231,9 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
         index_document(
             uuid="3b3f4514-7d8b-4e31-83ca-fa9376ff6522",
             publicatie="6dae9be7-4f93-4aad-b56a-10b683b16dcc",
+            informatie_categorieen=[
+                {"uuid": "2ff3d47c-7945-4267-b3b2-e63aca280b8d", "naam": "WOO"}
+            ],
             publisher={
                 "uuid": "2f809be7-b585-4cb8-8010-9682c4281aec",
                 "naam": "Utrecht",
@@ -265,6 +280,9 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
         index_document(
             uuid="387d982b-d7c8-48e8-9665-2dbfb6f8688c",
             publicatie="6dae9be7-4f93-4aad-b56a-10b683b16dcc",
+            informatie_categorieen=[
+                {"uuid": "2ff3d47c-7945-4267-b3b2-e63aca280b8d", "naam": "WOO"}
+            ],
             publisher={
                 "uuid": "2f809be7-b585-4cb8-8010-9682c4281aec",
                 "naam": "Utrecht",
@@ -314,6 +332,9 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
         index_document(
             uuid="6dd95a10-cc97-4f19-b7e4-2c85358acb98",
             publicatie="6dae9be7-4f93-4aad-b56a-10b683b16dcc",
+            informatie_categorieen=[
+                {"uuid": "2ff3d47c-7945-4267-b3b2-e63aca280b8d", "naam": "WOO"}
+            ],
             publisher={
                 "uuid": "2f809be7-b585-4cb8-8010-9682c4281aec",
                 "naam": "Utrecht",
@@ -344,6 +365,9 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
         index_document(
             uuid="3916925a-4260-4505-bfbb-0942113efd49",
             publicatie="6dae9be7-4f93-4aad-b56a-10b683b16dcc",
+            informatie_categorieen=[
+                {"uuid": "2ff3d47c-7945-4267-b3b2-e63aca280b8d", "naam": "WOO"}
+            ],
             publisher={
                 "uuid": "2f809be7-b585-4cb8-8010-9682c4281aec",
                 "naam": "Utrecht",
@@ -359,6 +383,9 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
         index_document(
             uuid="d49bc304-01a1-4eda-a914-a8dda5c901e2",
             publicatie="6dae9be7-4f93-4aad-b56a-10b683b16dcc",
+            informatie_categorieen=[
+                {"uuid": "2ff3d47c-7945-4267-b3b2-e63aca280b8d", "naam": "WOO"}
+            ],
             publisher={
                 "uuid": "2f809be7-b585-4cb8-8010-9682c4281aec",
                 "naam": "Utrecht",
@@ -374,6 +401,9 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
         index_document(
             uuid="bdcc4cea-b186-425e-8dcd-9fecb6818563",
             publicatie="6dae9be7-4f93-4aad-b56a-10b683b16dcc",
+            informatie_categorieen=[
+                {"uuid": "2ff3d47c-7945-4267-b3b2-e63aca280b8d", "naam": "WOO"}
+            ],
             publisher={
                 "uuid": "2f809be7-b585-4cb8-8010-9682c4281aec",
                 "naam": "Utrecht",
@@ -389,6 +419,9 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
         index_document(
             uuid="7eade718-bccb-4876-9f00-a095beebc360",
             publicatie="6dae9be7-4f93-4aad-b56a-10b683b16dcc",
+            informatie_categorieen=[
+                {"uuid": "2ff3d47c-7945-4267-b3b2-e63aca280b8d", "naam": "WOO"}
+            ],
             publisher={
                 "uuid": "2f809be7-b585-4cb8-8010-9682c4281aec",
                 "naam": "Utrecht",

--- a/src/woo_search/search_index/tests/test_search_api.py
+++ b/src/woo_search/search_index/tests/test_search_api.py
@@ -10,7 +10,12 @@ from woo_search.utils.tests.vcr import VCRMixin
 
 from ..tasks import index_document, index_publication
 from .base import ElasticSearchAPITestCase
-from .factories import IndexDocumentFactory, IndexPublicationFactory, PublisherFactory
+from .factories import (
+    IndexDocumentFactory,
+    IndexPublicationFactory,
+    InformationCategoryFactory,
+    PublisherFactory,
+)
 
 
 class SearchApiAccessTest(APIKeyUnAuthorizedMixin, APITestCase):
@@ -833,6 +838,88 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
                 {
                     "uuid": "e0eb40f7-eacb-45dc-973a-2e8480f49b76",
                     "naam": "Maycatt",
+                    "count": 1,
+                },
+            )
+
+    def test_filter_by_information_category_uuid(self):
+        ic_1 = InformationCategoryFactory.build(
+            uuid="f9cc8c26-7ce7-4a25-9554-e6a2892176d7",
+            naam="Inspanningsverplichting",
+        )
+        ic_2 = InformationCategoryFactory.build(
+            uuid="e0eb40f7-eacb-45dc-973a-2e8480f49b76",
+            naam="WOO",
+        )
+        doc1 = IndexDocumentFactory.build(
+            uuid="8bca9140-81f6-46f0-823a-31184e10ff66",
+            informatie_categorieen=[ic_1],
+        )
+        # document with random information categories, must not be a hit
+        doc2 = IndexDocumentFactory.build(uuid="0ea8b96e-cca5-45df-9797-abf9cfef3ed6")
+        pub1 = IndexPublicationFactory.build(
+            uuid="dd3b8be0-e461-498a-9a18-0f5fc8adc956",
+            informatie_categorieen=[ic_2],
+        )
+        # publication with random information categories, must not be a hit
+        pub2 = IndexPublicationFactory.build(
+            uuid="3d6f91fc-ce3b-45d0-b3d6-c304be03845d"
+        )
+        index_publication(**pub1)
+        index_publication(**pub2)
+        index_document(**doc1)
+        index_document(**doc2)
+
+        with self.subTest("query with non-existing UUID"):
+            response = self.client.post(
+                self.url,
+                {"informatieCategorieen": ["1934d1db-b5c8-4521-97fe-a2ef969dd84e"]},
+            )
+
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()["count"], 0)
+
+        with self.subTest("expect match on one of provided UUIDs"):
+            response = self.client.post(
+                self.url,
+                {
+                    "informatieCategorieen": [
+                        "f9cc8c26-7ce7-4a25-9554-e6a2892176d7",
+                        "e0eb40f7-eacb-45dc-973a-2e8480f49b76",
+                    ]
+                },
+            )
+
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            self.assertEqual(data["count"], 2)
+            expected_ids = {
+                "8bca9140-81f6-46f0-823a-31184e10ff66",
+                "dd3b8be0-e461-498a-9a18-0f5fc8adc956",
+            }
+            ids = set(result["record"]["uuid"] for result in data["results"])
+            self.assertEqual(ids, expected_ids)
+            # assert on the buckets
+            self.assertIn("facets", data)
+            self.assertIn("informatieCategorieen", data["facets"])
+            facets_by_id = {
+                publisher["uuid"]: publisher
+                for publisher in data["facets"]["informatieCategorieen"]
+            }
+            self.assertEqual(len(facets_by_id), 2)
+            self.assertEqual(
+                facets_by_id["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"],
+                {
+                    "uuid": "f9cc8c26-7ce7-4a25-9554-e6a2892176d7",
+                    "naam": "Inspanningsverplichting",
+                    "count": 1,
+                },
+            )
+            self.assertEqual(
+                facets_by_id["e0eb40f7-eacb-45dc-973a-2e8480f49b76"],
+                {
+                    "uuid": "e0eb40f7-eacb-45dc-973a-2e8480f49b76",
+                    "naam": "WOO",
                     "count": 1,
                 },
             )

--- a/src/woo_search/search_index/tests/test_tasks.py
+++ b/src/woo_search/search_index/tests/test_tasks.py
@@ -23,6 +23,9 @@ class DocumentTaskTest(VCRMixin, ElasticSearchTestCase):
         index_document(
             uuid=document_uuid,
             publicatie="d481bea6-335b-4d90-9b27-ac49f7196633",
+            informatie_categorieen=[
+                {"uuid": "3c42a70a-d81d-4143-91d1-ebf62ac8b597", "naam": "WOO"}
+            ],
             publisher={
                 "uuid": "f8b2b355-1d6e-4c1a-ba18-565f422997da",
                 "naam": "Utrecht",
@@ -48,6 +51,10 @@ class DocumentTaskTest(VCRMixin, ElasticSearchTestCase):
         # Assert the provided data is indexed properly.
         self.assertEqual(doc.uuid, "0095704d-4216-4de3-83d2-20dba551b0dc")
         self.assertEqual(doc.publicatie, "d481bea6-335b-4d90-9b27-ac49f7196633")
+        self.assertEqual(
+            doc.informatie_categorieen,
+            [{"uuid": "3c42a70a-d81d-4143-91d1-ebf62ac8b597", "naam": "WOO"}],
+        )
         self.assertEqual(
             doc.publisher,
             {
@@ -76,6 +83,9 @@ class DocumentTaskTest(VCRMixin, ElasticSearchTestCase):
             index_document(
                 uuid=document_uuid,
                 publicatie="CHANGED",
+                informatie_categorieen=[
+                    {"uuid": "3c42a70a-d81d-4143-91d1-ebf62ac8b597", "naam": "WOO"}
+                ],
                 publisher={
                     "uuid": "CHANGED",
                     "naam": "Amsterdam",
@@ -101,6 +111,10 @@ class DocumentTaskTest(VCRMixin, ElasticSearchTestCase):
             # Assert the provided data is indexed properly.
             self.assertEqual(updated_doc.uuid, "0095704d-4216-4de3-83d2-20dba551b0dc")
             self.assertEqual(updated_doc.publicatie, "CHANGED")
+            self.assertEqual(
+                doc.informatie_categorieen,
+                [{"uuid": "3c42a70a-d81d-4143-91d1-ebf62ac8b597", "naam": "WOO"}],
+            )
             self.assertEqual(
                 updated_doc.publisher,
                 {

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_publications_api/DocumentApiE2ETest/test_document_creation_happy_flow.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_publications_api/DocumentApiE2ETest/test_document_creation_happy_flow.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"uuid":"0c5730c7-17ed-42a7-bc3b-5ee527ef3326","publicatie":"e28fba05-14b3-4d9f-94c1-de95b60cc5b3","publisher":{"uuid":"f8b2b355-1d6e-4c1a-ba18-565f422997da","naam":"Utrecht"},"identifier":"https://example.com/b36519a5-64d9-4316-a042-3ac5406f8f61","officiele_titel":"Een
+    body: '{"uuid":"0c5730c7-17ed-42a7-bc3b-5ee527ef3326","publicatie":"e28fba05-14b3-4d9f-94c1-de95b60cc5b3","informatie_categorieen":[{"uuid":"cd26d21a-8c49-4dff-ae82-20f4e28dfbaf","naam":"WOO"}],"publisher":{"uuid":"f8b2b355-1d6e-4c1a-ba18-565f422997da","naam":"Utrecht"},"identifier":"https://example.com/b36519a5-64d9-4316-a042-3ac5406f8f61","officiele_titel":"Een
       erg belangrijk bestand.","verkorte_titel":"Een bestand.","omschrijving":"bla
       bla bla bla.","creatiedatum":"2025-02-04","registratiedatum":"2025-02-04T15:42:53.646693+01:00","laatst_gewijzigd_datum":"2025-02-04T15:42:53.646700+01:00"}'
     headers:
@@ -46,14 +46,14 @@ interactions:
     uri: http://localhost:9201/document/_doc/0c5730c7-17ed-42a7-bc3b-5ee527ef3326
   response:
     body:
-      string: '{"_index":"document","_id":"0c5730c7-17ed-42a7-bc3b-5ee527ef3326","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"uuid":"0c5730c7-17ed-42a7-bc3b-5ee527ef3326","publicatie":"e28fba05-14b3-4d9f-94c1-de95b60cc5b3","publisher":{"uuid":"f8b2b355-1d6e-4c1a-ba18-565f422997da","naam":"Utrecht"},"identifier":"https://example.com/b36519a5-64d9-4316-a042-3ac5406f8f61","officiele_titel":"Een
+      string: '{"_index":"document","_id":"0c5730c7-17ed-42a7-bc3b-5ee527ef3326","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"uuid":"0c5730c7-17ed-42a7-bc3b-5ee527ef3326","publicatie":"e28fba05-14b3-4d9f-94c1-de95b60cc5b3","informatie_categorieen":[{"uuid":"cd26d21a-8c49-4dff-ae82-20f4e28dfbaf","naam":"WOO"}],"publisher":{"uuid":"f8b2b355-1d6e-4c1a-ba18-565f422997da","naam":"Utrecht"},"identifier":"https://example.com/b36519a5-64d9-4316-a042-3ac5406f8f61","officiele_titel":"Een
         erg belangrijk bestand.","verkorte_titel":"Een bestand.","omschrijving":"bla
         bla bla bla.","creatiedatum":"2025-02-04","registratiedatum":"2025-02-04T15:42:53.646693+01:00","laatst_gewijzigd_datum":"2025-02-04T15:42:53.646700+01:00"}}'
     headers:
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '637'
+      - '725'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_information_category_uuid.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_information_category_uuid.yaml
@@ -1,9 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"ee010597-f23b-4b67-b104-0a3ea475fc20","naam":"Nunez
-      Inc"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Throughout
-      itself bed project color effect seat evidence.","verkorte_titel":"Measure.","omschrijving":"Society
-      wall war bad. Gas serve marriage star after.","registratiedatum":"2025-02-13T17:40:10.458512","laatst_gewijzigd_datum":"2025-02-02T12:37:08.214610"}'
+    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"c5df7545-829f-4067-9324-29d5c085d542","naam":"Kirby
+      Inc"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Draw
+      single wish right page.","verkorte_titel":"Game capital.","omschrijving":"Door
+      explain ask want family. Past serious police property send who. North head some
+      win Democrat thank push. Painting poor school bag.","registratiedatum":"2025-02-17T06:42:11.670415","laatst_gewijzigd_datum":"2025-02-25T17:26:08.963719"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,11 +34,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"15211614-be29-4724-9bf2-ee43cbd92b31","naam":"Owens
-      PLC"},"informatie_categorieen":[{"uuid":"52017054-dce2-4fd1-b737-0ee0ca9b501c","naam":"Capital
-      lose stop."}],"officiele_titel":"Improve painting benefit my impact.","verkorte_titel":"Quickly
-      painting.","omschrijving":"Dog line wife or. Will product smile thus response
-      as allow.","registratiedatum":"2025-02-24T11:05:41.153344","laatst_gewijzigd_datum":"2025-01-28T10:38:54.568907"}'
+    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"47d5fc4d-92fe-4d62-afa8-723e2e79839d","naam":"Evans-Kelly"},"informatie_categorieen":[{"uuid":"72787169-ca96-4e45-ad7e-2c89207ab5d3","naam":"Foreign
+      station."}],"officiele_titel":"Trip same movement season protect list entire
+      suddenly.","verkorte_titel":"Debate situation.","omschrijving":"Standard five
+      activity. Actually else different group thank region federal. Military eat course
+      scene any her.","registratiedatum":"2025-02-13T13:26:00.928976","laatst_gewijzigd_datum":"2025-02-25T00:01:56.557758"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -67,10 +68,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"64e65f57-37bc-4ed7-bf60-7be4c1f6f102","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"847d191e-e373-4cb6-ad1f-54db1198d7d4","naam":"Michael-Robinson"},"identifier":"identifier-0","officiele_titel":"Condition
-      board Mrs gun wife media yard within.","verkorte_titel":"Partner positive.","omschrijving":"Part
-      plant majority tonight choose learn. People law officer five field. Recent area
-      allow his task. See skin room whatever consider.","creatiedatum":"2025-01-29","registratiedatum":"2025-02-22T10:59:09.270013","laatst_gewijzigd_datum":"2025-01-26T22:27:12.902652"}'
+    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"f1988da3-2d9d-4439-b709-6479d97da80a","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"029d7504-15aa-4c23-825e-3f5b67f9bc2c","naam":"Douglas
+      Ltd"},"identifier":"identifier-0","officiele_titel":"Study style white nation
+      common past.","verkorte_titel":"Evening cause vote.","omschrijving":"About treatment
+      baby owner question region central. Loss something remain white too. Can civil
+      major well quality technology.","creatiedatum":"2025-01-30","registratiedatum":"2025-02-11T18:07:05.147537","laatst_gewijzigd_datum":"2025-02-22T09:09:56.459759"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -100,12 +102,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"df73ad01-7f1c-458b-bf1d-6dc0b9b0a942","informatie_categorieen":[{"uuid":"a76306d0-4c45-40b2-9839-cbdfb072463a","naam":"If
-      development."}],"publisher":{"uuid":"3c296a9c-a38d-49c0-8853-114e82c8d704","naam":"Perez,
-      Goodman and Brock"},"identifier":"identifier-1","officiele_titel":"Generation
-      yourself point tell.","verkorte_titel":"Cultural four anyone.","omschrijving":"Physical
-      sit land guy easy time. Understand threat product role prevent close service
-      century.","creatiedatum":"2025-02-08","registratiedatum":"2025-02-13T20:28:45.801470","laatst_gewijzigd_datum":"2025-02-01T12:44:35.127809"}'
+    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"b37d4784-4aa6-4298-b1ac-c0f6daa1ef72","informatie_categorieen":[{"uuid":"16dd0152-48e5-4b32-9755-88866e58b7d7","naam":"Charge
+      study."}],"publisher":{"uuid":"7a182016-bd2a-4b86-a88c-1d71fb9510d5","naam":"Hardy
+      LLC"},"identifier":"identifier-1","officiele_titel":"Seek education make space
+      do discuss.","verkorte_titel":"Clear eye discussion.","omschrijving":"A wind
+      much maybe be example behavior without. Population research deal. Operation
+      available surface second style.","creatiedatum":"2025-01-28","registratiedatum":"2025-02-21T10:51:32.565584","laatst_gewijzigd_datum":"2025-02-14T19:13:50.732951"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -151,7 +153,7 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
+      string: '{"took":109,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -179,14 +181,17 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":0.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"ee010597-f23b-4b67-b104-0a3ea475fc20","naam":"Nunez
-        Inc"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Throughout
-        itself bed project color effect seat evidence.","verkorte_titel":"Measure.","omschrijving":"Society
-        wall war bad. Gas serve marriage star after.","registratiedatum":"2025-02-13T17:40:10.458512","laatst_gewijzigd_datum":"2025-02-02T12:37:08.214610"},"sort":[0.0,1738499828214]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"64e65f57-37bc-4ed7-bf60-7be4c1f6f102","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"847d191e-e373-4cb6-ad1f-54db1198d7d4","naam":"Michael-Robinson"},"identifier":"identifier-0","officiele_titel":"Condition
-        board Mrs gun wife media yard within.","verkorte_titel":"Partner positive.","omschrijving":"Part
-        plant majority tonight choose learn. People law officer five field. Recent
-        area allow his task. See skin room whatever consider.","creatiedatum":"2025-01-29","registratiedatum":"2025-02-22T10:59:09.270013","laatst_gewijzigd_datum":"2025-01-26T22:27:12.902652"},"sort":[0.0,1737930432902]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["847d191e-e373-4cb6-ad1f-54db1198d7d4","Michael-Robinson"],"key_as_string":"847d191e-e373-4cb6-ad1f-54db1198d7d4|Michael-Robinson","doc_count":1},{"key":["ee010597-f23b-4b67-b104-0a3ea475fc20","Nunez
-        Inc"],"key_as_string":"ee010597-f23b-4b67-b104-0a3ea475fc20|Nunez Inc","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":58,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":0.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"c5df7545-829f-4067-9324-29d5c085d542","naam":"Kirby
+        Inc"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Draw
+        single wish right page.","verkorte_titel":"Game capital.","omschrijving":"Door
+        explain ask want family. Past serious police property send who. North head
+        some win Democrat thank push. Painting poor school bag.","registratiedatum":"2025-02-17T06:42:11.670415","laatst_gewijzigd_datum":"2025-02-25T17:26:08.963719"},"sort":[0.0,1740504368963]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"f1988da3-2d9d-4439-b709-6479d97da80a","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"029d7504-15aa-4c23-825e-3f5b67f9bc2c","naam":"Douglas
+        Ltd"},"identifier":"identifier-0","officiele_titel":"Study style white nation
+        common past.","verkorte_titel":"Evening cause vote.","omschrijving":"About
+        treatment baby owner question region central. Loss something remain white
+        too. Can civil major well quality technology.","creatiedatum":"2025-01-30","registratiedatum":"2025-02-11T18:07:05.147537","laatst_gewijzigd_datum":"2025-02-22T09:09:56.459759"},"sort":[0.0,1740215396459]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["029d7504-15aa-4c23-825e-3f5b67f9bc2c","Douglas
+        Ltd"],"key_as_string":"029d7504-15aa-4c23-825e-3f5b67f9bc2c|Douglas Ltd","doc_count":1},{"key":["c5df7545-829f-4067-9324-29d5c085d542","Kirby
+        Inc"],"key_as_string":"c5df7545-829f-4067-9324-29d5c085d542|Kirby Inc","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_information_category_uuid.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_information_category_uuid.yaml
@@ -1,0 +1,200 @@
+interactions:
+- request:
+    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"ee010597-f23b-4b67-b104-0a3ea475fc20","naam":"Nunez
+      Inc"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Throughout
+      itself bed project color effect seat evidence.","verkorte_titel":"Measure.","omschrijving":"Society
+      wall war bad. Gas serve marriage star after.","registratiedatum":"2025-02-13T17:40:10.458512","laatst_gewijzigd_datum":"2025-02-02T12:37:08.214610"}'
+    headers:
+      accept:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      connection:
+      - keep-alive
+      content-type:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      user-agent:
+      - elasticsearch-dsl-py/8.17.1
+      x-elastic-client-meta:
+      - es=8.17.1,py=3.12.8,t=8.17.0,ur=2.2.2
+    method: PUT
+    uri: http://localhost:9201/publication/_doc/dd3b8be0-e461-498a-9a18-0f5fc8adc956?refresh=wait_for
+  response:
+    body:
+      string: '{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
+    headers:
+      Location:
+      - /publication/_doc/dd3b8be0-e461-498a-9a18-0f5fc8adc956
+      X-elastic-product:
+      - Elasticsearch
+      content-length:
+      - '179'
+      content-type:
+      - application/vnd.elasticsearch+json;compatible-with=8
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"15211614-be29-4724-9bf2-ee43cbd92b31","naam":"Owens
+      PLC"},"informatie_categorieen":[{"uuid":"52017054-dce2-4fd1-b737-0ee0ca9b501c","naam":"Capital
+      lose stop."}],"officiele_titel":"Improve painting benefit my impact.","verkorte_titel":"Quickly
+      painting.","omschrijving":"Dog line wife or. Will product smile thus response
+      as allow.","registratiedatum":"2025-02-24T11:05:41.153344","laatst_gewijzigd_datum":"2025-01-28T10:38:54.568907"}'
+    headers:
+      accept:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      connection:
+      - keep-alive
+      content-type:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      user-agent:
+      - elasticsearch-dsl-py/8.17.1
+      x-elastic-client-meta:
+      - es=8.17.1,py=3.12.8,t=8.17.0,ur=2.2.2
+    method: PUT
+    uri: http://localhost:9201/publication/_doc/3d6f91fc-ce3b-45d0-b3d6-c304be03845d?refresh=wait_for
+  response:
+    body:
+      string: '{"_index":"publication","_id":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}'
+    headers:
+      Location:
+      - /publication/_doc/3d6f91fc-ce3b-45d0-b3d6-c304be03845d
+      X-elastic-product:
+      - Elasticsearch
+      content-length:
+      - '179'
+      content-type:
+      - application/vnd.elasticsearch+json;compatible-with=8
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"64e65f57-37bc-4ed7-bf60-7be4c1f6f102","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"847d191e-e373-4cb6-ad1f-54db1198d7d4","naam":"Michael-Robinson"},"identifier":"identifier-0","officiele_titel":"Condition
+      board Mrs gun wife media yard within.","verkorte_titel":"Partner positive.","omschrijving":"Part
+      plant majority tonight choose learn. People law officer five field. Recent area
+      allow his task. See skin room whatever consider.","creatiedatum":"2025-01-29","registratiedatum":"2025-02-22T10:59:09.270013","laatst_gewijzigd_datum":"2025-01-26T22:27:12.902652"}'
+    headers:
+      accept:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      connection:
+      - keep-alive
+      content-type:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      user-agent:
+      - elasticsearch-dsl-py/8.17.1
+      x-elastic-client-meta:
+      - es=8.17.1,py=3.12.8,t=8.17.0,ur=2.2.2
+    method: PUT
+    uri: http://localhost:9201/document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66?refresh=wait_for
+  response:
+    body:
+      string: '{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
+    headers:
+      Location:
+      - /document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66
+      X-elastic-product:
+      - Elasticsearch
+      content-length:
+      - '176'
+      content-type:
+      - application/vnd.elasticsearch+json;compatible-with=8
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"df73ad01-7f1c-458b-bf1d-6dc0b9b0a942","informatie_categorieen":[{"uuid":"a76306d0-4c45-40b2-9839-cbdfb072463a","naam":"If
+      development."}],"publisher":{"uuid":"3c296a9c-a38d-49c0-8853-114e82c8d704","naam":"Perez,
+      Goodman and Brock"},"identifier":"identifier-1","officiele_titel":"Generation
+      yourself point tell.","verkorte_titel":"Cultural four anyone.","omschrijving":"Physical
+      sit land guy easy time. Understand threat product role prevent close service
+      century.","creatiedatum":"2025-02-08","registratiedatum":"2025-02-13T20:28:45.801470","laatst_gewijzigd_datum":"2025-02-01T12:44:35.127809"}'
+    headers:
+      accept:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      connection:
+      - keep-alive
+      content-type:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      user-agent:
+      - elasticsearch-dsl-py/8.17.1
+      x-elastic-client-meta:
+      - es=8.17.1,py=3.12.8,t=8.17.0,ur=2.2.2
+    method: PUT
+    uri: http://localhost:9201/document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6?refresh=wait_for
+  response:
+    body:
+      string: '{"_index":"document","_id":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}'
+    headers:
+      Location:
+      - /document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6
+      X-elastic-product:
+      - Elasticsearch
+      content-length:
+      - '176'
+      content-type:
+      - application/vnd.elasticsearch+json;compatible-with=8
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"query":{"bool":{"filter":[{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["1934d1db-b5c8-4521-97fe-a2ef969dd84e"]}}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    headers:
+      accept:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      connection:
+      - keep-alive
+      content-type:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      user-agent:
+      - elasticsearch-dsl-py/8.17.1
+      x-elastic-client-meta:
+      - es=8.17.1,py=3.12.8,t=8.17.0,ur=2.2.2
+    method: POST
+    uri: http://localhost:9201/publication,document/_search
+  response:
+    body:
+      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
+    headers:
+      Transfer-Encoding:
+      - chunked
+      X-elastic-product:
+      - Elasticsearch
+      content-type:
+      - application/vnd.elasticsearch+json;compatible-with=8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"query":{"bool":{"filter":[{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","e0eb40f7-eacb-45dc-973a-2e8480f49b76"]}}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    headers:
+      accept:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      connection:
+      - keep-alive
+      content-type:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      user-agent:
+      - elasticsearch-dsl-py/8.17.1
+      x-elastic-client-meta:
+      - es=8.17.1,py=3.12.8,t=8.17.0,ur=2.2.2
+    method: POST
+    uri: http://localhost:9201/publication,document/_search
+  response:
+    body:
+      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":0.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"ee010597-f23b-4b67-b104-0a3ea475fc20","naam":"Nunez
+        Inc"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Throughout
+        itself bed project color effect seat evidence.","verkorte_titel":"Measure.","omschrijving":"Society
+        wall war bad. Gas serve marriage star after.","registratiedatum":"2025-02-13T17:40:10.458512","laatst_gewijzigd_datum":"2025-02-02T12:37:08.214610"},"sort":[0.0,1738499828214]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"64e65f57-37bc-4ed7-bf60-7be4c1f6f102","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"847d191e-e373-4cb6-ad1f-54db1198d7d4","naam":"Michael-Robinson"},"identifier":"identifier-0","officiele_titel":"Condition
+        board Mrs gun wife media yard within.","verkorte_titel":"Partner positive.","omschrijving":"Part
+        plant majority tonight choose learn. People law officer five field. Recent
+        area allow his task. See skin room whatever consider.","creatiedatum":"2025-01-29","registratiedatum":"2025-02-22T10:59:09.270013","laatst_gewijzigd_datum":"2025-01-26T22:27:12.902652"},"sort":[0.0,1737930432902]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["847d191e-e373-4cb6-ad1f-54db1198d7d4","Michael-Robinson"],"key_as_string":"847d191e-e373-4cb6-ad1f-54db1198d7d4|Michael-Robinson","doc_count":1},{"key":["ee010597-f23b-4b67-b104-0a3ea475fc20","Nunez
+        Inc"],"key_as_string":"ee010597-f23b-4b67-b104-0a3ea475fc20|Nunez Inc","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+    headers:
+      Transfer-Encoding:
+      - chunked
+      X-elastic-product:
+      - Elasticsearch
+      content-type:
+      - application/vnd.elasticsearch+json;compatible-with=8
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_publisher_uuid.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_publisher_uuid.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"d5f75ac0-b881-4550-98a9-abeaf34275a1","naam":"Guess
-      participant respond."}],"officiele_titel":"Author final the garden.","verkorte_titel":"Act
-      skill.","omschrijving":"Fly yet suddenly medical stock. Power recently almost.
-      Full with official involve simple several open room.","registratiedatum":"2025-02-23T10:48:19.389437","laatst_gewijzigd_datum":"2025-02-21T11:26:30.403320"}'
+    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"1cc255e8-e113-4d90-8180-0e6bf096e3e6","naam":"Deep
+      although hear."}],"officiele_titel":"Site population everyone effect those difference
+      top.","verkorte_titel":"Bed wife fish.","omschrijving":"Space purpose want owner
+      him attention phone. Billion administration minute finish charge exactly.","registratiedatum":"2025-01-29T11:13:49.151578","laatst_gewijzigd_datum":"2025-02-19T11:27:48.427899"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -19,7 +19,7 @@ interactions:
     uri: http://localhost:9201/publication/_doc/dd3b8be0-e461-498a-9a18-0f5fc8adc956?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":4,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/dd3b8be0-e461-498a-9a18-0f5fc8adc956
@@ -33,11 +33,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"8b9e4f48-71dc-462d-9d1d-87f142ecede8","naam":"Mcdonald
-      Inc"},"informatie_categorieen":[{"uuid":"f67796b0-8a0c-4355-9f48-cbc236743e45","naam":"Apply
-      through young student."}],"officiele_titel":"Science hotel notice instead present
-      particularly author.","verkorte_titel":"About drive financial.","omschrijving":"Story
-      statement others many democratic.","registratiedatum":"2025-02-01T16:48:31.461933","laatst_gewijzigd_datum":"2025-02-19T06:27:38.329957"}'
+    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"863a6a9b-4f56-4f90-b3b4-7d60c097dbca","naam":"Moss
+      PLC"},"informatie_categorieen":[{"uuid":"f8f7aef6-5ff7-481c-b165-61b160eaa99e","naam":"Interesting
+      home long."}],"officiele_titel":"Allow law week space country reflect direction.","verkorte_titel":"Need
+      tend reach.","omschrijving":"Item address father through job on still late.
+      Public join go find him man today ever. Candidate new right population race
+      her glass. Reason cut individual couple consumer forget.","registratiedatum":"2025-02-16T06:09:20.942413","laatst_gewijzigd_datum":"2025-02-18T10:55:55.733204"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -53,7 +54,7 @@ interactions:
     uri: http://localhost:9201/publication/_doc/3d6f91fc-ce3b-45d0-b3d6-c304be03845d?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":5,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/3d6f91fc-ce3b-45d0-b3d6-c304be03845d
@@ -67,9 +68,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"2417d55b-eb86-4b69-9708-f95b383958c2","informatie_categorieen":[{"uuid":"d2ca76a9-1b76-4cee-952c-518bc2301fe8","naam":"Beat."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-0","officiele_titel":"Player
-      return message start military mind southern.","verkorte_titel":"Song.","omschrijving":"Admit
-      wind miss send then.","creatiedatum":"2025-02-12","registratiedatum":"2025-02-03T08:14:50.300216","laatst_gewijzigd_datum":"2025-02-01T18:54:37.472544"}'
+    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"612affe4-3538-4455-b8b1-631dc08eb1f7","informatie_categorieen":[{"uuid":"77a21832-2602-4904-9ffa-2e00b1ec6418","naam":"Among
+      quality soon."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-2","officiele_titel":"Standard
+      thing society your because woman heavy.","verkorte_titel":"Their too grow play.","omschrijving":"Letter
+      purpose decade.","creatiedatum":"2025-02-08","registratiedatum":"2025-01-29T00:51:58.459804","laatst_gewijzigd_datum":"2025-02-06T00:59:27.470525"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -85,7 +87,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
+      string: '{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":4,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66
@@ -99,11 +101,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"53a20721-c639-4da4-8d92-ebfbe2264add","informatie_categorieen":[{"uuid":"a1fa6c21-e85a-4a46-aae2-f177dd5ea4f7","naam":"Myself
-      need pay."}],"publisher":{"uuid":"c7a81a99-5bbc-43ea-9cb3-5ea0137f8cfe","naam":"Marshall-Diaz"},"identifier":"identifier-1","officiele_titel":"Threat
-      herself affect economy.","verkorte_titel":"Assume though simply.","omschrijving":"We
-      full home interest whose mission without. Future training professor customer
-      quality pull life.","creatiedatum":"2025-02-10","registratiedatum":"2025-02-03T04:39:03.989710","laatst_gewijzigd_datum":"2025-02-02T13:11:16.025396"}'
+    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"cc679881-e5c5-4bce-ba18-2eab7512f2ad","informatie_categorieen":[{"uuid":"5217cb7c-c983-4fe7-82cc-0c8eb8087aa3","naam":"Four
+      nothing."}],"publisher":{"uuid":"8da0d183-cc0c-4fcc-9ca0-b15ab89fb6a4","naam":"Bowers
+      Inc"},"identifier":"identifier-3","officiele_titel":"Receive election choice.","verkorte_titel":"Result
+      head.","omschrijving":"Ask indicate world according though order north. Sea
+      suddenly I matter leg lawyer performance. Local describe hear challenge open
+      yeah onto.","creatiedatum":"2025-02-21","registratiedatum":"2025-02-08T11:19:14.800761","laatst_gewijzigd_datum":"2025-02-04T00:41:04.758510"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -119,7 +122,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}'
+      string: '{"_index":"document","_id":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":5,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6
@@ -133,7 +136,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"bool":{"filter":[{"terms":{"publisher.uuid.keyword":["1934d1db-b5c8-4521-97fe-a2ef969dd84e"]}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"bool":{"filter":[{"terms":{"publisher.uuid.keyword":["1934d1db-b5c8-4521-97fe-a2ef969dd84e"]}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -149,7 +152,7 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":109,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
+      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -161,7 +164,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"bool":{"filter":[{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","e0eb40f7-eacb-45dc-973a-2e8480f49b76"]}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"bool":{"filter":[{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","e0eb40f7-eacb-45dc-973a-2e8480f49b76"]}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -177,12 +180,18 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":51,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":0.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"d5f75ac0-b881-4550-98a9-abeaf34275a1","naam":"Guess
-        participant respond."}],"officiele_titel":"Author final the garden.","verkorte_titel":"Act
-        skill.","omschrijving":"Fly yet suddenly medical stock. Power recently almost.
-        Full with official involve simple several open room.","registratiedatum":"2025-02-23T10:48:19.389437","laatst_gewijzigd_datum":"2025-02-21T11:26:30.403320"},"sort":[0.0,1740137190403]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"2417d55b-eb86-4b69-9708-f95b383958c2","informatie_categorieen":[{"uuid":"d2ca76a9-1b76-4cee-952c-518bc2301fe8","naam":"Beat."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-0","officiele_titel":"Player
-        return message start military mind southern.","verkorte_titel":"Song.","omschrijving":"Admit
-        wind miss send then.","creatiedatum":"2025-02-12","registratiedatum":"2025-02-03T08:14:50.300216","laatst_gewijzigd_datum":"2025-02-01T18:54:37.472544"},"sort":[0.0,1738436077472]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":15,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":0.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"1cc255e8-e113-4d90-8180-0e6bf096e3e6","naam":"Deep
+        although hear."}],"officiele_titel":"Site population everyone effect those
+        difference top.","verkorte_titel":"Bed wife fish.","omschrijving":"Space purpose
+        want owner him attention phone. Billion administration minute finish charge
+        exactly.","registratiedatum":"2025-01-29T11:13:49.151578","laatst_gewijzigd_datum":"2025-02-19T11:27:48.427899"},"sort":[0.0,1739964468427]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"612affe4-3538-4455-b8b1-631dc08eb1f7","informatie_categorieen":[{"uuid":"77a21832-2602-4904-9ffa-2e00b1ec6418","naam":"Among
+        quality soon."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-2","officiele_titel":"Standard
+        thing society your because woman heavy.","verkorte_titel":"Their too grow
+        play.","omschrijving":"Letter purpose decade.","creatiedatum":"2025-02-08","registratiedatum":"2025-01-29T00:51:58.459804","laatst_gewijzigd_datum":"2025-02-06T00:59:27.470525"},"sort":[0.0,1738803567470]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["1cc255e8-e113-4d90-8180-0e6bf096e3e6","Deep
+        although hear."],"key_as_string":"1cc255e8-e113-4d90-8180-0e6bf096e3e6|Deep
+        although hear.","doc_count":1},{"key":["77a21832-2602-4904-9ffa-2e00b1ec6418","Among
+        quality soon."],"key_as_string":"77a21832-2602-4904-9ffa-2e00b1ec6418|Among
+        quality soon.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_publisher_uuid.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_publisher_uuid.yaml
@@ -1,8 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"f51eb11b-f78e-4af9-bd2c-68bc31ccbb67","naam":"Rock."}],"officiele_titel":"Pass
-      full anyone try less tell represent top.","verkorte_titel":"Deal fund.","omschrijving":"Get
-      huge method thousand art. Century great and bad. Machine most wait growth.","registratiedatum":"2025-02-20T21:43:43.282602","laatst_gewijzigd_datum":"2025-02-24T08:08:34.551231"}'
+    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"d5f75ac0-b881-4550-98a9-abeaf34275a1","naam":"Guess
+      participant respond."}],"officiele_titel":"Author final the garden.","verkorte_titel":"Act
+      skill.","omschrijving":"Fly yet suddenly medical stock. Power recently almost.
+      Full with official involve simple several open room.","registratiedatum":"2025-02-23T10:48:19.389437","laatst_gewijzigd_datum":"2025-02-21T11:26:30.403320"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -32,11 +33,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"f78e3170-62bd-421b-8de2-be7607ab57b4","naam":"Mason,
-      Howell and Grant"},"informatie_categorieen":[{"uuid":"f82b5a01-d8b2-44b4-a6d0-bd8271c5a38f","naam":"Person
-      up design."}],"officiele_titel":"Require act issue tell soon physical few remember.","verkorte_titel":"All
-      discussion.","omschrijving":"Note nation new environmental. There whether here
-      cell five wonder maintain.","registratiedatum":"2025-02-23T12:31:26.365698","laatst_gewijzigd_datum":"2025-02-03T06:36:32.350705"}'
+    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"8b9e4f48-71dc-462d-9d1d-87f142ecede8","naam":"Mcdonald
+      Inc"},"informatie_categorieen":[{"uuid":"f67796b0-8a0c-4355-9f48-cbc236743e45","naam":"Apply
+      through young student."}],"officiele_titel":"Science hotel notice instead present
+      particularly author.","verkorte_titel":"About drive financial.","omschrijving":"Story
+      statement others many democratic.","registratiedatum":"2025-02-01T16:48:31.461933","laatst_gewijzigd_datum":"2025-02-19T06:27:38.329957"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -66,10 +67,9 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"2feede97-d535-48e5-8c37-756e037ff203","publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-0","officiele_titel":"Crime
-      maybe interview wide blood begin.","verkorte_titel":"Stand moment.","omschrijving":"Bad
-      investment population high east activity. Finally spend stuff area there chance
-      safe age.","creatiedatum":"2025-01-30","registratiedatum":"2025-02-06T15:31:10.842755","laatst_gewijzigd_datum":"2025-02-04T03:59:28.085177"}'
+    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"2417d55b-eb86-4b69-9708-f95b383958c2","informatie_categorieen":[{"uuid":"d2ca76a9-1b76-4cee-952c-518bc2301fe8","naam":"Beat."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-0","officiele_titel":"Player
+      return message start military mind southern.","verkorte_titel":"Song.","omschrijving":"Admit
+      wind miss send then.","creatiedatum":"2025-02-12","registratiedatum":"2025-02-03T08:14:50.300216","laatst_gewijzigd_datum":"2025-02-01T18:54:37.472544"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -99,10 +99,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"a237a0eb-8521-4212-be18-ccef6bc02bb4","publisher":{"uuid":"1818f669-d34c-4715-a6f8-e78aaf56d1df","naam":"Carter
-      Ltd"},"identifier":"identifier-1","officiele_titel":"So art voice practice PM
-      increase agency.","verkorte_titel":"Myself environmental way last.","omschrijving":"Message
-      car teacher style girl choice traditional. Scientist four where type throw both.","creatiedatum":"2025-02-15","registratiedatum":"2025-02-07T14:42:35.091620","laatst_gewijzigd_datum":"2025-02-20T20:15:00.706870"}'
+    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"53a20721-c639-4da4-8d92-ebfbe2264add","informatie_categorieen":[{"uuid":"a1fa6c21-e85a-4a46-aae2-f177dd5ea4f7","naam":"Myself
+      need pay."}],"publisher":{"uuid":"c7a81a99-5bbc-43ea-9cb3-5ea0137f8cfe","naam":"Marshall-Diaz"},"identifier":"identifier-1","officiele_titel":"Threat
+      herself affect economy.","verkorte_titel":"Assume though simply.","omschrijving":"We
+      full home interest whose mission without. Future training professor customer
+      quality pull life.","creatiedatum":"2025-02-10","registratiedatum":"2025-02-03T04:39:03.989710","laatst_gewijzigd_datum":"2025-02-02T13:11:16.025396"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -148,7 +149,7 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":86,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
+      string: '{"took":109,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -176,12 +177,12 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":30,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":0.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"f51eb11b-f78e-4af9-bd2c-68bc31ccbb67","naam":"Rock."}],"officiele_titel":"Pass
-        full anyone try less tell represent top.","verkorte_titel":"Deal fund.","omschrijving":"Get
-        huge method thousand art. Century great and bad. Machine most wait growth.","registratiedatum":"2025-02-20T21:43:43.282602","laatst_gewijzigd_datum":"2025-02-24T08:08:34.551231"},"sort":[0.0,1740384514551]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"2feede97-d535-48e5-8c37-756e037ff203","publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-0","officiele_titel":"Crime
-        maybe interview wide blood begin.","verkorte_titel":"Stand moment.","omschrijving":"Bad
-        investment population high east activity. Finally spend stuff area there chance
-        safe age.","creatiedatum":"2025-01-30","registratiedatum":"2025-02-06T15:31:10.842755","laatst_gewijzigd_datum":"2025-02-04T03:59:28.085177"},"sort":[0.0,1738641568085]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":51,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":0.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"d5f75ac0-b881-4550-98a9-abeaf34275a1","naam":"Guess
+        participant respond."}],"officiele_titel":"Author final the garden.","verkorte_titel":"Act
+        skill.","omschrijving":"Fly yet suddenly medical stock. Power recently almost.
+        Full with official involve simple several open room.","registratiedatum":"2025-02-23T10:48:19.389437","laatst_gewijzigd_datum":"2025-02-21T11:26:30.403320"},"sort":[0.0,1740137190403]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"2417d55b-eb86-4b69-9708-f95b383958c2","informatie_categorieen":[{"uuid":"d2ca76a9-1b76-4cee-952c-518bc2301fe8","naam":"Beat."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-0","officiele_titel":"Player
+        return message start military mind southern.","verkorte_titel":"Song.","omschrijving":"Admit
+        wind miss send then.","creatiedatum":"2025-02-12","registratiedatum":"2025-02-03T08:14:50.300216","laatst_gewijzigd_datum":"2025-02-01T18:54:37.472544"},"sort":[0.0,1738436077472]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_creatiedatum.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_creatiedatum.yaml
@@ -1,9 +1,11 @@
 interactions:
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"106c1137-6f22-44b6-bb89-f2829e2b4e6e","publisher":{"uuid":"041834a3-d967-4230-818b-50a217fb3a19","naam":"Jordan
-      PLC"},"identifier":"identifier-2","officiele_titel":"Entire step moment by interesting
-      relationship.","verkorte_titel":"Woman type.","omschrijving":"Resource know
-      goal but read.","creatiedatum":"2024-02-11","registratiedatum":"2025-02-22T10:29:55.579882","laatst_gewijzigd_datum":"2025-02-20T10:18:28.232787"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"3adb728a-103e-4c52-a282-d143c74d2a14","informatie_categorieen":[{"uuid":"4aa7821b-d9d1-4ac3-aa21-1563a7deafa4","naam":"Account
+      represent."}],"publisher":{"uuid":"2fd10027-9e02-41c7-9d4f-9d33225a0359","naam":"Kaiser,
+      Taylor and Campbell"},"identifier":"identifier-2","officiele_titel":"Growth
+      it impact difficult.","verkorte_titel":"Peace hour.","omschrijving":"Former
+      medical easy together. Or true indicate despite first long. Occur long parent
+      partner production.","creatiedatum":"2024-02-11","registratiedatum":"2025-02-15T05:13:16.143520","laatst_gewijzigd_datum":"2025-01-29T05:55:08.854242"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,10 +35,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"0c359aad-1873-459d-91dc-bcbc24c063f1","publisher":{"uuid":"8ffd8481-acab-40e8-86c7-7d0f35278a8d","naam":"Scott
-      Inc"},"identifier":"identifier-3","officiele_titel":"Necessary successful mention
-      minute.","verkorte_titel":"Trouble rest.","omschrijving":"Southern body treat
-      it past him food. Yourself just eat effect necessary trial camera.","creatiedatum":"2022-12-10","registratiedatum":"2025-02-02T14:04:26.653804","laatst_gewijzigd_datum":"2025-02-07T23:25:23.249268"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"234ca7ac-701a-48ef-981a-e7499d3c893e","informatie_categorieen":[{"uuid":"109c4719-0487-42ba-bdf6-a244c58b45b3","naam":"Professional
+      table."}],"publisher":{"uuid":"c653fa20-f3ea-4748-82b6-5ade03969514","naam":"Leblanc,
+      Mata and Johnson"},"identifier":"identifier-3","officiele_titel":"Growth probably
+      grow price image behavior day.","verkorte_titel":"System difference.","omschrijving":"Thing
+      there discussion. Catch under alone expect. Treatment moment note treat exist.","creatiedatum":"2022-12-10","registratiedatum":"2025-02-15T12:32:59.794260","laatst_gewijzigd_datum":"2025-02-01T17:17:30.326512"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -66,9 +69,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"f210a2ac-3f3a-4e19-93a5-ab6ac233bad5","publisher":{"uuid":"d11eebea-0d00-4b2d-af80-b5431a4916d5","naam":"Martin
-      Inc"},"identifier":"identifier-4","officiele_titel":"News red simple star.","verkorte_titel":"Property.","omschrijving":"Phone
-      become easy. Drop crime traditional store continue article report.","creatiedatum":"2025-01-14","registratiedatum":"2025-02-05T11:17:14.696801","laatst_gewijzigd_datum":"2025-02-09T09:45:21.221124"}'
+    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"77de31e9-fb27-43d4-95f1-f3efa9a89b0a","informatie_categorieen":[{"uuid":"ed07d272-21a5-4416-9668-2db7bf8ff840","naam":"Decade
+      mean."}],"publisher":{"uuid":"6c606340-0c53-468b-9b65-292222965fd1","naam":"Castro,
+      Dixon and Campbell"},"identifier":"identifier-4","officiele_titel":"Edge wait
+      real issue also finally.","verkorte_titel":"Look wait each.","omschrijving":"Business
+      factor sometimes amount democratic of none. Phone light not religious. Maintain
+      hear even.","creatiedatum":"2025-01-14","registratiedatum":"2025-02-18T19:16:58.674771","laatst_gewijzigd_datum":"2025-02-18T16:02:16.724006"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -114,14 +120,21 @@ interactions:
     uri: http://localhost:9201/document/_search
   response:
     body:
-      string: '{"took":13,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"106c1137-6f22-44b6-bb89-f2829e2b4e6e","publisher":{"uuid":"041834a3-d967-4230-818b-50a217fb3a19","naam":"Jordan
-        PLC"},"identifier":"identifier-2","officiele_titel":"Entire step moment by
-        interesting relationship.","verkorte_titel":"Woman type.","omschrijving":"Resource
-        know goal but read.","creatiedatum":"2024-02-11","registratiedatum":"2025-02-22T10:29:55.579882","laatst_gewijzigd_datum":"2025-02-20T10:18:28.232787"},"sort":[0.0,1740046708232]},{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"f210a2ac-3f3a-4e19-93a5-ab6ac233bad5","publisher":{"uuid":"d11eebea-0d00-4b2d-af80-b5431a4916d5","naam":"Martin
-        Inc"},"identifier":"identifier-4","officiele_titel":"News red simple star.","verkorte_titel":"Property.","omschrijving":"Phone
-        become easy. Drop crime traditional store continue article report.","creatiedatum":"2025-01-14","registratiedatum":"2025-02-05T11:17:14.696801","laatst_gewijzigd_datum":"2025-02-09T09:45:21.221124"},"sort":[0.0,1739094321221]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["041834a3-d967-4230-818b-50a217fb3a19","Jordan
-        PLC"],"key_as_string":"041834a3-d967-4230-818b-50a217fb3a19|Jordan PLC","doc_count":1},{"key":["d11eebea-0d00-4b2d-af80-b5431a4916d5","Martin
-        Inc"],"key_as_string":"d11eebea-0d00-4b2d-af80-b5431a4916d5|Martin Inc","doc_count":1}]}}}'
+      string: '{"took":29,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"77de31e9-fb27-43d4-95f1-f3efa9a89b0a","informatie_categorieen":[{"uuid":"ed07d272-21a5-4416-9668-2db7bf8ff840","naam":"Decade
+        mean."}],"publisher":{"uuid":"6c606340-0c53-468b-9b65-292222965fd1","naam":"Castro,
+        Dixon and Campbell"},"identifier":"identifier-4","officiele_titel":"Edge wait
+        real issue also finally.","verkorte_titel":"Look wait each.","omschrijving":"Business
+        factor sometimes amount democratic of none. Phone light not religious. Maintain
+        hear even.","creatiedatum":"2025-01-14","registratiedatum":"2025-02-18T19:16:58.674771","laatst_gewijzigd_datum":"2025-02-18T16:02:16.724006"},"sort":[0.0,1739894536724]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"3adb728a-103e-4c52-a282-d143c74d2a14","informatie_categorieen":[{"uuid":"4aa7821b-d9d1-4ac3-aa21-1563a7deafa4","naam":"Account
+        represent."}],"publisher":{"uuid":"2fd10027-9e02-41c7-9d4f-9d33225a0359","naam":"Kaiser,
+        Taylor and Campbell"},"identifier":"identifier-2","officiele_titel":"Growth
+        it impact difficult.","verkorte_titel":"Peace hour.","omschrijving":"Former
+        medical easy together. Or true indicate despite first long. Occur long parent
+        partner production.","creatiedatum":"2024-02-11","registratiedatum":"2025-02-15T05:13:16.143520","laatst_gewijzigd_datum":"2025-01-29T05:55:08.854242"},"sort":[0.0,1738130108854]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2fd10027-9e02-41c7-9d4f-9d33225a0359","Kaiser,
+        Taylor and Campbell"],"key_as_string":"2fd10027-9e02-41c7-9d4f-9d33225a0359|Kaiser,
+        Taylor and Campbell","doc_count":1},{"key":["6c606340-0c53-468b-9b65-292222965fd1","Castro,
+        Dixon and Campbell"],"key_as_string":"6c606340-0c53-468b-9b65-292222965fd1|Castro,
+        Dixon and Campbell","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -149,11 +162,13 @@ interactions:
     uri: http://localhost:9201/document/_search
   response:
     body:
-      string: '{"took":5,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"0c359aad-1873-459d-91dc-bcbc24c063f1","publisher":{"uuid":"8ffd8481-acab-40e8-86c7-7d0f35278a8d","naam":"Scott
-        Inc"},"identifier":"identifier-3","officiele_titel":"Necessary successful
-        mention minute.","verkorte_titel":"Trouble rest.","omschrijving":"Southern
-        body treat it past him food. Yourself just eat effect necessary trial camera.","creatiedatum":"2022-12-10","registratiedatum":"2025-02-02T14:04:26.653804","laatst_gewijzigd_datum":"2025-02-07T23:25:23.249268"},"sort":[0.0,1738970723249]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["8ffd8481-acab-40e8-86c7-7d0f35278a8d","Scott
-        Inc"],"key_as_string":"8ffd8481-acab-40e8-86c7-7d0f35278a8d|Scott Inc","doc_count":1}]}}}'
+      string: '{"took":9,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"234ca7ac-701a-48ef-981a-e7499d3c893e","informatie_categorieen":[{"uuid":"109c4719-0487-42ba-bdf6-a244c58b45b3","naam":"Professional
+        table."}],"publisher":{"uuid":"c653fa20-f3ea-4748-82b6-5ade03969514","naam":"Leblanc,
+        Mata and Johnson"},"identifier":"identifier-3","officiele_titel":"Growth probably
+        grow price image behavior day.","verkorte_titel":"System difference.","omschrijving":"Thing
+        there discussion. Catch under alone expect. Treatment moment note treat exist.","creatiedatum":"2022-12-10","registratiedatum":"2025-02-15T12:32:59.794260","laatst_gewijzigd_datum":"2025-02-01T17:17:30.326512"},"sort":[0.0,1738430250326]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c653fa20-f3ea-4748-82b6-5ade03969514","Leblanc,
+        Mata and Johnson"],"key_as_string":"c653fa20-f3ea-4748-82b6-5ade03969514|Leblanc,
+        Mata and Johnson","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -181,11 +196,14 @@ interactions:
     uri: http://localhost:9201/document/_search
   response:
     body:
-      string: '{"took":6,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"106c1137-6f22-44b6-bb89-f2829e2b4e6e","publisher":{"uuid":"041834a3-d967-4230-818b-50a217fb3a19","naam":"Jordan
-        PLC"},"identifier":"identifier-2","officiele_titel":"Entire step moment by
-        interesting relationship.","verkorte_titel":"Woman type.","omschrijving":"Resource
-        know goal but read.","creatiedatum":"2024-02-11","registratiedatum":"2025-02-22T10:29:55.579882","laatst_gewijzigd_datum":"2025-02-20T10:18:28.232787"},"sort":[0.0,1740046708232]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["041834a3-d967-4230-818b-50a217fb3a19","Jordan
-        PLC"],"key_as_string":"041834a3-d967-4230-818b-50a217fb3a19|Jordan PLC","doc_count":1}]}}}'
+      string: '{"took":9,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"3adb728a-103e-4c52-a282-d143c74d2a14","informatie_categorieen":[{"uuid":"4aa7821b-d9d1-4ac3-aa21-1563a7deafa4","naam":"Account
+        represent."}],"publisher":{"uuid":"2fd10027-9e02-41c7-9d4f-9d33225a0359","naam":"Kaiser,
+        Taylor and Campbell"},"identifier":"identifier-2","officiele_titel":"Growth
+        it impact difficult.","verkorte_titel":"Peace hour.","omschrijving":"Former
+        medical easy together. Or true indicate despite first long. Occur long parent
+        partner production.","creatiedatum":"2024-02-11","registratiedatum":"2025-02-15T05:13:16.143520","laatst_gewijzigd_datum":"2025-01-29T05:55:08.854242"},"sort":[0.0,1738130108854]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2fd10027-9e02-41c7-9d4f-9d33225a0359","Kaiser,
+        Taylor and Campbell"],"key_as_string":"2fd10027-9e02-41c7-9d4f-9d33225a0359|Kaiser,
+        Taylor and Campbell","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_creatiedatum.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_creatiedatum.yaml
@@ -1,11 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"3adb728a-103e-4c52-a282-d143c74d2a14","informatie_categorieen":[{"uuid":"4aa7821b-d9d1-4ac3-aa21-1563a7deafa4","naam":"Account
-      represent."}],"publisher":{"uuid":"2fd10027-9e02-41c7-9d4f-9d33225a0359","naam":"Kaiser,
-      Taylor and Campbell"},"identifier":"identifier-2","officiele_titel":"Growth
-      it impact difficult.","verkorte_titel":"Peace hour.","omschrijving":"Former
-      medical easy together. Or true indicate despite first long. Occur long parent
-      partner production.","creatiedatum":"2024-02-11","registratiedatum":"2025-02-15T05:13:16.143520","laatst_gewijzigd_datum":"2025-01-29T05:55:08.854242"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"b2800683-d46e-4a54-bcbd-fdd08ad5c022","informatie_categorieen":[{"uuid":"1e8561ff-b54e-46dd-8819-18046bea5263","naam":"Total
+      over last."}],"publisher":{"uuid":"bdd69e57-5f80-4ce1-a869-e737795361cd","naam":"Holland
+      and Sons"},"identifier":"identifier-4","officiele_titel":"Animal agree factor.","verkorte_titel":"Field
+      television.","omschrijving":"Town field room opportunity. Simply group least
+      structure.","creatiedatum":"2024-02-11","registratiedatum":"2025-02-19T02:38:08.442734","laatst_gewijzigd_datum":"2025-02-24T17:26:47.803504"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -21,7 +20,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/6aac4fb2-d532-490b-bd6b-87b0257c0236?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":4,"_primary_term":1}'
+      string: '{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":8,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/6aac4fb2-d532-490b-bd6b-87b0257c0236
@@ -35,11 +34,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"234ca7ac-701a-48ef-981a-e7499d3c893e","informatie_categorieen":[{"uuid":"109c4719-0487-42ba-bdf6-a244c58b45b3","naam":"Professional
-      table."}],"publisher":{"uuid":"c653fa20-f3ea-4748-82b6-5ade03969514","naam":"Leblanc,
-      Mata and Johnson"},"identifier":"identifier-3","officiele_titel":"Growth probably
-      grow price image behavior day.","verkorte_titel":"System difference.","omschrijving":"Thing
-      there discussion. Catch under alone expect. Treatment moment note treat exist.","creatiedatum":"2022-12-10","registratiedatum":"2025-02-15T12:32:59.794260","laatst_gewijzigd_datum":"2025-02-01T17:17:30.326512"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"19b1c587-3727-43f5-aa56-aaba00120921","informatie_categorieen":[{"uuid":"497fffdc-9dfb-43f5-b678-3afe3d875601","naam":"Heavy."}],"publisher":{"uuid":"24538483-8a7f-4f05-abbf-1ee005cd5bfe","naam":"Prince,
+      Garcia and Rodriguez"},"identifier":"identifier-5","officiele_titel":"Accept
+      yes million short.","verkorte_titel":"Threat manager.","omschrijving":"Station
+      card available style style form type. Prove ground again sell. Include positive
+      agency common.","creatiedatum":"2022-12-10","registratiedatum":"2025-02-05T14:25:23.975546","laatst_gewijzigd_datum":"2025-02-02T16:06:12.939781"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -55,7 +54,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/62fceb92-98bd-475c-b184-49ee8a274787?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":5,"_primary_term":1}'
+      string: '{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":9,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/62fceb92-98bd-475c-b184-49ee8a274787
@@ -69,12 +68,9 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"77de31e9-fb27-43d4-95f1-f3efa9a89b0a","informatie_categorieen":[{"uuid":"ed07d272-21a5-4416-9668-2db7bf8ff840","naam":"Decade
-      mean."}],"publisher":{"uuid":"6c606340-0c53-468b-9b65-292222965fd1","naam":"Castro,
-      Dixon and Campbell"},"identifier":"identifier-4","officiele_titel":"Edge wait
-      real issue also finally.","verkorte_titel":"Look wait each.","omschrijving":"Business
-      factor sometimes amount democratic of none. Phone light not religious. Maintain
-      hear even.","creatiedatum":"2025-01-14","registratiedatum":"2025-02-18T19:16:58.674771","laatst_gewijzigd_datum":"2025-02-18T16:02:16.724006"}'
+    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"8217cc3a-22bb-443a-908a-7e1a3dc10c40","informatie_categorieen":[{"uuid":"18d4e234-d567-448d-8e4d-c7c200eea244","naam":"Short."}],"publisher":{"uuid":"d87d0311-00a6-4375-b066-4289bcf05291","naam":"Floyd-Smith"},"identifier":"identifier-6","officiele_titel":"Idea
+      receive leave crime just.","verkorte_titel":"Will wrong be.","omschrijving":"Accept
+      pass area day be from take why. Action carry son growth positive south.","creatiedatum":"2025-01-14","registratiedatum":"2025-02-02T22:39:10.292027","laatst_gewijzigd_datum":"2025-02-15T13:08:37.629665"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -90,21 +86,21 @@ interactions:
     uri: http://localhost:9201/document/_doc/ef1dead2-e0f8-45be-acf7-3583adc14906?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":6,"_primary_term":1}'
+      string: '{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":10,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/ef1dead2-e0f8-45be-acf7-3583adc14906
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '176'
+      - '177'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":"2024-02-11","lte":null}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":"2024-02-11","lte":null}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -120,21 +116,17 @@ interactions:
     uri: http://localhost:9201/document/_search
   response:
     body:
-      string: '{"took":29,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"77de31e9-fb27-43d4-95f1-f3efa9a89b0a","informatie_categorieen":[{"uuid":"ed07d272-21a5-4416-9668-2db7bf8ff840","naam":"Decade
-        mean."}],"publisher":{"uuid":"6c606340-0c53-468b-9b65-292222965fd1","naam":"Castro,
-        Dixon and Campbell"},"identifier":"identifier-4","officiele_titel":"Edge wait
-        real issue also finally.","verkorte_titel":"Look wait each.","omschrijving":"Business
-        factor sometimes amount democratic of none. Phone light not religious. Maintain
-        hear even.","creatiedatum":"2025-01-14","registratiedatum":"2025-02-18T19:16:58.674771","laatst_gewijzigd_datum":"2025-02-18T16:02:16.724006"},"sort":[0.0,1739894536724]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"3adb728a-103e-4c52-a282-d143c74d2a14","informatie_categorieen":[{"uuid":"4aa7821b-d9d1-4ac3-aa21-1563a7deafa4","naam":"Account
-        represent."}],"publisher":{"uuid":"2fd10027-9e02-41c7-9d4f-9d33225a0359","naam":"Kaiser,
-        Taylor and Campbell"},"identifier":"identifier-2","officiele_titel":"Growth
-        it impact difficult.","verkorte_titel":"Peace hour.","omschrijving":"Former
-        medical easy together. Or true indicate despite first long. Occur long parent
-        partner production.","creatiedatum":"2024-02-11","registratiedatum":"2025-02-15T05:13:16.143520","laatst_gewijzigd_datum":"2025-01-29T05:55:08.854242"},"sort":[0.0,1738130108854]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2fd10027-9e02-41c7-9d4f-9d33225a0359","Kaiser,
-        Taylor and Campbell"],"key_as_string":"2fd10027-9e02-41c7-9d4f-9d33225a0359|Kaiser,
-        Taylor and Campbell","doc_count":1},{"key":["6c606340-0c53-468b-9b65-292222965fd1","Castro,
-        Dixon and Campbell"],"key_as_string":"6c606340-0c53-468b-9b65-292222965fd1|Castro,
-        Dixon and Campbell","doc_count":1}]}}}'
+      string: '{"took":31,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"b2800683-d46e-4a54-bcbd-fdd08ad5c022","informatie_categorieen":[{"uuid":"1e8561ff-b54e-46dd-8819-18046bea5263","naam":"Total
+        over last."}],"publisher":{"uuid":"bdd69e57-5f80-4ce1-a869-e737795361cd","naam":"Holland
+        and Sons"},"identifier":"identifier-4","officiele_titel":"Animal agree factor.","verkorte_titel":"Field
+        television.","omschrijving":"Town field room opportunity. Simply group least
+        structure.","creatiedatum":"2024-02-11","registratiedatum":"2025-02-19T02:38:08.442734","laatst_gewijzigd_datum":"2025-02-24T17:26:47.803504"},"sort":[0.0,1740418007803]},{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"8217cc3a-22bb-443a-908a-7e1a3dc10c40","informatie_categorieen":[{"uuid":"18d4e234-d567-448d-8e4d-c7c200eea244","naam":"Short."}],"publisher":{"uuid":"d87d0311-00a6-4375-b066-4289bcf05291","naam":"Floyd-Smith"},"identifier":"identifier-6","officiele_titel":"Idea
+        receive leave crime just.","verkorte_titel":"Will wrong be.","omschrijving":"Accept
+        pass area day be from take why. Action carry son growth positive south.","creatiedatum":"2025-01-14","registratiedatum":"2025-02-02T22:39:10.292027","laatst_gewijzigd_datum":"2025-02-15T13:08:37.629665"},"sort":[0.0,1739624917629]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["bdd69e57-5f80-4ce1-a869-e737795361cd","Holland
+        and Sons"],"key_as_string":"bdd69e57-5f80-4ce1-a869-e737795361cd|Holland and
+        Sons","doc_count":1},{"key":["d87d0311-00a6-4375-b066-4289bcf05291","Floyd-Smith"],"key_as_string":"d87d0311-00a6-4375-b066-4289bcf05291|Floyd-Smith","doc_count":1}]},"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["18d4e234-d567-448d-8e4d-c7c200eea244","Short."],"key_as_string":"18d4e234-d567-448d-8e4d-c7c200eea244|Short.","doc_count":1},{"key":["1e8561ff-b54e-46dd-8819-18046bea5263","Total
+        over last."],"key_as_string":"1e8561ff-b54e-46dd-8819-18046bea5263|Total over
+        last.","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -146,7 +138,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":null,"lte":"2022-12-10"}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":null,"lte":"2022-12-10"}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -162,13 +154,13 @@ interactions:
     uri: http://localhost:9201/document/_search
   response:
     body:
-      string: '{"took":9,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"234ca7ac-701a-48ef-981a-e7499d3c893e","informatie_categorieen":[{"uuid":"109c4719-0487-42ba-bdf6-a244c58b45b3","naam":"Professional
-        table."}],"publisher":{"uuid":"c653fa20-f3ea-4748-82b6-5ade03969514","naam":"Leblanc,
-        Mata and Johnson"},"identifier":"identifier-3","officiele_titel":"Growth probably
-        grow price image behavior day.","verkorte_titel":"System difference.","omschrijving":"Thing
-        there discussion. Catch under alone expect. Treatment moment note treat exist.","creatiedatum":"2022-12-10","registratiedatum":"2025-02-15T12:32:59.794260","laatst_gewijzigd_datum":"2025-02-01T17:17:30.326512"},"sort":[0.0,1738430250326]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c653fa20-f3ea-4748-82b6-5ade03969514","Leblanc,
-        Mata and Johnson"],"key_as_string":"c653fa20-f3ea-4748-82b6-5ade03969514|Leblanc,
-        Mata and Johnson","doc_count":1}]}}}'
+      string: '{"took":11,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"19b1c587-3727-43f5-aa56-aaba00120921","informatie_categorieen":[{"uuid":"497fffdc-9dfb-43f5-b678-3afe3d875601","naam":"Heavy."}],"publisher":{"uuid":"24538483-8a7f-4f05-abbf-1ee005cd5bfe","naam":"Prince,
+        Garcia and Rodriguez"},"identifier":"identifier-5","officiele_titel":"Accept
+        yes million short.","verkorte_titel":"Threat manager.","omschrijving":"Station
+        card available style style form type. Prove ground again sell. Include positive
+        agency common.","creatiedatum":"2022-12-10","registratiedatum":"2025-02-05T14:25:23.975546","laatst_gewijzigd_datum":"2025-02-02T16:06:12.939781"},"sort":[0.0,1738512372939]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["24538483-8a7f-4f05-abbf-1ee005cd5bfe","Prince,
+        Garcia and Rodriguez"],"key_as_string":"24538483-8a7f-4f05-abbf-1ee005cd5bfe|Prince,
+        Garcia and Rodriguez","doc_count":1}]},"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["497fffdc-9dfb-43f5-b678-3afe3d875601","Heavy."],"key_as_string":"497fffdc-9dfb-43f5-b678-3afe3d875601|Heavy.","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -180,7 +172,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":"2024-01-01","lte":"2024-12-31"}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":"2024-01-01","lte":"2024-12-31"}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -196,14 +188,15 @@ interactions:
     uri: http://localhost:9201/document/_search
   response:
     body:
-      string: '{"took":9,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"3adb728a-103e-4c52-a282-d143c74d2a14","informatie_categorieen":[{"uuid":"4aa7821b-d9d1-4ac3-aa21-1563a7deafa4","naam":"Account
-        represent."}],"publisher":{"uuid":"2fd10027-9e02-41c7-9d4f-9d33225a0359","naam":"Kaiser,
-        Taylor and Campbell"},"identifier":"identifier-2","officiele_titel":"Growth
-        it impact difficult.","verkorte_titel":"Peace hour.","omschrijving":"Former
-        medical easy together. Or true indicate despite first long. Occur long parent
-        partner production.","creatiedatum":"2024-02-11","registratiedatum":"2025-02-15T05:13:16.143520","laatst_gewijzigd_datum":"2025-01-29T05:55:08.854242"},"sort":[0.0,1738130108854]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2fd10027-9e02-41c7-9d4f-9d33225a0359","Kaiser,
-        Taylor and Campbell"],"key_as_string":"2fd10027-9e02-41c7-9d4f-9d33225a0359|Kaiser,
-        Taylor and Campbell","doc_count":1}]}}}'
+      string: '{"took":11,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"b2800683-d46e-4a54-bcbd-fdd08ad5c022","informatie_categorieen":[{"uuid":"1e8561ff-b54e-46dd-8819-18046bea5263","naam":"Total
+        over last."}],"publisher":{"uuid":"bdd69e57-5f80-4ce1-a869-e737795361cd","naam":"Holland
+        and Sons"},"identifier":"identifier-4","officiele_titel":"Animal agree factor.","verkorte_titel":"Field
+        television.","omschrijving":"Town field room opportunity. Simply group least
+        structure.","creatiedatum":"2024-02-11","registratiedatum":"2025-02-19T02:38:08.442734","laatst_gewijzigd_datum":"2025-02-24T17:26:47.803504"},"sort":[0.0,1740418007803]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["bdd69e57-5f80-4ce1-a869-e737795361cd","Holland
+        and Sons"],"key_as_string":"bdd69e57-5f80-4ce1-a869-e737795361cd|Holland and
+        Sons","doc_count":1}]},"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["1e8561ff-b54e-46dd-8819-18046bea5263","Total
+        over last."],"key_as_string":"1e8561ff-b54e-46dd-8819-18046bea5263|Total over
+        last.","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_last_modified_date.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_last_modified_date.yaml
@@ -1,10 +1,11 @@
 interactions:
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"080e196d-18ce-434c-b2cf-90d407fd2044","publisher":{"uuid":"6c23f6bb-8175-47da-bae4-da62257c6284","naam":"Stewart
-      PLC"},"identifier":"identifier-5","officiele_titel":"Single those modern thus
-      successful.","verkorte_titel":"Its model.","omschrijving":"Draw throughout enter
-      fly occur form table. May when pass firm price would move. Audience doctor most
-      very discover hear me because.","creatiedatum":"2025-02-17","registratiedatum":"2025-02-04T16:11:51.813916","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"42caf03e-9e66-4aaf-896c-24af5cda08a3","informatie_categorieen":[{"uuid":"a1df88ec-ee80-47b3-a201-0d37272335bf","naam":"Prevent
+      explain."}],"publisher":{"uuid":"c7b99cbb-bf79-41b8-89f2-76456a1973af","naam":"Barrett,
+      Johnson and Hall"},"identifier":"identifier-5","officiele_titel":"Daughter purpose
+      gas could produce yourself.","verkorte_titel":"Turn develop sell.","omschrijving":"Rise
+      power paper kind. Take traditional than ball nature. Activity store here knowledge
+      tend reflect contain.","creatiedatum":"2025-02-18","registratiedatum":"2025-02-19T15:03:37.282529","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -34,11 +35,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"25a8b91f-3b20-47de-913e-ec9b65500233","publisher":{"uuid":"11f5137b-9a9e-4d56-86d4-6614d259c15d","naam":"Murphy
-      LLC"},"identifier":"identifier-6","officiele_titel":"Series recognize surface
-      wall.","verkorte_titel":"Shoulder low catch fear.","omschrijving":"Question
-      state war indeed then. State her before peace strong. Direction my film then
-      goal.","creatiedatum":"2025-01-26","registratiedatum":"2025-02-13T02:39:51.417591","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"599188f8-c44b-49b1-a069-bee9db4146a1","informatie_categorieen":[{"uuid":"a198e391-d927-4e55-8309-aaa391ccd78a","naam":"Because
+      data yes."}],"publisher":{"uuid":"0c9cbd7b-2c51-4229-91d8-5d3691ed13f5","naam":"Rivera
+      PLC"},"identifier":"identifier-6","officiele_titel":"Window blue administration
+      relate TV heart.","verkorte_titel":"Matter market like.","omschrijving":"However
+      serve believe mouth production blue. Rock region yard resource when plant attention.
+      Probably down feeling trouble space move purpose.","creatiedatum":"2025-02-08","registratiedatum":"2025-02-16T20:56:25.888163","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -68,10 +70,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"43e1be61-1e04-4178-a015-00f9d0654244","publisher":{"uuid":"6352a91d-d48b-4e0a-8dfa-e1f862b72c88","naam":"Oneill
-      Inc"},"identifier":"identifier-7","officiele_titel":"Upon what Mr control reveal
-      season group.","verkorte_titel":"Central list try.","omschrijving":"Not happy
-      final. Ok themselves truth present the respond phone. Task these interview song.","creatiedatum":"2025-02-09","registratiedatum":"2025-02-16T08:41:40.846551","laatst_gewijzigd_datum":"2025-01-14T21:12:00+00:00"}'
+    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"774ff16f-d510-4703-85d7-662d69bc445d","informatie_categorieen":[{"uuid":"c31491c5-1fad-4a09-9a77-4ba2770ee4e4","naam":"Wish
+      money tell soon."}],"publisher":{"uuid":"e6a95e9d-474c-4c04-a483-79c4f72742d7","naam":"Jones-Johnson"},"identifier":"identifier-7","officiele_titel":"Behind
+      model open network must enjoy write think.","verkorte_titel":"Pattern.","omschrijving":"Agency
+      past sure early. Technology help adult strong.","creatiedatum":"2025-02-09","registratiedatum":"2025-01-30T21:43:01.110115","laatst_gewijzigd_datum":"2025-01-14T21:12:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -117,17 +119,17 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":13,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"43e1be61-1e04-4178-a015-00f9d0654244","publisher":{"uuid":"6352a91d-d48b-4e0a-8dfa-e1f862b72c88","naam":"Oneill
-        Inc"},"identifier":"identifier-7","officiele_titel":"Upon what Mr control
-        reveal season group.","verkorte_titel":"Central list try.","omschrijving":"Not
-        happy final. Ok themselves truth present the respond phone. Task these interview
-        song.","creatiedatum":"2025-02-09","registratiedatum":"2025-02-16T08:41:40.846551","laatst_gewijzigd_datum":"2025-01-14T21:12:00+00:00"},"sort":[0.0,1736889120000]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"080e196d-18ce-434c-b2cf-90d407fd2044","publisher":{"uuid":"6c23f6bb-8175-47da-bae4-da62257c6284","naam":"Stewart
-        PLC"},"identifier":"identifier-5","officiele_titel":"Single those modern thus
-        successful.","verkorte_titel":"Its model.","omschrijving":"Draw throughout
-        enter fly occur form table. May when pass firm price would move. Audience
-        doctor most very discover hear me because.","creatiedatum":"2025-02-17","registratiedatum":"2025-02-04T16:11:51.813916","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["6352a91d-d48b-4e0a-8dfa-e1f862b72c88","Oneill
-        Inc"],"key_as_string":"6352a91d-d48b-4e0a-8dfa-e1f862b72c88|Oneill Inc","doc_count":1},{"key":["6c23f6bb-8175-47da-bae4-da62257c6284","Stewart
-        PLC"],"key_as_string":"6c23f6bb-8175-47da-bae4-da62257c6284|Stewart PLC","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}'
+      string: '{"took":22,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"774ff16f-d510-4703-85d7-662d69bc445d","informatie_categorieen":[{"uuid":"c31491c5-1fad-4a09-9a77-4ba2770ee4e4","naam":"Wish
+        money tell soon."}],"publisher":{"uuid":"e6a95e9d-474c-4c04-a483-79c4f72742d7","naam":"Jones-Johnson"},"identifier":"identifier-7","officiele_titel":"Behind
+        model open network must enjoy write think.","verkorte_titel":"Pattern.","omschrijving":"Agency
+        past sure early. Technology help adult strong.","creatiedatum":"2025-02-09","registratiedatum":"2025-01-30T21:43:01.110115","laatst_gewijzigd_datum":"2025-01-14T21:12:00+00:00"},"sort":[0.0,1736889120000]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"42caf03e-9e66-4aaf-896c-24af5cda08a3","informatie_categorieen":[{"uuid":"a1df88ec-ee80-47b3-a201-0d37272335bf","naam":"Prevent
+        explain."}],"publisher":{"uuid":"c7b99cbb-bf79-41b8-89f2-76456a1973af","naam":"Barrett,
+        Johnson and Hall"},"identifier":"identifier-5","officiele_titel":"Daughter
+        purpose gas could produce yourself.","verkorte_titel":"Turn develop sell.","omschrijving":"Rise
+        power paper kind. Take traditional than ball nature. Activity store here knowledge
+        tend reflect contain.","creatiedatum":"2025-02-18","registratiedatum":"2025-02-19T15:03:37.282529","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c7b99cbb-bf79-41b8-89f2-76456a1973af","Barrett,
+        Johnson and Hall"],"key_as_string":"c7b99cbb-bf79-41b8-89f2-76456a1973af|Barrett,
+        Johnson and Hall","doc_count":1},{"key":["e6a95e9d-474c-4c04-a483-79c4f72742d7","Jones-Johnson"],"key_as_string":"e6a95e9d-474c-4c04-a483-79c4f72742d7|Jones-Johnson","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -155,12 +157,13 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"25a8b91f-3b20-47de-913e-ec9b65500233","publisher":{"uuid":"11f5137b-9a9e-4d56-86d4-6614d259c15d","naam":"Murphy
-        LLC"},"identifier":"identifier-6","officiele_titel":"Series recognize surface
-        wall.","verkorte_titel":"Shoulder low catch fear.","omschrijving":"Question
-        state war indeed then. State her before peace strong. Direction my film then
-        goal.","creatiedatum":"2025-01-26","registratiedatum":"2025-02-13T02:39:51.417591","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"},"sort":[0.0,1670695200000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["11f5137b-9a9e-4d56-86d4-6614d259c15d","Murphy
-        LLC"],"key_as_string":"11f5137b-9a9e-4d56-86d4-6614d259c15d|Murphy LLC","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
+      string: '{"took":15,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"599188f8-c44b-49b1-a069-bee9db4146a1","informatie_categorieen":[{"uuid":"a198e391-d927-4e55-8309-aaa391ccd78a","naam":"Because
+        data yes."}],"publisher":{"uuid":"0c9cbd7b-2c51-4229-91d8-5d3691ed13f5","naam":"Rivera
+        PLC"},"identifier":"identifier-6","officiele_titel":"Window blue administration
+        relate TV heart.","verkorte_titel":"Matter market like.","omschrijving":"However
+        serve believe mouth production blue. Rock region yard resource when plant
+        attention. Probably down feeling trouble space move purpose.","creatiedatum":"2025-02-08","registratiedatum":"2025-02-16T20:56:25.888163","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"},"sort":[0.0,1670695200000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["0c9cbd7b-2c51-4229-91d8-5d3691ed13f5","Rivera
+        PLC"],"key_as_string":"0c9cbd7b-2c51-4229-91d8-5d3691ed13f5|Rivera PLC","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -188,12 +191,14 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"080e196d-18ce-434c-b2cf-90d407fd2044","publisher":{"uuid":"6c23f6bb-8175-47da-bae4-da62257c6284","naam":"Stewart
-        PLC"},"identifier":"identifier-5","officiele_titel":"Single those modern thus
-        successful.","verkorte_titel":"Its model.","omschrijving":"Draw throughout
-        enter fly occur form table. May when pass firm price would move. Audience
-        doctor most very discover hear me because.","creatiedatum":"2025-02-17","registratiedatum":"2025-02-04T16:11:51.813916","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["6c23f6bb-8175-47da-bae4-da62257c6284","Stewart
-        PLC"],"key_as_string":"6c23f6bb-8175-47da-bae4-da62257c6284|Stewart PLC","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
+      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"42caf03e-9e66-4aaf-896c-24af5cda08a3","informatie_categorieen":[{"uuid":"a1df88ec-ee80-47b3-a201-0d37272335bf","naam":"Prevent
+        explain."}],"publisher":{"uuid":"c7b99cbb-bf79-41b8-89f2-76456a1973af","naam":"Barrett,
+        Johnson and Hall"},"identifier":"identifier-5","officiele_titel":"Daughter
+        purpose gas could produce yourself.","verkorte_titel":"Turn develop sell.","omschrijving":"Rise
+        power paper kind. Take traditional than ball nature. Activity store here knowledge
+        tend reflect contain.","creatiedatum":"2025-02-18","registratiedatum":"2025-02-19T15:03:37.282529","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c7b99cbb-bf79-41b8-89f2-76456a1973af","Barrett,
+        Johnson and Hall"],"key_as_string":"c7b99cbb-bf79-41b8-89f2-76456a1973af|Barrett,
+        Johnson and Hall","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_last_modified_date.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_last_modified_date.yaml
@@ -1,11 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"42caf03e-9e66-4aaf-896c-24af5cda08a3","informatie_categorieen":[{"uuid":"a1df88ec-ee80-47b3-a201-0d37272335bf","naam":"Prevent
-      explain."}],"publisher":{"uuid":"c7b99cbb-bf79-41b8-89f2-76456a1973af","naam":"Barrett,
-      Johnson and Hall"},"identifier":"identifier-5","officiele_titel":"Daughter purpose
-      gas could produce yourself.","verkorte_titel":"Turn develop sell.","omschrijving":"Rise
-      power paper kind. Take traditional than ball nature. Activity store here knowledge
-      tend reflect contain.","creatiedatum":"2025-02-18","registratiedatum":"2025-02-19T15:03:37.282529","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"50f16773-5aa4-4169-a572-ba9014d149c5","informatie_categorieen":[{"uuid":"2a0492ab-84f4-4bcb-93b0-f9f6e7876c65","naam":"Yes
+      officer woman."}],"publisher":{"uuid":"022f869a-867c-4af2-9572-b1e63dd35e1f","naam":"Gutierrez-Simpson"},"identifier":"identifier-7","officiele_titel":"Training
+      could daughter so pass bed.","verkorte_titel":"Kind option.","omschrijving":"Similar
+      why the raise change return. Day right television.","creatiedatum":"2025-02-03","registratiedatum":"2025-02-07T18:26:16.772446","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -21,7 +19,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/6aac4fb2-d532-490b-bd6b-87b0257c0236?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":10,"_primary_term":1}'
+      string: '{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":14,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/6aac4fb2-d532-490b-bd6b-87b0257c0236
@@ -35,12 +33,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"599188f8-c44b-49b1-a069-bee9db4146a1","informatie_categorieen":[{"uuid":"a198e391-d927-4e55-8309-aaa391ccd78a","naam":"Because
-      data yes."}],"publisher":{"uuid":"0c9cbd7b-2c51-4229-91d8-5d3691ed13f5","naam":"Rivera
-      PLC"},"identifier":"identifier-6","officiele_titel":"Window blue administration
-      relate TV heart.","verkorte_titel":"Matter market like.","omschrijving":"However
-      serve believe mouth production blue. Rock region yard resource when plant attention.
-      Probably down feeling trouble space move purpose.","creatiedatum":"2025-02-08","registratiedatum":"2025-02-16T20:56:25.888163","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"e82e9a90-3538-420e-adbc-a9eb0165441b","informatie_categorieen":[{"uuid":"c5aa2eaf-2c5d-4f37-8181-a6ac3a5fa8d7","naam":"Sound
+      agree."}],"publisher":{"uuid":"2fb4f2c9-96df-4f63-b54b-2f6e2c80d9ef","naam":"Knight,
+      Thomas and Murray"},"identifier":"identifier-8","officiele_titel":"Near miss
+      argue movie increase age seven perform.","verkorte_titel":"Prepare western.","omschrijving":"Either
+      impact southern few attorney ago. Serve actually whom. Anyone her no fund continue
+      seven.","creatiedatum":"2025-01-31","registratiedatum":"2025-02-07T12:20:15.938378","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -56,7 +54,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/62fceb92-98bd-475c-b184-49ee8a274787?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":11,"_primary_term":1}'
+      string: '{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":15,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/62fceb92-98bd-475c-b184-49ee8a274787
@@ -70,10 +68,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"774ff16f-d510-4703-85d7-662d69bc445d","informatie_categorieen":[{"uuid":"c31491c5-1fad-4a09-9a77-4ba2770ee4e4","naam":"Wish
-      money tell soon."}],"publisher":{"uuid":"e6a95e9d-474c-4c04-a483-79c4f72742d7","naam":"Jones-Johnson"},"identifier":"identifier-7","officiele_titel":"Behind
-      model open network must enjoy write think.","verkorte_titel":"Pattern.","omschrijving":"Agency
-      past sure early. Technology help adult strong.","creatiedatum":"2025-02-09","registratiedatum":"2025-01-30T21:43:01.110115","laatst_gewijzigd_datum":"2025-01-14T21:12:00+00:00"}'
+    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"c033b176-162f-42d3-b754-b5d6957d48c1","informatie_categorieen":[{"uuid":"dc576428-f98d-4198-a1d4-491a43e6c19b","naam":"News."}],"publisher":{"uuid":"691eab04-ef1f-445e-a05b-9e6f851106d6","naam":"Elliott
+      Inc"},"identifier":"identifier-9","officiele_titel":"Move we way project yes
+      commercial somebody car.","verkorte_titel":"Network rich.","omschrijving":"Relationship
+      simple course sit more movement. School outside paper popular summer instead.
+      Yard boy imagine truth sort.","creatiedatum":"2025-02-11","registratiedatum":"2025-02-14T06:27:35.767746","laatst_gewijzigd_datum":"2025-01-14T21:12:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -89,7 +88,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/ef1dead2-e0f8-45be-acf7-3583adc14906?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":12,"_primary_term":1}'
+      string: '{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":16,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/ef1dead2-e0f8-45be-acf7-3583adc14906
@@ -103,7 +102,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"bool":{"filter":[{"range":{"laatst_gewijzigd_datum":{"gte":"2024-01-01T00:00:00+01:00","lt":null}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"bool":{"filter":[{"range":{"laatst_gewijzigd_datum":{"gte":"2024-01-01T00:00:00+01:00","lt":null}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -119,17 +118,17 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":22,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"774ff16f-d510-4703-85d7-662d69bc445d","informatie_categorieen":[{"uuid":"c31491c5-1fad-4a09-9a77-4ba2770ee4e4","naam":"Wish
-        money tell soon."}],"publisher":{"uuid":"e6a95e9d-474c-4c04-a483-79c4f72742d7","naam":"Jones-Johnson"},"identifier":"identifier-7","officiele_titel":"Behind
-        model open network must enjoy write think.","verkorte_titel":"Pattern.","omschrijving":"Agency
-        past sure early. Technology help adult strong.","creatiedatum":"2025-02-09","registratiedatum":"2025-01-30T21:43:01.110115","laatst_gewijzigd_datum":"2025-01-14T21:12:00+00:00"},"sort":[0.0,1736889120000]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"42caf03e-9e66-4aaf-896c-24af5cda08a3","informatie_categorieen":[{"uuid":"a1df88ec-ee80-47b3-a201-0d37272335bf","naam":"Prevent
-        explain."}],"publisher":{"uuid":"c7b99cbb-bf79-41b8-89f2-76456a1973af","naam":"Barrett,
-        Johnson and Hall"},"identifier":"identifier-5","officiele_titel":"Daughter
-        purpose gas could produce yourself.","verkorte_titel":"Turn develop sell.","omschrijving":"Rise
-        power paper kind. Take traditional than ball nature. Activity store here knowledge
-        tend reflect contain.","creatiedatum":"2025-02-18","registratiedatum":"2025-02-19T15:03:37.282529","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c7b99cbb-bf79-41b8-89f2-76456a1973af","Barrett,
-        Johnson and Hall"],"key_as_string":"c7b99cbb-bf79-41b8-89f2-76456a1973af|Barrett,
-        Johnson and Hall","doc_count":1},{"key":["e6a95e9d-474c-4c04-a483-79c4f72742d7","Jones-Johnson"],"key_as_string":"e6a95e9d-474c-4c04-a483-79c4f72742d7|Jones-Johnson","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}'
+      string: '{"took":24,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"c033b176-162f-42d3-b754-b5d6957d48c1","informatie_categorieen":[{"uuid":"dc576428-f98d-4198-a1d4-491a43e6c19b","naam":"News."}],"publisher":{"uuid":"691eab04-ef1f-445e-a05b-9e6f851106d6","naam":"Elliott
+        Inc"},"identifier":"identifier-9","officiele_titel":"Move we way project yes
+        commercial somebody car.","verkorte_titel":"Network rich.","omschrijving":"Relationship
+        simple course sit more movement. School outside paper popular summer instead.
+        Yard boy imagine truth sort.","creatiedatum":"2025-02-11","registratiedatum":"2025-02-14T06:27:35.767746","laatst_gewijzigd_datum":"2025-01-14T21:12:00+00:00"},"sort":[0.0,1736889120000]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"50f16773-5aa4-4169-a572-ba9014d149c5","informatie_categorieen":[{"uuid":"2a0492ab-84f4-4bcb-93b0-f9f6e7876c65","naam":"Yes
+        officer woman."}],"publisher":{"uuid":"022f869a-867c-4af2-9572-b1e63dd35e1f","naam":"Gutierrez-Simpson"},"identifier":"identifier-7","officiele_titel":"Training
+        could daughter so pass bed.","verkorte_titel":"Kind option.","omschrijving":"Similar
+        why the raise change return. Day right television.","creatiedatum":"2025-02-03","registratiedatum":"2025-02-07T18:26:16.772446","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2a0492ab-84f4-4bcb-93b0-f9f6e7876c65","Yes
+        officer woman."],"key_as_string":"2a0492ab-84f4-4bcb-93b0-f9f6e7876c65|Yes
+        officer woman.","doc_count":1},{"key":["dc576428-f98d-4198-a1d4-491a43e6c19b","News."],"key_as_string":"dc576428-f98d-4198-a1d4-491a43e6c19b|News.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["022f869a-867c-4af2-9572-b1e63dd35e1f","Gutierrez-Simpson"],"key_as_string":"022f869a-867c-4af2-9572-b1e63dd35e1f|Gutierrez-Simpson","doc_count":1},{"key":["691eab04-ef1f-445e-a05b-9e6f851106d6","Elliott
+        Inc"],"key_as_string":"691eab04-ef1f-445e-a05b-9e6f851106d6|Elliott Inc","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -141,7 +140,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"bool":{"filter":[{"range":{"laatst_gewijzigd_datum":{"gte":null,"lt":"2022-12-31T23:59:59.999999+01:00"}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"bool":{"filter":[{"range":{"laatst_gewijzigd_datum":{"gte":null,"lt":"2022-12-31T23:59:59.999999+01:00"}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -157,13 +156,15 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":15,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"599188f8-c44b-49b1-a069-bee9db4146a1","informatie_categorieen":[{"uuid":"a198e391-d927-4e55-8309-aaa391ccd78a","naam":"Because
-        data yes."}],"publisher":{"uuid":"0c9cbd7b-2c51-4229-91d8-5d3691ed13f5","naam":"Rivera
-        PLC"},"identifier":"identifier-6","officiele_titel":"Window blue administration
-        relate TV heart.","verkorte_titel":"Matter market like.","omschrijving":"However
-        serve believe mouth production blue. Rock region yard resource when plant
-        attention. Probably down feeling trouble space move purpose.","creatiedatum":"2025-02-08","registratiedatum":"2025-02-16T20:56:25.888163","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"},"sort":[0.0,1670695200000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["0c9cbd7b-2c51-4229-91d8-5d3691ed13f5","Rivera
-        PLC"],"key_as_string":"0c9cbd7b-2c51-4229-91d8-5d3691ed13f5|Rivera PLC","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
+      string: '{"took":17,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"e82e9a90-3538-420e-adbc-a9eb0165441b","informatie_categorieen":[{"uuid":"c5aa2eaf-2c5d-4f37-8181-a6ac3a5fa8d7","naam":"Sound
+        agree."}],"publisher":{"uuid":"2fb4f2c9-96df-4f63-b54b-2f6e2c80d9ef","naam":"Knight,
+        Thomas and Murray"},"identifier":"identifier-8","officiele_titel":"Near miss
+        argue movie increase age seven perform.","verkorte_titel":"Prepare western.","omschrijving":"Either
+        impact southern few attorney ago. Serve actually whom. Anyone her no fund
+        continue seven.","creatiedatum":"2025-01-31","registratiedatum":"2025-02-07T12:20:15.938378","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"},"sort":[0.0,1670695200000]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c5aa2eaf-2c5d-4f37-8181-a6ac3a5fa8d7","Sound
+        agree."],"key_as_string":"c5aa2eaf-2c5d-4f37-8181-a6ac3a5fa8d7|Sound agree.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2fb4f2c9-96df-4f63-b54b-2f6e2c80d9ef","Knight,
+        Thomas and Murray"],"key_as_string":"2fb4f2c9-96df-4f63-b54b-2f6e2c80d9ef|Knight,
+        Thomas and Murray","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -175,7 +176,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"bool":{"filter":[{"range":{"laatst_gewijzigd_datum":{"gte":"2024-01-01T00:00:00+01:00","lt":"2024-12-31T23:59:59.999999+01:00"}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"bool":{"filter":[{"range":{"laatst_gewijzigd_datum":{"gte":"2024-01-01T00:00:00+01:00","lt":"2024-12-31T23:59:59.999999+01:00"}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -191,14 +192,12 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"42caf03e-9e66-4aaf-896c-24af5cda08a3","informatie_categorieen":[{"uuid":"a1df88ec-ee80-47b3-a201-0d37272335bf","naam":"Prevent
-        explain."}],"publisher":{"uuid":"c7b99cbb-bf79-41b8-89f2-76456a1973af","naam":"Barrett,
-        Johnson and Hall"},"identifier":"identifier-5","officiele_titel":"Daughter
-        purpose gas could produce yourself.","verkorte_titel":"Turn develop sell.","omschrijving":"Rise
-        power paper kind. Take traditional than ball nature. Activity store here knowledge
-        tend reflect contain.","creatiedatum":"2025-02-18","registratiedatum":"2025-02-19T15:03:37.282529","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c7b99cbb-bf79-41b8-89f2-76456a1973af","Barrett,
-        Johnson and Hall"],"key_as_string":"c7b99cbb-bf79-41b8-89f2-76456a1973af|Barrett,
-        Johnson and Hall","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
+      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"50f16773-5aa4-4169-a572-ba9014d149c5","informatie_categorieen":[{"uuid":"2a0492ab-84f4-4bcb-93b0-f9f6e7876c65","naam":"Yes
+        officer woman."}],"publisher":{"uuid":"022f869a-867c-4af2-9572-b1e63dd35e1f","naam":"Gutierrez-Simpson"},"identifier":"identifier-7","officiele_titel":"Training
+        could daughter so pass bed.","verkorte_titel":"Kind option.","omschrijving":"Similar
+        why the raise change return. Day right television.","creatiedatum":"2025-02-03","registratiedatum":"2025-02-07T18:26:16.772446","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2a0492ab-84f4-4bcb-93b0-f9f6e7876c65","Yes
+        officer woman."],"key_as_string":"2a0492ab-84f4-4bcb-93b0-f9f6e7876c65|Yes
+        officer woman.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["022f869a-867c-4af2-9572-b1e63dd35e1f","Gutierrez-Simpson"],"key_as_string":"022f869a-867c-4af2-9572-b1e63dd35e1f|Gutierrez-Simpson","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_last_modified_date_both_indexes.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_last_modified_date_both_indexes.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"3a7c5227-be54-473a-b377-3f921a6efef3","naam":"Davis-Kim"},"informatie_categorieen":[{"uuid":"26a66228-b8d4-4e1a-82dc-e78ceca514f9","naam":"Cup
-      book military."}],"officiele_titel":"Simple hundred require play agreement top.","verkorte_titel":"Effort
-      hear amount.","omschrijving":"Suggest different collection several black. Out
-      country personal interview stand source. Nearly talk where father make allow.","registratiedatum":"2025-02-12T02:42:59.784235","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
+    body: '{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"44407667-f846-4f2d-987c-b475a00c2e8b","naam":"Williams-Carlson"},"informatie_categorieen":[{"uuid":"0ea9a3dd-a965-4e47-825a-130f6541cac7","naam":"While
+      live to."}],"officiele_titel":"Important measure gun test resource finish situation.","verkorte_titel":"Star
+      win.","omschrijving":"Bank college save treat audience. Push project sometimes
+      turn recent. Available air win middle. Activity different hotel.","registratiedatum":"2025-02-18T10:52:47.949294","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,11 +33,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"de225c2e-2700-4fee-a6ea-efa276db42d4","publisher":{"uuid":"db86b29a-d2f7-48f1-8197-353dabc07470","naam":"Smith,
-      Henry and Henderson"},"informatie_categorieen":[{"uuid":"bb0cd6fd-cd08-4760-a05c-8c090725b891","naam":"To
-      each."}],"officiele_titel":"Quality job real score.","verkorte_titel":"Board
-      know design.","omschrijving":"Long again despite story tree. Camera travel cultural
-      enter. Catch know health want gas money year realize.","registratiedatum":"2025-02-16T22:21:15.519976","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
+    body: '{"uuid":"de225c2e-2700-4fee-a6ea-efa276db42d4","publisher":{"uuid":"245012dc-46b3-4665-a428-b0738fe63aa8","naam":"Moore,
+      Jones and Leon"},"informatie_categorieen":[{"uuid":"a9c9e2b7-bd38-46cb-9d5b-23e7c4003bb5","naam":"Music
+      put."}],"officiele_titel":"Any attention feel any.","verkorte_titel":"Hotel
+      development physical.","omschrijving":"Travel standard newspaper suddenly. Admit
+      development in price group on meeting.","registratiedatum":"2025-02-02T01:16:37.728533","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -67,10 +67,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"00ef950c-1ac5-4a27-a0ed-9ef4d1c85547","publisher":{"uuid":"b237fdde-a2d0-4ea2-a27e-3cf1eda430b9","naam":"Newton-Freeman"},"identifier":"identifier-8","officiele_titel":"Check
-      home itself free itself always yard authority.","verkorte_titel":"Interview
-      town.","omschrijving":"Who president present me onto. Though account air well
-      actually. Huge behind head.","creatiedatum":"2025-01-26","registratiedatum":"2025-02-10T19:00:40.927251","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"05bfa91c-7d60-4efb-b504-3173c481d13b","informatie_categorieen":[{"uuid":"99bae709-cc42-4779-9788-48aeb0443994","naam":"Relate
+      film."}],"publisher":{"uuid":"5a21d96a-9fab-4b7e-9a9c-35f46d18f5ad","naam":"Long-Morrow"},"identifier":"identifier-8","officiele_titel":"Remain
+      marriage later.","verkorte_titel":"My heavy.","omschrijving":"Play check avoid
+      discussion game woman. Large character attack trial reflect capital message.
+      Cold glass production structure simple court senior. Avoid edge cold age high
+      writer.","creatiedatum":"2025-02-17","registratiedatum":"2025-02-09T14:16:36.317498","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -100,10 +102,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"a00a843e-0288-4c8e-a3aa-9f0530195b3a","publisher":{"uuid":"5715c4c8-1fbe-4bd0-98be-5b2523ebb682","naam":"Wilson,
-      Fuller and Christian"},"identifier":"identifier-9","officiele_titel":"Add huge
-      move.","verkorte_titel":"Nation miss.","omschrijving":"Music bad senior response.
-      Happen scene since.","creatiedatum":"2025-02-08","registratiedatum":"2025-01-28T13:48:53.484127","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"dddca982-889b-4a72-9b20-ae9b130981b9","informatie_categorieen":[{"uuid":"5b8755c0-80fb-403e-b986-e019c700115f","naam":"Economy
+      mouth."}],"publisher":{"uuid":"140e243f-4bc8-47de-a3ff-6dba7e237aaf","naam":"Mathis
+      Group"},"identifier":"identifier-9","officiele_titel":"Summer third small season
+      continue particularly.","verkorte_titel":"Many century street near.","omschrijving":"Rule
+      much significant word traditional act. Last up century behavior green fill.
+      Growth nation arrive feel major affect bring.","creatiedatum":"2025-02-17","registratiedatum":"2025-02-13T14:42:45.443807","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -149,14 +153,16 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"00ef950c-1ac5-4a27-a0ed-9ef4d1c85547","publisher":{"uuid":"b237fdde-a2d0-4ea2-a27e-3cf1eda430b9","naam":"Newton-Freeman"},"identifier":"identifier-8","officiele_titel":"Check
-        home itself free itself always yard authority.","verkorte_titel":"Interview
-        town.","omschrijving":"Who president present me onto. Though account air well
-        actually. Huge behind head.","creatiedatum":"2025-01-26","registratiedatum":"2025-02-10T19:00:40.927251","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]},{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_score":0.0,"_source":{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"3a7c5227-be54-473a-b377-3f921a6efef3","naam":"Davis-Kim"},"informatie_categorieen":[{"uuid":"26a66228-b8d4-4e1a-82dc-e78ceca514f9","naam":"Cup
-        book military."}],"officiele_titel":"Simple hundred require play agreement
-        top.","verkorte_titel":"Effort hear amount.","omschrijving":"Suggest different
-        collection several black. Out country personal interview stand source. Nearly
-        talk where father make allow.","registratiedatum":"2025-02-12T02:42:59.784235","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3a7c5227-be54-473a-b377-3f921a6efef3","Davis-Kim"],"key_as_string":"3a7c5227-be54-473a-b377-3f921a6efef3|Davis-Kim","doc_count":1},{"key":["b237fdde-a2d0-4ea2-a27e-3cf1eda430b9","Newton-Freeman"],"key_as_string":"b237fdde-a2d0-4ea2-a27e-3cf1eda430b9|Newton-Freeman","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"05bfa91c-7d60-4efb-b504-3173c481d13b","informatie_categorieen":[{"uuid":"99bae709-cc42-4779-9788-48aeb0443994","naam":"Relate
+        film."}],"publisher":{"uuid":"5a21d96a-9fab-4b7e-9a9c-35f46d18f5ad","naam":"Long-Morrow"},"identifier":"identifier-8","officiele_titel":"Remain
+        marriage later.","verkorte_titel":"My heavy.","omschrijving":"Play check avoid
+        discussion game woman. Large character attack trial reflect capital message.
+        Cold glass production structure simple court senior. Avoid edge cold age high
+        writer.","creatiedatum":"2025-02-17","registratiedatum":"2025-02-09T14:16:36.317498","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]},{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_score":0.0,"_source":{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"44407667-f846-4f2d-987c-b475a00c2e8b","naam":"Williams-Carlson"},"informatie_categorieen":[{"uuid":"0ea9a3dd-a965-4e47-825a-130f6541cac7","naam":"While
+        live to."}],"officiele_titel":"Important measure gun test resource finish
+        situation.","verkorte_titel":"Star win.","omschrijving":"Bank college save
+        treat audience. Push project sometimes turn recent. Available air win middle.
+        Activity different hotel.","registratiedatum":"2025-02-18T10:52:47.949294","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["44407667-f846-4f2d-987c-b475a00c2e8b","Williams-Carlson"],"key_as_string":"44407667-f846-4f2d-987c-b475a00c2e8b|Williams-Carlson","doc_count":1},{"key":["5a21d96a-9fab-4b7e-9a9c-35f46d18f5ad","Long-Morrow"],"key_as_string":"5a21d96a-9fab-4b7e-9a9c-35f46d18f5ad|Long-Morrow","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_last_modified_date_both_indexes.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_last_modified_date_both_indexes.yaml
@@ -1,9 +1,11 @@
 interactions:
 - request:
-    body: '{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"44407667-f846-4f2d-987c-b475a00c2e8b","naam":"Williams-Carlson"},"informatie_categorieen":[{"uuid":"0ea9a3dd-a965-4e47-825a-130f6541cac7","naam":"While
-      live to."}],"officiele_titel":"Important measure gun test resource finish situation.","verkorte_titel":"Star
-      win.","omschrijving":"Bank college save treat audience. Push project sometimes
-      turn recent. Available air win middle. Activity different hotel.","registratiedatum":"2025-02-18T10:52:47.949294","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
+    body: '{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"616a6e04-a228-403d-a5b5-605459754b2d","naam":"Lowery
+      PLC"},"informatie_categorieen":[{"uuid":"f534debb-7add-4204-8847-607815c9ff6f","naam":"Study
+      discover federal far."}],"officiele_titel":"Determine career hit trial development
+      military firm case.","verkorte_titel":"Condition wish.","omschrijving":"Dinner
+      well concern main improve open ever. Town magazine clearly explain view. Find
+      including site few dinner language. Get stop however as choose prove smile.","registratiedatum":"2025-01-31T14:12:38.714175","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -19,7 +21,7 @@ interactions:
     uri: http://localhost:9201/publication/_doc/b38065ee-322e-46c7-ae64-c47112a4b408?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":4,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":8,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/b38065ee-322e-46c7-ae64-c47112a4b408
@@ -33,11 +35,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"de225c2e-2700-4fee-a6ea-efa276db42d4","publisher":{"uuid":"245012dc-46b3-4665-a428-b0738fe63aa8","naam":"Moore,
-      Jones and Leon"},"informatie_categorieen":[{"uuid":"a9c9e2b7-bd38-46cb-9d5b-23e7c4003bb5","naam":"Music
-      put."}],"officiele_titel":"Any attention feel any.","verkorte_titel":"Hotel
-      development physical.","omschrijving":"Travel standard newspaper suddenly. Admit
-      development in price group on meeting.","registratiedatum":"2025-02-02T01:16:37.728533","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
+    body: '{"uuid":"de225c2e-2700-4fee-a6ea-efa276db42d4","publisher":{"uuid":"6233c93d-3d35-4730-b877-add2fcae9f28","naam":"Lynch-Weber"},"informatie_categorieen":[{"uuid":"ef76cea9-95d8-4b8e-a1cf-53ed86ce9e9a","naam":"Agency
+      station company."}],"officiele_titel":"Guy north read.","verkorte_titel":"Raise
+      executive despite.","omschrijving":"News discussion yourself production research
+      culture. Various be event or behind or write. Government let away.","registratiedatum":"2025-02-21T21:20:38.073360","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -53,7 +54,7 @@ interactions:
     uri: http://localhost:9201/publication/_doc/de225c2e-2700-4fee-a6ea-efa276db42d4?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"de225c2e-2700-4fee-a6ea-efa276db42d4","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":5,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"de225c2e-2700-4fee-a6ea-efa276db42d4","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":9,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/de225c2e-2700-4fee-a6ea-efa276db42d4
@@ -67,12 +68,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"05bfa91c-7d60-4efb-b504-3173c481d13b","informatie_categorieen":[{"uuid":"99bae709-cc42-4779-9788-48aeb0443994","naam":"Relate
-      film."}],"publisher":{"uuid":"5a21d96a-9fab-4b7e-9a9c-35f46d18f5ad","naam":"Long-Morrow"},"identifier":"identifier-8","officiele_titel":"Remain
-      marriage later.","verkorte_titel":"My heavy.","omschrijving":"Play check avoid
-      discussion game woman. Large character attack trial reflect capital message.
-      Cold glass production structure simple court senior. Avoid edge cold age high
-      writer.","creatiedatum":"2025-02-17","registratiedatum":"2025-02-09T14:16:36.317498","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"578e2992-fcf6-4457-9b11-49eeea49439f","informatie_categorieen":[{"uuid":"dd600641-2b7f-4cdb-9ecb-21d744f4246c","naam":"Here
+      statement."}],"publisher":{"uuid":"6ffb64cf-79aa-4983-bda1-6ec6623ab17d","naam":"Davis-Robinson"},"identifier":"identifier-10","officiele_titel":"Five
+      not near land involve.","verkorte_titel":"Cost.","omschrijving":"Star suddenly
+      realize some forward represent behind. Cut bar born toward. Worker describe
+      woman really.","creatiedatum":"2025-02-06","registratiedatum":"2025-01-27T07:11:28.364125","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -88,7 +88,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/6aac4fb2-d532-490b-bd6b-87b0257c0236?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_version":5,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":16,"_primary_term":1}'
+      string: '{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_version":5,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":20,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/6aac4fb2-d532-490b-bd6b-87b0257c0236
@@ -102,12 +102,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"dddca982-889b-4a72-9b20-ae9b130981b9","informatie_categorieen":[{"uuid":"5b8755c0-80fb-403e-b986-e019c700115f","naam":"Economy
-      mouth."}],"publisher":{"uuid":"140e243f-4bc8-47de-a3ff-6dba7e237aaf","naam":"Mathis
-      Group"},"identifier":"identifier-9","officiele_titel":"Summer third small season
-      continue particularly.","verkorte_titel":"Many century street near.","omschrijving":"Rule
-      much significant word traditional act. Last up century behavior green fill.
-      Growth nation arrive feel major affect bring.","creatiedatum":"2025-02-17","registratiedatum":"2025-02-13T14:42:45.443807","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"410c84a6-454e-44c3-b3eb-fbc532372377","informatie_categorieen":[{"uuid":"da1ce656-0aee-4f63-96b8-784263942971","naam":"Approach
+      protect alone."}],"publisher":{"uuid":"62eaa9e6-ce99-4e0c-9da3-dde964adb189","naam":"Kim
+      and Sons"},"identifier":"identifier-11","officiele_titel":"Or baby success couple
+      strong political.","verkorte_titel":"Forward article future.","omschrijving":"Want
+      however gas trial. Response wait audience indicate institution free. New vote
+      happy behavior discussion of ground money.","creatiedatum":"2025-02-16","registratiedatum":"2025-02-10T21:29:49.105545","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -123,7 +123,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/62fceb92-98bd-475c-b184-49ee8a274787?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_version":5,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":17,"_primary_term":1}'
+      string: '{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_version":5,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":21,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/62fceb92-98bd-475c-b184-49ee8a274787
@@ -137,7 +137,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"bool":{"filter":[{"range":{"laatst_gewijzigd_datum":{"gte":"2024-01-01T00:00:00+01:00","lt":"2024-12-31T23:59:59.999999+01:00"}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"bool":{"filter":[{"range":{"laatst_gewijzigd_datum":{"gte":"2024-01-01T00:00:00+01:00","lt":"2024-12-31T23:59:59.999999+01:00"}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -153,16 +153,20 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"05bfa91c-7d60-4efb-b504-3173c481d13b","informatie_categorieen":[{"uuid":"99bae709-cc42-4779-9788-48aeb0443994","naam":"Relate
-        film."}],"publisher":{"uuid":"5a21d96a-9fab-4b7e-9a9c-35f46d18f5ad","naam":"Long-Morrow"},"identifier":"identifier-8","officiele_titel":"Remain
-        marriage later.","verkorte_titel":"My heavy.","omschrijving":"Play check avoid
-        discussion game woman. Large character attack trial reflect capital message.
-        Cold glass production structure simple court senior. Avoid edge cold age high
-        writer.","creatiedatum":"2025-02-17","registratiedatum":"2025-02-09T14:16:36.317498","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]},{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_score":0.0,"_source":{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"44407667-f846-4f2d-987c-b475a00c2e8b","naam":"Williams-Carlson"},"informatie_categorieen":[{"uuid":"0ea9a3dd-a965-4e47-825a-130f6541cac7","naam":"While
-        live to."}],"officiele_titel":"Important measure gun test resource finish
-        situation.","verkorte_titel":"Star win.","omschrijving":"Bank college save
-        treat audience. Push project sometimes turn recent. Available air win middle.
-        Activity different hotel.","registratiedatum":"2025-02-18T10:52:47.949294","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["44407667-f846-4f2d-987c-b475a00c2e8b","Williams-Carlson"],"key_as_string":"44407667-f846-4f2d-987c-b475a00c2e8b|Williams-Carlson","doc_count":1},{"key":["5a21d96a-9fab-4b7e-9a9c-35f46d18f5ad","Long-Morrow"],"key_as_string":"5a21d96a-9fab-4b7e-9a9c-35f46d18f5ad|Long-Morrow","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"578e2992-fcf6-4457-9b11-49eeea49439f","informatie_categorieen":[{"uuid":"dd600641-2b7f-4cdb-9ecb-21d744f4246c","naam":"Here
+        statement."}],"publisher":{"uuid":"6ffb64cf-79aa-4983-bda1-6ec6623ab17d","naam":"Davis-Robinson"},"identifier":"identifier-10","officiele_titel":"Five
+        not near land involve.","verkorte_titel":"Cost.","omschrijving":"Star suddenly
+        realize some forward represent behind. Cut bar born toward. Worker describe
+        woman really.","creatiedatum":"2025-02-06","registratiedatum":"2025-01-27T07:11:28.364125","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]},{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_score":0.0,"_source":{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"616a6e04-a228-403d-a5b5-605459754b2d","naam":"Lowery
+        PLC"},"informatie_categorieen":[{"uuid":"f534debb-7add-4204-8847-607815c9ff6f","naam":"Study
+        discover federal far."}],"officiele_titel":"Determine career hit trial development
+        military firm case.","verkorte_titel":"Condition wish.","omschrijving":"Dinner
+        well concern main improve open ever. Town magazine clearly explain view. Find
+        including site few dinner language. Get stop however as choose prove smile.","registratiedatum":"2025-01-31T14:12:38.714175","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["dd600641-2b7f-4cdb-9ecb-21d744f4246c","Here
+        statement."],"key_as_string":"dd600641-2b7f-4cdb-9ecb-21d744f4246c|Here statement.","doc_count":1},{"key":["f534debb-7add-4204-8847-607815c9ff6f","Study
+        discover federal far."],"key_as_string":"f534debb-7add-4204-8847-607815c9ff6f|Study
+        discover federal far.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["616a6e04-a228-403d-a5b5-605459754b2d","Lowery
+        PLC"],"key_as_string":"616a6e04-a228-403d-a5b5-605459754b2d|Lowery PLC","doc_count":1},{"key":["6ffb64cf-79aa-4983-bda1-6ec6623ab17d","Davis-Robinson"],"key_as_string":"6ffb64cf-79aa-4983-bda1-6ec6623ab17d|Davis-Robinson","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_registration_date.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_registration_date.yaml
@@ -1,11 +1,11 @@
 interactions:
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"20131298-b208-4cb6-892f-89f2f1f3aefc","informatie_categorieen":[{"uuid":"89512418-31f9-4c9a-9163-f5476ef7d9c5","naam":"Program
-      appear sign."}],"publisher":{"uuid":"b1d6a707-cdec-4f7d-882a-72d372d21c20","naam":"Curtis,
-      Black and Tucker"},"identifier":"identifier-10","officiele_titel":"Student adult
-      decade need officer east reveal.","verkorte_titel":"Once although.","omschrijving":"Race
-      professor determine senior value enjoy report. Human black seek charge anyone.
-      Brother whom approach interest also then care.","creatiedatum":"2025-02-07","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-01-29T04:34:08.351757"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"3d8cbd82-cc60-40a2-b3bd-b3be19ca835f","informatie_categorieen":[{"uuid":"a4def23b-dbe5-461b-8a2e-07d7a43d8738","naam":"Market
+      environment."}],"publisher":{"uuid":"ab93b8c0-6e8b-471c-af61-879a5f5f7aa0","naam":"Edwards,
+      Winters and Lee"},"identifier":"identifier-12","officiele_titel":"Make my care
+      support fear.","verkorte_titel":"Hospital mention concern.","omschrijving":"Both
+      home kid enter significant. Continue another season smile thing every most.
+      Reality determine myself necessary necessary past art.","creatiedatum":"2025-02-10","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-22T20:18:24.600353"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -21,7 +21,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/6aac4fb2-d532-490b-bd6b-87b0257c0236?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_version":7,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":20,"_primary_term":1}'
+      string: '{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_version":7,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":24,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/6aac4fb2-d532-490b-bd6b-87b0257c0236
@@ -35,11 +35,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"35dc64a8-b57a-4d1f-9228-0fe606ea69f4","informatie_categorieen":[{"uuid":"5a41cda5-65cc-49e2-8be8-cd1ebf6ec054","naam":"Inside."}],"publisher":{"uuid":"d379a25f-afd9-4e6d-9476-a13277e617b8","naam":"Crawford
-      Ltd"},"identifier":"identifier-11","officiele_titel":"Especially name campaign
-      situation.","verkorte_titel":"South certainly.","omschrijving":"Town run whose
-      practice many production. Suddenly type participant response. Congress use especially
-      great late really yard treat.","creatiedatum":"2025-02-10","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-01-31T05:34:11.936238"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"55965b4c-8427-4dbe-ac95-5f4d0f31ce5b","informatie_categorieen":[{"uuid":"7eadb9d5-b94a-42da-938c-fc1ca753fa32","naam":"Mention
+      hair another."}],"publisher":{"uuid":"344fa03d-10c0-4a72-bda1-e321865eb873","naam":"Gross,
+      Williams and Watson"},"identifier":"identifier-13","officiele_titel":"Age center
+      stand.","verkorte_titel":"Suffer court visit.","omschrijving":"Now least single
+      TV poor. Address think material choose statement father.","creatiedatum":"2025-02-14","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-02-03T01:36:23.710559"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -55,7 +55,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/62fceb92-98bd-475c-b184-49ee8a274787?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_version":7,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":21,"_primary_term":1}'
+      string: '{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_version":7,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":25,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/62fceb92-98bd-475c-b184-49ee8a274787
@@ -69,12 +69,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"b63e515d-04da-4234-a911-cc746e55f541","informatie_categorieen":[{"uuid":"d65c1a07-d39e-444a-b978-44e36df2f47e","naam":"Defense
-      activity."}],"publisher":{"uuid":"03303ff1-06ad-43bd-928d-39591988643f","naam":"Pearson
-      PLC"},"identifier":"identifier-12","officiele_titel":"Recognize artist exactly
-      strong art visit throw.","verkorte_titel":"Information staff physical.","omschrijving":"Skin
-      government play they time item start. Then whom data account structure important
-      from. Ago white show attention.","creatiedatum":"2025-02-06","registratiedatum":"2025-01-14T21:12:00+00:00","laatst_gewijzigd_datum":"2025-01-29T22:46:49.226901"}'
+    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"3abe222e-14b4-4e04-bbad-aed4884bf73a","informatie_categorieen":[{"uuid":"5bbd4633-050e-4f46-af97-915d7f6e80a0","naam":"Despite
+      employee."}],"publisher":{"uuid":"3094cc94-0843-4725-a6fe-8b7be51668d9","naam":"Bender
+      Ltd"},"identifier":"identifier-14","officiele_titel":"Price health culture experience
+      recently authority true.","verkorte_titel":"Close he.","omschrijving":"Peace
+      another try this they born star. Data thank would soldier travel create institution
+      important. Pass building point matter.","creatiedatum":"2025-02-02","registratiedatum":"2025-01-14T21:12:00+00:00","laatst_gewijzigd_datum":"2025-01-28T11:00:50.150745"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -90,7 +90,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/ef1dead2-e0f8-45be-acf7-3583adc14906?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_version":5,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":22,"_primary_term":1}'
+      string: '{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_version":5,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":26,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/ef1dead2-e0f8-45be-acf7-3583adc14906
@@ -104,7 +104,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"bool":{"filter":[{"range":{"registratiedatum":{"gte":"2024-01-01T00:00:00+01:00","lt":null}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"bool":{"filter":[{"range":{"registratiedatum":{"gte":"2024-01-01T00:00:00+01:00","lt":null}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -120,20 +120,24 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"b63e515d-04da-4234-a911-cc746e55f541","informatie_categorieen":[{"uuid":"d65c1a07-d39e-444a-b978-44e36df2f47e","naam":"Defense
-        activity."}],"publisher":{"uuid":"03303ff1-06ad-43bd-928d-39591988643f","naam":"Pearson
-        PLC"},"identifier":"identifier-12","officiele_titel":"Recognize artist exactly
-        strong art visit throw.","verkorte_titel":"Information staff physical.","omschrijving":"Skin
-        government play they time item start. Then whom data account structure important
-        from. Ago white show attention.","creatiedatum":"2025-02-06","registratiedatum":"2025-01-14T21:12:00+00:00","laatst_gewijzigd_datum":"2025-01-29T22:46:49.226901"},"sort":[0.0,1738190809226]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"20131298-b208-4cb6-892f-89f2f1f3aefc","informatie_categorieen":[{"uuid":"89512418-31f9-4c9a-9163-f5476ef7d9c5","naam":"Program
-        appear sign."}],"publisher":{"uuid":"b1d6a707-cdec-4f7d-882a-72d372d21c20","naam":"Curtis,
-        Black and Tucker"},"identifier":"identifier-10","officiele_titel":"Student
-        adult decade need officer east reveal.","verkorte_titel":"Once although.","omschrijving":"Race
-        professor determine senior value enjoy report. Human black seek charge anyone.
-        Brother whom approach interest also then care.","creatiedatum":"2025-02-07","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-01-29T04:34:08.351757"},"sort":[0.0,1738125248351]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["03303ff1-06ad-43bd-928d-39591988643f","Pearson
-        PLC"],"key_as_string":"03303ff1-06ad-43bd-928d-39591988643f|Pearson PLC","doc_count":1},{"key":["b1d6a707-cdec-4f7d-882a-72d372d21c20","Curtis,
-        Black and Tucker"],"key_as_string":"b1d6a707-cdec-4f7d-882a-72d372d21c20|Curtis,
-        Black and Tucker","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}'
+      string: '{"took":14,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"3d8cbd82-cc60-40a2-b3bd-b3be19ca835f","informatie_categorieen":[{"uuid":"a4def23b-dbe5-461b-8a2e-07d7a43d8738","naam":"Market
+        environment."}],"publisher":{"uuid":"ab93b8c0-6e8b-471c-af61-879a5f5f7aa0","naam":"Edwards,
+        Winters and Lee"},"identifier":"identifier-12","officiele_titel":"Make my
+        care support fear.","verkorte_titel":"Hospital mention concern.","omschrijving":"Both
+        home kid enter significant. Continue another season smile thing every most.
+        Reality determine myself necessary necessary past art.","creatiedatum":"2025-02-10","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-22T20:18:24.600353"},"sort":[0.0,1740255504600]},{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"3abe222e-14b4-4e04-bbad-aed4884bf73a","informatie_categorieen":[{"uuid":"5bbd4633-050e-4f46-af97-915d7f6e80a0","naam":"Despite
+        employee."}],"publisher":{"uuid":"3094cc94-0843-4725-a6fe-8b7be51668d9","naam":"Bender
+        Ltd"},"identifier":"identifier-14","officiele_titel":"Price health culture
+        experience recently authority true.","verkorte_titel":"Close he.","omschrijving":"Peace
+        another try this they born star. Data thank would soldier travel create institution
+        important. Pass building point matter.","creatiedatum":"2025-02-02","registratiedatum":"2025-01-14T21:12:00+00:00","laatst_gewijzigd_datum":"2025-01-28T11:00:50.150745"},"sort":[0.0,1738062050150]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["5bbd4633-050e-4f46-af97-915d7f6e80a0","Despite
+        employee."],"key_as_string":"5bbd4633-050e-4f46-af97-915d7f6e80a0|Despite
+        employee.","doc_count":1},{"key":["a4def23b-dbe5-461b-8a2e-07d7a43d8738","Market
+        environment."],"key_as_string":"a4def23b-dbe5-461b-8a2e-07d7a43d8738|Market
+        environment.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3094cc94-0843-4725-a6fe-8b7be51668d9","Bender
+        Ltd"],"key_as_string":"3094cc94-0843-4725-a6fe-8b7be51668d9|Bender Ltd","doc_count":1},{"key":["ab93b8c0-6e8b-471c-af61-879a5f5f7aa0","Edwards,
+        Winters and Lee"],"key_as_string":"ab93b8c0-6e8b-471c-af61-879a5f5f7aa0|Edwards,
+        Winters and Lee","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -145,7 +149,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"bool":{"filter":[{"range":{"registratiedatum":{"gte":null,"lt":"2022-12-31T23:59:59.999999+01:00"}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"bool":{"filter":[{"range":{"registratiedatum":{"gte":null,"lt":"2022-12-31T23:59:59.999999+01:00"}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -161,12 +165,15 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"35dc64a8-b57a-4d1f-9228-0fe606ea69f4","informatie_categorieen":[{"uuid":"5a41cda5-65cc-49e2-8be8-cd1ebf6ec054","naam":"Inside."}],"publisher":{"uuid":"d379a25f-afd9-4e6d-9476-a13277e617b8","naam":"Crawford
-        Ltd"},"identifier":"identifier-11","officiele_titel":"Especially name campaign
-        situation.","verkorte_titel":"South certainly.","omschrijving":"Town run whose
-        practice many production. Suddenly type participant response. Congress use
-        especially great late really yard treat.","creatiedatum":"2025-02-10","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-01-31T05:34:11.936238"},"sort":[0.0,1738301651936]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["d379a25f-afd9-4e6d-9476-a13277e617b8","Crawford
-        Ltd"],"key_as_string":"d379a25f-afd9-4e6d-9476-a13277e617b8|Crawford Ltd","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
+      string: '{"took":13,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"55965b4c-8427-4dbe-ac95-5f4d0f31ce5b","informatie_categorieen":[{"uuid":"7eadb9d5-b94a-42da-938c-fc1ca753fa32","naam":"Mention
+        hair another."}],"publisher":{"uuid":"344fa03d-10c0-4a72-bda1-e321865eb873","naam":"Gross,
+        Williams and Watson"},"identifier":"identifier-13","officiele_titel":"Age
+        center stand.","verkorte_titel":"Suffer court visit.","omschrijving":"Now
+        least single TV poor. Address think material choose statement father.","creatiedatum":"2025-02-14","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-02-03T01:36:23.710559"},"sort":[0.0,1738546583710]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["7eadb9d5-b94a-42da-938c-fc1ca753fa32","Mention
+        hair another."],"key_as_string":"7eadb9d5-b94a-42da-938c-fc1ca753fa32|Mention
+        hair another.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["344fa03d-10c0-4a72-bda1-e321865eb873","Gross,
+        Williams and Watson"],"key_as_string":"344fa03d-10c0-4a72-bda1-e321865eb873|Gross,
+        Williams and Watson","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -178,7 +185,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"bool":{"filter":[{"range":{"registratiedatum":{"gte":"2024-01-01T00:00:00+01:00","lt":"2024-12-31T23:59:59.999999+01:00"}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"bool":{"filter":[{"range":{"registratiedatum":{"gte":"2024-01-01T00:00:00+01:00","lt":"2024-12-31T23:59:59.999999+01:00"}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -194,14 +201,16 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"20131298-b208-4cb6-892f-89f2f1f3aefc","informatie_categorieen":[{"uuid":"89512418-31f9-4c9a-9163-f5476ef7d9c5","naam":"Program
-        appear sign."}],"publisher":{"uuid":"b1d6a707-cdec-4f7d-882a-72d372d21c20","naam":"Curtis,
-        Black and Tucker"},"identifier":"identifier-10","officiele_titel":"Student
-        adult decade need officer east reveal.","verkorte_titel":"Once although.","omschrijving":"Race
-        professor determine senior value enjoy report. Human black seek charge anyone.
-        Brother whom approach interest also then care.","creatiedatum":"2025-02-07","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-01-29T04:34:08.351757"},"sort":[0.0,1738125248351]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["b1d6a707-cdec-4f7d-882a-72d372d21c20","Curtis,
-        Black and Tucker"],"key_as_string":"b1d6a707-cdec-4f7d-882a-72d372d21c20|Curtis,
-        Black and Tucker","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
+      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"3d8cbd82-cc60-40a2-b3bd-b3be19ca835f","informatie_categorieen":[{"uuid":"a4def23b-dbe5-461b-8a2e-07d7a43d8738","naam":"Market
+        environment."}],"publisher":{"uuid":"ab93b8c0-6e8b-471c-af61-879a5f5f7aa0","naam":"Edwards,
+        Winters and Lee"},"identifier":"identifier-12","officiele_titel":"Make my
+        care support fear.","verkorte_titel":"Hospital mention concern.","omschrijving":"Both
+        home kid enter significant. Continue another season smile thing every most.
+        Reality determine myself necessary necessary past art.","creatiedatum":"2025-02-10","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-22T20:18:24.600353"},"sort":[0.0,1740255504600]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["a4def23b-dbe5-461b-8a2e-07d7a43d8738","Market
+        environment."],"key_as_string":"a4def23b-dbe5-461b-8a2e-07d7a43d8738|Market
+        environment.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["ab93b8c0-6e8b-471c-af61-879a5f5f7aa0","Edwards,
+        Winters and Lee"],"key_as_string":"ab93b8c0-6e8b-471c-af61-879a5f5f7aa0|Edwards,
+        Winters and Lee","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_registration_date.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_registration_date.yaml
@@ -1,9 +1,11 @@
 interactions:
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"85e64881-7159-44bd-b1da-2af2d162ee04","publisher":{"uuid":"d1ffbcc2-ec25-453e-b895-1e736612ac95","naam":"Grant
-      LLC"},"identifier":"identifier-10","officiele_titel":"Student recognize authority
-      we space.","verkorte_titel":"Town.","omschrijving":"Girl major product pattern
-      ten country.","creatiedatum":"2025-02-20","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-01-29T13:35:21.944279"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"20131298-b208-4cb6-892f-89f2f1f3aefc","informatie_categorieen":[{"uuid":"89512418-31f9-4c9a-9163-f5476ef7d9c5","naam":"Program
+      appear sign."}],"publisher":{"uuid":"b1d6a707-cdec-4f7d-882a-72d372d21c20","naam":"Curtis,
+      Black and Tucker"},"identifier":"identifier-10","officiele_titel":"Student adult
+      decade need officer east reveal.","verkorte_titel":"Once although.","omschrijving":"Race
+      professor determine senior value enjoy report. Human black seek charge anyone.
+      Brother whom approach interest also then care.","creatiedatum":"2025-02-07","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-01-29T04:34:08.351757"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,11 +35,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"a6d0b06c-9c27-454a-897d-0535d29b4864","publisher":{"uuid":"0237915e-0d2b-45e2-af7f-465e24f4a0ce","naam":"Jackson,
-      Lawson and Hunter"},"identifier":"identifier-11","officiele_titel":"Draw pressure
-      somebody radio reach method.","verkorte_titel":"Pay peace under.","omschrijving":"Different
-      number three industry wish. Defense billion prevent coach partner environment
-      often. Heart paper beyond contain medical then answer item.","creatiedatum":"2025-02-21","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-01-30T15:37:41.313993"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"35dc64a8-b57a-4d1f-9228-0fe606ea69f4","informatie_categorieen":[{"uuid":"5a41cda5-65cc-49e2-8be8-cd1ebf6ec054","naam":"Inside."}],"publisher":{"uuid":"d379a25f-afd9-4e6d-9476-a13277e617b8","naam":"Crawford
+      Ltd"},"identifier":"identifier-11","officiele_titel":"Especially name campaign
+      situation.","verkorte_titel":"South certainly.","omschrijving":"Town run whose
+      practice many production. Suddenly type participant response. Congress use especially
+      great late really yard treat.","creatiedatum":"2025-02-10","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-01-31T05:34:11.936238"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -67,10 +69,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"a8396c7d-ea48-437a-a22d-0219a67b99e9","publisher":{"uuid":"c94d7a72-1440-4002-a177-9d280eadca53","naam":"Garza,
-      Smith and Mercado"},"identifier":"identifier-12","officiele_titel":"Win treat
-      government job.","verkorte_titel":"Natural window enough.","omschrijving":"Well
-      reveal join than. Arm employee star however. Check yard history able responsibility.","creatiedatum":"2025-02-19","registratiedatum":"2025-01-14T21:12:00+00:00","laatst_gewijzigd_datum":"2025-02-21T22:48:01.801569"}'
+    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"b63e515d-04da-4234-a911-cc746e55f541","informatie_categorieen":[{"uuid":"d65c1a07-d39e-444a-b978-44e36df2f47e","naam":"Defense
+      activity."}],"publisher":{"uuid":"03303ff1-06ad-43bd-928d-39591988643f","naam":"Pearson
+      PLC"},"identifier":"identifier-12","officiele_titel":"Recognize artist exactly
+      strong art visit throw.","verkorte_titel":"Information staff physical.","omschrijving":"Skin
+      government play they time item start. Then whom data account structure important
+      from. Ago white show attention.","creatiedatum":"2025-02-06","registratiedatum":"2025-01-14T21:12:00+00:00","laatst_gewijzigd_datum":"2025-01-29T22:46:49.226901"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -116,16 +120,20 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"a8396c7d-ea48-437a-a22d-0219a67b99e9","publisher":{"uuid":"c94d7a72-1440-4002-a177-9d280eadca53","naam":"Garza,
-        Smith and Mercado"},"identifier":"identifier-12","officiele_titel":"Win treat
-        government job.","verkorte_titel":"Natural window enough.","omschrijving":"Well
-        reveal join than. Arm employee star however. Check yard history able responsibility.","creatiedatum":"2025-02-19","registratiedatum":"2025-01-14T21:12:00+00:00","laatst_gewijzigd_datum":"2025-02-21T22:48:01.801569"},"sort":[0.0,1740178081801]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"85e64881-7159-44bd-b1da-2af2d162ee04","publisher":{"uuid":"d1ffbcc2-ec25-453e-b895-1e736612ac95","naam":"Grant
-        LLC"},"identifier":"identifier-10","officiele_titel":"Student recognize authority
-        we space.","verkorte_titel":"Town.","omschrijving":"Girl major product pattern
-        ten country.","creatiedatum":"2025-02-20","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-01-29T13:35:21.944279"},"sort":[0.0,1738157721944]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c94d7a72-1440-4002-a177-9d280eadca53","Garza,
-        Smith and Mercado"],"key_as_string":"c94d7a72-1440-4002-a177-9d280eadca53|Garza,
-        Smith and Mercado","doc_count":1},{"key":["d1ffbcc2-ec25-453e-b895-1e736612ac95","Grant
-        LLC"],"key_as_string":"d1ffbcc2-ec25-453e-b895-1e736612ac95|Grant LLC","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}'
+      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"b63e515d-04da-4234-a911-cc746e55f541","informatie_categorieen":[{"uuid":"d65c1a07-d39e-444a-b978-44e36df2f47e","naam":"Defense
+        activity."}],"publisher":{"uuid":"03303ff1-06ad-43bd-928d-39591988643f","naam":"Pearson
+        PLC"},"identifier":"identifier-12","officiele_titel":"Recognize artist exactly
+        strong art visit throw.","verkorte_titel":"Information staff physical.","omschrijving":"Skin
+        government play they time item start. Then whom data account structure important
+        from. Ago white show attention.","creatiedatum":"2025-02-06","registratiedatum":"2025-01-14T21:12:00+00:00","laatst_gewijzigd_datum":"2025-01-29T22:46:49.226901"},"sort":[0.0,1738190809226]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"20131298-b208-4cb6-892f-89f2f1f3aefc","informatie_categorieen":[{"uuid":"89512418-31f9-4c9a-9163-f5476ef7d9c5","naam":"Program
+        appear sign."}],"publisher":{"uuid":"b1d6a707-cdec-4f7d-882a-72d372d21c20","naam":"Curtis,
+        Black and Tucker"},"identifier":"identifier-10","officiele_titel":"Student
+        adult decade need officer east reveal.","verkorte_titel":"Once although.","omschrijving":"Race
+        professor determine senior value enjoy report. Human black seek charge anyone.
+        Brother whom approach interest also then care.","creatiedatum":"2025-02-07","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-01-29T04:34:08.351757"},"sort":[0.0,1738125248351]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["03303ff1-06ad-43bd-928d-39591988643f","Pearson
+        PLC"],"key_as_string":"03303ff1-06ad-43bd-928d-39591988643f|Pearson PLC","doc_count":1},{"key":["b1d6a707-cdec-4f7d-882a-72d372d21c20","Curtis,
+        Black and Tucker"],"key_as_string":"b1d6a707-cdec-4f7d-882a-72d372d21c20|Curtis,
+        Black and Tucker","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -153,13 +161,12 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"a6d0b06c-9c27-454a-897d-0535d29b4864","publisher":{"uuid":"0237915e-0d2b-45e2-af7f-465e24f4a0ce","naam":"Jackson,
-        Lawson and Hunter"},"identifier":"identifier-11","officiele_titel":"Draw pressure
-        somebody radio reach method.","verkorte_titel":"Pay peace under.","omschrijving":"Different
-        number three industry wish. Defense billion prevent coach partner environment
-        often. Heart paper beyond contain medical then answer item.","creatiedatum":"2025-02-21","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-01-30T15:37:41.313993"},"sort":[0.0,1738251461313]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["0237915e-0d2b-45e2-af7f-465e24f4a0ce","Jackson,
-        Lawson and Hunter"],"key_as_string":"0237915e-0d2b-45e2-af7f-465e24f4a0ce|Jackson,
-        Lawson and Hunter","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
+      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"35dc64a8-b57a-4d1f-9228-0fe606ea69f4","informatie_categorieen":[{"uuid":"5a41cda5-65cc-49e2-8be8-cd1ebf6ec054","naam":"Inside."}],"publisher":{"uuid":"d379a25f-afd9-4e6d-9476-a13277e617b8","naam":"Crawford
+        Ltd"},"identifier":"identifier-11","officiele_titel":"Especially name campaign
+        situation.","verkorte_titel":"South certainly.","omschrijving":"Town run whose
+        practice many production. Suddenly type participant response. Congress use
+        especially great late really yard treat.","creatiedatum":"2025-02-10","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-01-31T05:34:11.936238"},"sort":[0.0,1738301651936]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["d379a25f-afd9-4e6d-9476-a13277e617b8","Crawford
+        Ltd"],"key_as_string":"d379a25f-afd9-4e6d-9476-a13277e617b8|Crawford Ltd","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -187,11 +194,14 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"85e64881-7159-44bd-b1da-2af2d162ee04","publisher":{"uuid":"d1ffbcc2-ec25-453e-b895-1e736612ac95","naam":"Grant
-        LLC"},"identifier":"identifier-10","officiele_titel":"Student recognize authority
-        we space.","verkorte_titel":"Town.","omschrijving":"Girl major product pattern
-        ten country.","creatiedatum":"2025-02-20","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-01-29T13:35:21.944279"},"sort":[0.0,1738157721944]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["d1ffbcc2-ec25-453e-b895-1e736612ac95","Grant
-        LLC"],"key_as_string":"d1ffbcc2-ec25-453e-b895-1e736612ac95|Grant LLC","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
+      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"20131298-b208-4cb6-892f-89f2f1f3aefc","informatie_categorieen":[{"uuid":"89512418-31f9-4c9a-9163-f5476ef7d9c5","naam":"Program
+        appear sign."}],"publisher":{"uuid":"b1d6a707-cdec-4f7d-882a-72d372d21c20","naam":"Curtis,
+        Black and Tucker"},"identifier":"identifier-10","officiele_titel":"Student
+        adult decade need officer east reveal.","verkorte_titel":"Once although.","omschrijving":"Race
+        professor determine senior value enjoy report. Human black seek charge anyone.
+        Brother whom approach interest also then care.","creatiedatum":"2025-02-07","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-01-29T04:34:08.351757"},"sort":[0.0,1738125248351]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["b1d6a707-cdec-4f7d-882a-72d372d21c20","Curtis,
+        Black and Tucker"],"key_as_string":"b1d6a707-cdec-4f7d-882a-72d372d21c20|Curtis,
+        Black and Tucker","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_registration_date_both_indexes.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_registration_date_both_indexes.yaml
@@ -1,9 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"325f4c82-53b0-4741-af9f-4cbd3d934a1a","naam":"Le-Henry"},"informatie_categorieen":[{"uuid":"a3a938b5-c58c-4280-826c-c0f45542aded","naam":"Career
-      few outside."}],"officiele_titel":"Half change traditional.","verkorte_titel":"Lead
-      its.","omschrijving":"Return attack form personal. Degree practice either protect.
-      Sister song this ago.","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-01-31T18:55:15.050003"}'
+    body: '{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"30e1b0f2-c641-4e11-bf88-1ffe7a586d38","naam":"Wright,
+      Flowers and Brown"},"informatie_categorieen":[{"uuid":"c0f6947f-b270-4422-bbbf-3258c6c0e9d6","naam":"Class
+      water their."}],"officiele_titel":"Campaign well energy thus you class morning
+      whatever.","verkorte_titel":"Member learn front.","omschrijving":"Moment free
+      training him six organization war.","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-25T17:30:10.169202"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -19,25 +20,25 @@ interactions:
     uri: http://localhost:9201/publication/_doc/b38065ee-322e-46c7-ae64-c47112a4b408?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":8,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":12,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/b38065ee-322e-46c7-ae64-c47112a4b408
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '179'
+      - '180'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"de225c2e-2700-4fee-a6ea-efa276db42d4","publisher":{"uuid":"af1765a6-b414-4796-87c6-75fa7b33be25","naam":"Nichols
-      LLC"},"informatie_categorieen":[{"uuid":"58d5fed5-9626-4bf2-9b22-eae8cdd6a2d9","naam":"Style
-      position."}],"officiele_titel":"Available push relate.","verkorte_titel":"Best
-      wife.","omschrijving":"Draw behavior less strategy key rule first stuff. Media
-      better response collection scene character next owner.","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-02-21T09:07:49.443389"}'
+    body: '{"uuid":"de225c2e-2700-4fee-a6ea-efa276db42d4","publisher":{"uuid":"404b667b-d921-4541-8d72-2b975fffd460","naam":"Thomas
+      Inc"},"informatie_categorieen":[{"uuid":"e688ea27-d4c9-4255-9f13-8afc06a8f83b","naam":"Identify
+      get."}],"officiele_titel":"Method lay boy dream the citizen.","verkorte_titel":"Represent
+      risk business.","omschrijving":"Whatever structure nature democratic woman in.
+      Know room plan heavy dream. His point road main send policy weight.","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-01-27T13:30:10.794003"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -53,26 +54,25 @@ interactions:
     uri: http://localhost:9201/publication/_doc/de225c2e-2700-4fee-a6ea-efa276db42d4?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"de225c2e-2700-4fee-a6ea-efa276db42d4","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":9,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"de225c2e-2700-4fee-a6ea-efa276db42d4","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":13,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/de225c2e-2700-4fee-a6ea-efa276db42d4
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '179'
+      - '180'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"6c000215-63ac-44f0-b7d3-fe058072625e","informatie_categorieen":[{"uuid":"72efb333-c043-407a-8dcf-4b1036c9cd87","naam":"Store
-      in somebody how."}],"publisher":{"uuid":"fdeabf4a-2997-4fdc-9760-1ba75e456e23","naam":"Bradford
-      LLC"},"identifier":"identifier-13","officiele_titel":"Voice mean executive color.","verkorte_titel":"Health
-      movement allow.","omschrijving":"International control remember hundred hundred.
-      Night woman stand. School consider decade carry want. Home various continue
-      thus.","creatiedatum":"2025-02-16","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-07T23:13:00.149757"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"3421af9f-7669-475e-98f2-172dc9895fd8","informatie_categorieen":[{"uuid":"5469d72d-8c8e-4b8d-8425-ba2b9edc134b","naam":"Where
+      theory."}],"publisher":{"uuid":"5f3150fa-ace2-4230-9d71-67c2e067247c","naam":"Wise,
+      Craig and Smith"},"identifier":"identifier-15","officiele_titel":"Put organization
+      foot myself.","verkorte_titel":"Green specific.","omschrijving":"Energy gas
+      spring. Class its group bit employee.","creatiedatum":"2025-02-14","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-23T08:01:45.785845"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -88,7 +88,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/6aac4fb2-d532-490b-bd6b-87b0257c0236?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_version":9,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":26,"_primary_term":1}'
+      string: '{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_version":9,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":30,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/6aac4fb2-d532-490b-bd6b-87b0257c0236
@@ -102,11 +102,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"36e34d86-a3e8-4328-a454-cf0066d05caf","informatie_categorieen":[{"uuid":"6ef614b1-c03f-4ca6-a734-ba699813153c","naam":"There."}],"publisher":{"uuid":"4415ad51-e760-4c49-8aa7-48183cd9da8b","naam":"Mooney
-      LLC"},"identifier":"identifier-14","officiele_titel":"Bar score until item eye.","verkorte_titel":"Usually
-      good cell.","omschrijving":"Draw technology never size today page finish personal.
-      Article head eat water structure. Station key common down program dinner agent
-      like. Everyone hear station realize case get.","creatiedatum":"2025-02-17","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-02-09T11:00:53.836032"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"ebfe768e-33ee-4d5f-b40b-1905e0e43dd5","informatie_categorieen":[{"uuid":"a263aeaa-1ddd-4901-9f9d-deb62d35806d","naam":"Military
+      brother."}],"publisher":{"uuid":"4ab225d1-0a56-4278-95c4-586838eddb36","naam":"Miller,
+      Melton and Edwards"},"identifier":"identifier-16","officiele_titel":"Good television
+      firm.","verkorte_titel":"Audience yes author remain.","omschrijving":"Business
+      do sister yet truth.","creatiedatum":"2025-02-08","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-02-04T18:45:28.890702"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -122,7 +122,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/62fceb92-98bd-475c-b184-49ee8a274787?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_version":9,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":27,"_primary_term":1}'
+      string: '{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_version":9,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":31,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/62fceb92-98bd-475c-b184-49ee8a274787
@@ -136,7 +136,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"bool":{"filter":[{"range":{"registratiedatum":{"gte":"2024-01-01T00:00:00+01:00","lt":"2024-12-31T23:59:59.999999+01:00"}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"bool":{"filter":[{"range":{"registratiedatum":{"gte":"2024-01-01T00:00:00+01:00","lt":"2024-12-31T23:59:59.999999+01:00"}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -152,16 +152,22 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":16,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"6c000215-63ac-44f0-b7d3-fe058072625e","informatie_categorieen":[{"uuid":"72efb333-c043-407a-8dcf-4b1036c9cd87","naam":"Store
-        in somebody how."}],"publisher":{"uuid":"fdeabf4a-2997-4fdc-9760-1ba75e456e23","naam":"Bradford
-        LLC"},"identifier":"identifier-13","officiele_titel":"Voice mean executive
-        color.","verkorte_titel":"Health movement allow.","omschrijving":"International
-        control remember hundred hundred. Night woman stand. School consider decade
-        carry want. Home various continue thus.","creatiedatum":"2025-02-16","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-07T23:13:00.149757"},"sort":[0.0,1738969980149]},{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_score":0.0,"_source":{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"325f4c82-53b0-4741-af9f-4cbd3d934a1a","naam":"Le-Henry"},"informatie_categorieen":[{"uuid":"a3a938b5-c58c-4280-826c-c0f45542aded","naam":"Career
-        few outside."}],"officiele_titel":"Half change traditional.","verkorte_titel":"Lead
-        its.","omschrijving":"Return attack form personal. Degree practice either
-        protect. Sister song this ago.","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-01-31T18:55:15.050003"},"sort":[0.0,1738349715050]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["325f4c82-53b0-4741-af9f-4cbd3d934a1a","Le-Henry"],"key_as_string":"325f4c82-53b0-4741-af9f-4cbd3d934a1a|Le-Henry","doc_count":1},{"key":["fdeabf4a-2997-4fdc-9760-1ba75e456e23","Bradford
-        LLC"],"key_as_string":"fdeabf4a-2997-4fdc-9760-1ba75e456e23|Bradford LLC","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_score":0.0,"_source":{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"30e1b0f2-c641-4e11-bf88-1ffe7a586d38","naam":"Wright,
+        Flowers and Brown"},"informatie_categorieen":[{"uuid":"c0f6947f-b270-4422-bbbf-3258c6c0e9d6","naam":"Class
+        water their."}],"officiele_titel":"Campaign well energy thus you class morning
+        whatever.","verkorte_titel":"Member learn front.","omschrijving":"Moment free
+        training him six organization war.","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-25T17:30:10.169202"},"sort":[0.0,1740504610169]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"3421af9f-7669-475e-98f2-172dc9895fd8","informatie_categorieen":[{"uuid":"5469d72d-8c8e-4b8d-8425-ba2b9edc134b","naam":"Where
+        theory."}],"publisher":{"uuid":"5f3150fa-ace2-4230-9d71-67c2e067247c","naam":"Wise,
+        Craig and Smith"},"identifier":"identifier-15","officiele_titel":"Put organization
+        foot myself.","verkorte_titel":"Green specific.","omschrijving":"Energy gas
+        spring. Class its group bit employee.","creatiedatum":"2025-02-14","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-23T08:01:45.785845"},"sort":[0.0,1740297705785]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["5469d72d-8c8e-4b8d-8425-ba2b9edc134b","Where
+        theory."],"key_as_string":"5469d72d-8c8e-4b8d-8425-ba2b9edc134b|Where theory.","doc_count":1},{"key":["c0f6947f-b270-4422-bbbf-3258c6c0e9d6","Class
+        water their."],"key_as_string":"c0f6947f-b270-4422-bbbf-3258c6c0e9d6|Class
+        water their.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["30e1b0f2-c641-4e11-bf88-1ffe7a586d38","Wright,
+        Flowers and Brown"],"key_as_string":"30e1b0f2-c641-4e11-bf88-1ffe7a586d38|Wright,
+        Flowers and Brown","doc_count":1},{"key":["5f3150fa-ace2-4230-9d71-67c2e067247c","Wise,
+        Craig and Smith"],"key_as_string":"5f3150fa-ace2-4230-9d71-67c2e067247c|Wise,
+        Craig and Smith","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_registration_date_both_indexes.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_registration_date_both_indexes.yaml
@@ -1,8 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"df180c5f-40d4-4086-a258-186ad4c6c17b","naam":"Bentley-Wyatt"},"informatie_categorieen":[{"uuid":"1eae4f5a-4ede-476e-b5a3-6722a35fdaf5","naam":"Piece."}],"officiele_titel":"Network
-      high base although development.","verkorte_titel":"Data keep prepare.","omschrijving":"Third
-      seat future box.","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-16T04:33:53.522559"}'
+    body: '{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"325f4c82-53b0-4741-af9f-4cbd3d934a1a","naam":"Le-Henry"},"informatie_categorieen":[{"uuid":"a3a938b5-c58c-4280-826c-c0f45542aded","naam":"Career
+      few outside."}],"officiele_titel":"Half change traditional.","verkorte_titel":"Lead
+      its.","omschrijving":"Return attack form personal. Degree practice either protect.
+      Sister song this ago.","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-01-31T18:55:15.050003"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -32,12 +33,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"de225c2e-2700-4fee-a6ea-efa276db42d4","publisher":{"uuid":"8a5eb616-fdb4-45ef-bb53-7599d5dde5cb","naam":"Taylor,
-      Raymond and Johnson"},"informatie_categorieen":[{"uuid":"485558ca-ac43-42d5-b5d3-9e8e3d4f2814","naam":"Save
-      continue fact."}],"officiele_titel":"Business central a fire white face appear
-      room.","verkorte_titel":"Sit work collection.","omschrijving":"Bad simple interview
-      strong. Wrong wish understand Mr successful performance. Financial road certain
-      turn. Want leave role win stand.","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-01-30T04:07:19.491267"}'
+    body: '{"uuid":"de225c2e-2700-4fee-a6ea-efa276db42d4","publisher":{"uuid":"af1765a6-b414-4796-87c6-75fa7b33be25","naam":"Nichols
+      LLC"},"informatie_categorieen":[{"uuid":"58d5fed5-9626-4bf2-9b22-eae8cdd6a2d9","naam":"Style
+      position."}],"officiele_titel":"Available push relate.","verkorte_titel":"Best
+      wife.","omschrijving":"Draw behavior less strategy key rule first stuff. Media
+      better response collection scene character next owner.","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-02-21T09:07:49.443389"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -67,10 +67,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"a1946930-fda8-48eb-82f1-1710849e50f6","publisher":{"uuid":"1e3ec5b3-6546-4ce7-9e44-b49418c2cca6","naam":"Weaver-Johnson"},"identifier":"identifier-13","officiele_titel":"Candidate
-      season customer light.","verkorte_titel":"Bag well soldier food.","omschrijving":"Certainly
-      four before majority role often. Subject theory too itself. All nothing third
-      short forward day work suddenly. State million heart career view.","creatiedatum":"2025-02-09","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-05T18:24:36.360069"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"6c000215-63ac-44f0-b7d3-fe058072625e","informatie_categorieen":[{"uuid":"72efb333-c043-407a-8dcf-4b1036c9cd87","naam":"Store
+      in somebody how."}],"publisher":{"uuid":"fdeabf4a-2997-4fdc-9760-1ba75e456e23","naam":"Bradford
+      LLC"},"identifier":"identifier-13","officiele_titel":"Voice mean executive color.","verkorte_titel":"Health
+      movement allow.","omschrijving":"International control remember hundred hundred.
+      Night woman stand. School consider decade carry want. Home various continue
+      thus.","creatiedatum":"2025-02-16","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-07T23:13:00.149757"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -100,9 +102,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"3cb38d56-ca92-4da9-b946-de09f419f1c5","publisher":{"uuid":"ab243fb9-1e27-47ed-ab2d-9416aab17ede","naam":"Forbes-Krause"},"identifier":"identifier-14","officiele_titel":"Whole
-      trouble arm lawyer itself.","verkorte_titel":"Hundred lay really.","omschrijving":"Difference
-      tree nation read fear own.","creatiedatum":"2025-02-11","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-01-30T07:46:47.736691"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"36e34d86-a3e8-4328-a454-cf0066d05caf","informatie_categorieen":[{"uuid":"6ef614b1-c03f-4ca6-a734-ba699813153c","naam":"There."}],"publisher":{"uuid":"4415ad51-e760-4c49-8aa7-48183cd9da8b","naam":"Mooney
+      LLC"},"identifier":"identifier-14","officiele_titel":"Bar score until item eye.","verkorte_titel":"Usually
+      good cell.","omschrijving":"Draw technology never size today page finish personal.
+      Article head eat water structure. Station key common down program dinner agent
+      like. Everyone hear station realize case get.","creatiedatum":"2025-02-17","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-02-09T11:00:53.836032"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -148,12 +152,16 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_score":0.0,"_source":{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"df180c5f-40d4-4086-a258-186ad4c6c17b","naam":"Bentley-Wyatt"},"informatie_categorieen":[{"uuid":"1eae4f5a-4ede-476e-b5a3-6722a35fdaf5","naam":"Piece."}],"officiele_titel":"Network
-        high base although development.","verkorte_titel":"Data keep prepare.","omschrijving":"Third
-        seat future box.","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-16T04:33:53.522559"},"sort":[0.0,1739680433522]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"a1946930-fda8-48eb-82f1-1710849e50f6","publisher":{"uuid":"1e3ec5b3-6546-4ce7-9e44-b49418c2cca6","naam":"Weaver-Johnson"},"identifier":"identifier-13","officiele_titel":"Candidate
-        season customer light.","verkorte_titel":"Bag well soldier food.","omschrijving":"Certainly
-        four before majority role often. Subject theory too itself. All nothing third
-        short forward day work suddenly. State million heart career view.","creatiedatum":"2025-02-09","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-05T18:24:36.360069"},"sort":[0.0,1738779876360]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["1e3ec5b3-6546-4ce7-9e44-b49418c2cca6","Weaver-Johnson"],"key_as_string":"1e3ec5b3-6546-4ce7-9e44-b49418c2cca6|Weaver-Johnson","doc_count":1},{"key":["df180c5f-40d4-4086-a258-186ad4c6c17b","Bentley-Wyatt"],"key_as_string":"df180c5f-40d4-4086-a258-186ad4c6c17b|Bentley-Wyatt","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":16,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"6c000215-63ac-44f0-b7d3-fe058072625e","informatie_categorieen":[{"uuid":"72efb333-c043-407a-8dcf-4b1036c9cd87","naam":"Store
+        in somebody how."}],"publisher":{"uuid":"fdeabf4a-2997-4fdc-9760-1ba75e456e23","naam":"Bradford
+        LLC"},"identifier":"identifier-13","officiele_titel":"Voice mean executive
+        color.","verkorte_titel":"Health movement allow.","omschrijving":"International
+        control remember hundred hundred. Night woman stand. School consider decade
+        carry want. Home various continue thus.","creatiedatum":"2025-02-16","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-07T23:13:00.149757"},"sort":[0.0,1738969980149]},{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_score":0.0,"_source":{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"325f4c82-53b0-4741-af9f-4cbd3d934a1a","naam":"Le-Henry"},"informatie_categorieen":[{"uuid":"a3a938b5-c58c-4280-826c-c0f45542aded","naam":"Career
+        few outside."}],"officiele_titel":"Half change traditional.","verkorte_titel":"Lead
+        its.","omschrijving":"Return attack form personal. Degree practice either
+        protect. Sister song this ago.","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-01-31T18:55:15.050003"},"sort":[0.0,1738349715050]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["325f4c82-53b0-4741-af9f-4cbd3d934a1a","Le-Henry"],"key_as_string":"325f4c82-53b0-4741-af9f-4cbd3d934a1a|Le-Henry","doc_count":1},{"key":["fdeabf4a-2997-4fdc-9760-1ba75e456e23","Bradford
+        LLC"],"key_as_string":"fdeabf4a-2997-4fdc-9760-1ba75e456e23|Bradford LLC","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_no_body.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_no_body.yaml
@@ -19,21 +19,21 @@ interactions:
     uri: http://localhost:9201/publication/_doc/6dae9be7-4f93-4aad-b56a-10b683b16dcc?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":12,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/6dae9be7-4f93-4aad-b56a-10b683b16dcc
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '180'
+      - '179'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
+    body: '{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
       test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
       sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
@@ -51,14 +51,14 @@ interactions:
     uri: http://localhost:9201/document/_doc/525747fd-7e58-4005-8efa-59bcf4403385?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"525747fd-7e58-4005-8efa-59bcf4403385","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":30,"_primary_term":1}'
+      string: '{"_index":"document","_id":"525747fd-7e58-4005-8efa-59bcf4403385","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/525747fd-7e58-4005-8efa-59bcf4403385
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '177'
+      - '176'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
@@ -81,7 +81,7 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"525747fd-7e58-4005-8efa-59bcf4403385","_score":1.0,"_source":{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
+      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"525747fd-7e58-4005-8efa-59bcf4403385","_score":1.0,"_source":{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
         test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
         sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]},{"_index":"publication","_id":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","_score":1.0,"_source":{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"62da7e9d-2481-4d46-9c77-563b490126aa","naam":"Utrecht"},"informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"officiele_titel":"Lorem
         ipsum dolor sit amet, consectetur adipiscing elit.","verkorte_titel":"Donec

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_no_body.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_no_body.yaml
@@ -19,14 +19,14 @@ interactions:
     uri: http://localhost:9201/publication/_doc/6dae9be7-4f93-4aad-b56a-10b683b16dcc?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":16,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/6dae9be7-4f93-4aad-b56a-10b683b16dcc
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '179'
+      - '180'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
@@ -51,21 +51,21 @@ interactions:
     uri: http://localhost:9201/document/_doc/525747fd-7e58-4005-8efa-59bcf4403385?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"525747fd-7e58-4005-8efa-59bcf4403385","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
+      string: '{"_index":"document","_id":"525747fd-7e58-4005-8efa-59bcf4403385","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":34,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/525747fd-7e58-4005-8efa-59bcf4403385
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '176'
+      - '177'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -81,12 +81,12 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"525747fd-7e58-4005-8efa-59bcf4403385","_score":1.0,"_source":{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
+      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"525747fd-7e58-4005-8efa-59bcf4403385","_score":1.0,"_source":{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
         test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
         sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]},{"_index":"publication","_id":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","_score":1.0,"_source":{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"62da7e9d-2481-4d46-9c77-563b490126aa","naam":"Utrecht"},"informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"officiele_titel":"Lorem
         ipsum dolor sit amet, consectetur adipiscing elit.","verkorte_titel":"Donec
         finibus non tortor quis sollicitudin.","omschrijving":"Nulla at nisi at enim
-        eleifend facilisis at vitae velit.","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":1},{"key":["62da7e9d-2481-4d46-9c77-563b490126aa","Utrecht"],"key_as_string":"62da7e9d-2481-4d46-9c77-563b490126aa|Utrecht","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+        eleifend facilisis at vitae velit.","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2ff3d47c-7945-4267-b3b2-e63aca280b8d","WOO"],"key_as_string":"2ff3d47c-7945-4267-b3b2-e63aca280b8d|WOO","doc_count":2}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":1},{"key":["62da7e9d-2481-4d46-9c77-563b490126aa","Utrecht"],"key_as_string":"62da7e9d-2481-4d46-9c77-563b490126aa|Utrecht","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_pagination_next_and_page_size.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_pagination_next_and_page_size.yaml
@@ -33,7 +33,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"85a095ea-e1fa-438c-9e05-1862874f57a0","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
+    body: '{"uuid":"85a095ea-e1fa-438c-9e05-1862874f57a0","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
       test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
       sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
@@ -81,7 +81,7 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"85a095ea-e1fa-438c-9e05-1862874f57a0","_score":1.0,"_source":{"uuid":"85a095ea-e1fa-438c-9e05-1862874f57a0","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
+      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"85a095ea-e1fa-438c-9e05-1862874f57a0","_score":1.0,"_source":{"uuid":"85a095ea-e1fa-438c-9e05-1862874f57a0","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
         test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
         sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":1},{"key":["62da7e9d-2481-4d46-9c77-563b490126aa","Utrecht"],"key_as_string":"62da7e9d-2481-4d46-9c77-563b490126aa|Utrecht","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_pagination_next_and_page_size.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_pagination_next_and_page_size.yaml
@@ -19,7 +19,7 @@ interactions:
     uri: http://localhost:9201/publication/_doc/1aa78d62-0cc7-4273-86b4-8c6bf4f28a98?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"1aa78d62-0cc7-4273-86b4-8c6bf4f28a98","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":14,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"1aa78d62-0cc7-4273-86b4-8c6bf4f28a98","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":18,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/1aa78d62-0cc7-4273-86b4-8c6bf4f28a98
@@ -51,7 +51,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/85a095ea-e1fa-438c-9e05-1862874f57a0?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"85a095ea-e1fa-438c-9e05-1862874f57a0","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":32,"_primary_term":1}'
+      string: '{"_index":"document","_id":"85a095ea-e1fa-438c-9e05-1862874f57a0","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":36,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/85a095ea-e1fa-438c-9e05-1862874f57a0
@@ -65,7 +65,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":1}'
+    body: '{"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":1}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -83,7 +83,7 @@ interactions:
     body:
       string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"85a095ea-e1fa-438c-9e05-1862874f57a0","_score":1.0,"_source":{"uuid":"85a095ea-e1fa-438c-9e05-1862874f57a0","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
         test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
-        sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":1},{"key":["62da7e9d-2481-4d46-9c77-563b490126aa","Utrecht"],"key_as_string":"62da7e9d-2481-4d46-9c77-563b490126aa|Utrecht","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+        sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2ff3d47c-7945-4267-b3b2-e63aca280b8d","WOO"],"key_as_string":"2ff3d47c-7945-4267-b3b2-e63aca280b8d|WOO","doc_count":2}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":1},{"key":["62da7e9d-2481-4d46-9c77-563b490126aa","Utrecht"],"key_as_string":"62da7e9d-2481-4d46-9c77-563b490126aa|Utrecht","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_pagination_previous.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_pagination_previous.yaml
@@ -33,7 +33,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"48981334-b480-4e7d-8c8d-925bbc67a969","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
+    body: '{"uuid":"48981334-b480-4e7d-8c8d-925bbc67a969","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
       test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
       sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
@@ -81,7 +81,7 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"80485d67-0b97-4ed5-8483-f2d03d012e19","_score":1.0,"_source":{"uuid":"80485d67-0b97-4ed5-8483-f2d03d012e19","publisher":{"uuid":"62da7e9d-2481-4d46-9c77-563b490126aa","naam":"Utrecht"},"informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"officiele_titel":"Lorem
+      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"80485d67-0b97-4ed5-8483-f2d03d012e19","_score":1.0,"_source":{"uuid":"80485d67-0b97-4ed5-8483-f2d03d012e19","publisher":{"uuid":"62da7e9d-2481-4d46-9c77-563b490126aa","naam":"Utrecht"},"informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"officiele_titel":"Lorem
         ipsum dolor sit amet, consectetur adipiscing elit.","verkorte_titel":"Donec
         finibus non tortor quis sollicitudin.","omschrijving":"Nulla at nisi at enim
         eleifend facilisis at vitae velit.","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":1},{"key":["62da7e9d-2481-4d46-9c77-563b490126aa","Utrecht"],"key_as_string":"62da7e9d-2481-4d46-9c77-563b490126aa|Utrecht","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_pagination_previous.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_pagination_previous.yaml
@@ -19,7 +19,7 @@ interactions:
     uri: http://localhost:9201/publication/_doc/80485d67-0b97-4ed5-8483-f2d03d012e19?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"80485d67-0b97-4ed5-8483-f2d03d012e19","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":16,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"80485d67-0b97-4ed5-8483-f2d03d012e19","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":20,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/80485d67-0b97-4ed5-8483-f2d03d012e19
@@ -51,7 +51,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/48981334-b480-4e7d-8c8d-925bbc67a969?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"48981334-b480-4e7d-8c8d-925bbc67a969","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":34,"_primary_term":1}'
+      string: '{"_index":"document","_id":"48981334-b480-4e7d-8c8d-925bbc67a969","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":38,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/48981334-b480-4e7d-8c8d-925bbc67a969
@@ -65,7 +65,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":1,"size":1}'
+    body: '{"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":1,"size":1}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -81,10 +81,10 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"80485d67-0b97-4ed5-8483-f2d03d012e19","_score":1.0,"_source":{"uuid":"80485d67-0b97-4ed5-8483-f2d03d012e19","publisher":{"uuid":"62da7e9d-2481-4d46-9c77-563b490126aa","naam":"Utrecht"},"informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"officiele_titel":"Lorem
+      string: '{"took":12,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"80485d67-0b97-4ed5-8483-f2d03d012e19","_score":1.0,"_source":{"uuid":"80485d67-0b97-4ed5-8483-f2d03d012e19","publisher":{"uuid":"62da7e9d-2481-4d46-9c77-563b490126aa","naam":"Utrecht"},"informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"officiele_titel":"Lorem
         ipsum dolor sit amet, consectetur adipiscing elit.","verkorte_titel":"Donec
         finibus non tortor quis sollicitudin.","omschrijving":"Nulla at nisi at enim
-        eleifend facilisis at vitae velit.","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":1},{"key":["62da7e9d-2481-4d46-9c77-563b490126aa","Utrecht"],"key_as_string":"62da7e9d-2481-4d46-9c77-563b490126aa|Utrecht","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+        eleifend facilisis at vitae velit.","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2ff3d47c-7945-4267-b3b2-e63aca280b8d","WOO"],"key_as_string":"2ff3d47c-7945-4267-b3b2-e63aca280b8d|WOO","doc_count":2}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":1},{"key":["62da7e9d-2481-4d46-9c77-563b490126aa","Utrecht"],"key_as_string":"62da7e9d-2481-4d46-9c77-563b490126aa|Utrecht","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query.yaml
@@ -33,7 +33,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
+    body: '{"uuid":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
       test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
       sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
@@ -81,7 +81,7 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":20,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","_score":5.4604793,"_source":{"uuid":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
+      string: '{"took":39,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","_score":5.4604793,"_source":{"uuid":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
         test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
         sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[5.4604793,1767614400000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query.yaml
@@ -19,7 +19,7 @@ interactions:
     uri: http://localhost:9201/publication/_doc/50e32c44-515e-4c48-ae57-3aae82fc9cf1?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"50e32c44-515e-4c48-ae57-3aae82fc9cf1","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":18,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"50e32c44-515e-4c48-ae57-3aae82fc9cf1","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":22,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/50e32c44-515e-4c48-ae57-3aae82fc9cf1
@@ -51,7 +51,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/6dd95a10-cc97-4f19-b7e4-2c85358acb98?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":36,"_primary_term":1}'
+      string: '{"_index":"document","_id":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":40,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/6dd95a10-cc97-4f19-b7e4-2c85358acb98
@@ -65,7 +65,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"query_string":{"query":"document1","fields":["identifier^3","officiele_titel^2","verkorte_titel^1.5","omschrijving"],"fuzziness":2}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"query_string":{"query":"document1","fields":["identifier^3","officiele_titel^2","verkorte_titel^1.5","omschrijving"],"fuzziness":2}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -81,9 +81,9 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":39,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","_score":5.4604793,"_source":{"uuid":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
+      string: '{"took":44,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","_score":5.8273926,"_source":{"uuid":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
         test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
-        sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[5.4604793,1767614400000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
+        sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[5.8273926,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2ff3d47c-7945-4267-b3b2-e63aca280b8d","WOO"],"key_as_string":"2ff3d47c-7945-4267-b3b2-e63aca280b8d|WOO","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query_field_boosts.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query_field_boosts.yaml
@@ -16,7 +16,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/3916925a-4260-4505-bfbb-0942113efd49?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"3916925a-4260-4505-bfbb-0942113efd49","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":38,"_primary_term":1}'
+      string: '{"_index":"document","_id":"3916925a-4260-4505-bfbb-0942113efd49","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":42,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/3916925a-4260-4505-bfbb-0942113efd49
@@ -47,7 +47,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/d49bc304-01a1-4eda-a914-a8dda5c901e2?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"d49bc304-01a1-4eda-a914-a8dda5c901e2","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":39,"_primary_term":1}'
+      string: '{"_index":"document","_id":"d49bc304-01a1-4eda-a914-a8dda5c901e2","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":43,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/d49bc304-01a1-4eda-a914-a8dda5c901e2
@@ -78,7 +78,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/bdcc4cea-b186-425e-8dcd-9fecb6818563?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"bdcc4cea-b186-425e-8dcd-9fecb6818563","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":40,"_primary_term":1}'
+      string: '{"_index":"document","_id":"bdcc4cea-b186-425e-8dcd-9fecb6818563","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":44,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/bdcc4cea-b186-425e-8dcd-9fecb6818563
@@ -109,7 +109,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/7eade718-bccb-4876-9f00-a095beebc360?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"7eade718-bccb-4876-9f00-a095beebc360","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":41,"_primary_term":1}'
+      string: '{"_index":"document","_id":"7eade718-bccb-4876-9f00-a095beebc360","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":45,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/7eade718-bccb-4876-9f00-a095beebc360
@@ -123,7 +123,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"query_string":{"query":"snowflake","fields":["identifier^3","officiele_titel^2","verkorte_titel^1.5","omschrijving"],"fuzziness":2}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"query_string":{"query":"snowflake","fields":["identifier^3","officiele_titel^2","verkorte_titel^1.5","omschrijving"],"fuzziness":2}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -139,10 +139,10 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":4,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"d49bc304-01a1-4eda-a914-a8dda5c901e2","_score":9.91962,"_source":{"uuid":"d49bc304-01a1-4eda-a914-a8dda5c901e2","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"snowflake","officiele_titel":"titel","verkorte_titel":"verkorte
-        titel","omschrijving":"omschrijving","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[9.91962,1767614400000]},{"_index":"document","_id":"7eade718-bccb-4876-9f00-a095beebc360","_score":8.095149,"_source":{"uuid":"7eade718-bccb-4876-9f00-a095beebc360","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document4","officiele_titel":"snowflake","verkorte_titel":"verkorte
-        titel","omschrijving":"omschrijving","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[8.095149,1767614400000]},{"_index":"document","_id":"3916925a-4260-4505-bfbb-0942113efd49","_score":5.38818,"_source":{"uuid":"3916925a-4260-4505-bfbb-0942113efd49","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"titel","verkorte_titel":"snowflake","omschrijving":"omschrijving","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[5.38818,1767614400000]},{"_index":"document","_id":"bdcc4cea-b186-425e-8dcd-9fecb6818563","_score":4.4429684,"_source":{"uuid":"bdcc4cea-b186-425e-8dcd-9fecb6818563","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document3","officiele_titel":"titel","verkorte_titel":"verkorte
-        titel","omschrijving":"snowflake","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[4.4429684,1767614400000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":4}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":4}]}}}'
+      string: '{"took":14,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":4,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"d49bc304-01a1-4eda-a914-a8dda5c901e2","_score":10.256153,"_source":{"uuid":"d49bc304-01a1-4eda-a914-a8dda5c901e2","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"snowflake","officiele_titel":"titel","verkorte_titel":"verkorte
+        titel","omschrijving":"omschrijving","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[10.256153,1767614400000]},{"_index":"document","_id":"7eade718-bccb-4876-9f00-a095beebc360","_score":8.288778,"_source":{"uuid":"7eade718-bccb-4876-9f00-a095beebc360","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document4","officiele_titel":"snowflake","verkorte_titel":"verkorte
+        titel","omschrijving":"omschrijving","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[8.288778,1767614400000]},{"_index":"document","_id":"3916925a-4260-4505-bfbb-0942113efd49","_score":5.577055,"_source":{"uuid":"3916925a-4260-4505-bfbb-0942113efd49","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"titel","verkorte_titel":"snowflake","omschrijving":"omschrijving","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[5.577055,1767614400000]},{"_index":"document","_id":"bdcc4cea-b186-425e-8dcd-9fecb6818563","_score":4.5336466,"_source":{"uuid":"bdcc4cea-b186-425e-8dcd-9fecb6818563","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document3","officiele_titel":"titel","verkorte_titel":"verkorte
+        titel","omschrijving":"snowflake","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[4.5336466,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":4,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2ff3d47c-7945-4267-b3b2-e63aca280b8d","WOO"],"key_as_string":"2ff3d47c-7945-4267-b3b2-e63aca280b8d|WOO","doc_count":4}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":4}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":4}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query_field_boosts.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query_field_boosts.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"uuid":"3916925a-4260-4505-bfbb-0942113efd49","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"titel","verkorte_titel":"snowflake","omschrijving":"omschrijving","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"3916925a-4260-4505-bfbb-0942113efd49","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"titel","verkorte_titel":"snowflake","omschrijving":"omschrijving","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -30,7 +30,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"d49bc304-01a1-4eda-a914-a8dda5c901e2","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"snowflake","officiele_titel":"titel","verkorte_titel":"verkorte
+    body: '{"uuid":"d49bc304-01a1-4eda-a914-a8dda5c901e2","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"snowflake","officiele_titel":"titel","verkorte_titel":"verkorte
       titel","omschrijving":"omschrijving","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
@@ -61,7 +61,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"bdcc4cea-b186-425e-8dcd-9fecb6818563","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document3","officiele_titel":"titel","verkorte_titel":"verkorte
+    body: '{"uuid":"bdcc4cea-b186-425e-8dcd-9fecb6818563","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document3","officiele_titel":"titel","verkorte_titel":"verkorte
       titel","omschrijving":"snowflake","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
@@ -92,7 +92,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"7eade718-bccb-4876-9f00-a095beebc360","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document4","officiele_titel":"snowflake","verkorte_titel":"verkorte
+    body: '{"uuid":"7eade718-bccb-4876-9f00-a095beebc360","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document4","officiele_titel":"snowflake","verkorte_titel":"verkorte
       titel","omschrijving":"omschrijving","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
@@ -139,10 +139,10 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":4,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"d49bc304-01a1-4eda-a914-a8dda5c901e2","_score":9.91962,"_source":{"uuid":"d49bc304-01a1-4eda-a914-a8dda5c901e2","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"snowflake","officiele_titel":"titel","verkorte_titel":"verkorte
-        titel","omschrijving":"omschrijving","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[9.91962,1767614400000]},{"_index":"document","_id":"7eade718-bccb-4876-9f00-a095beebc360","_score":8.024792,"_source":{"uuid":"7eade718-bccb-4876-9f00-a095beebc360","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document4","officiele_titel":"snowflake","verkorte_titel":"verkorte
-        titel","omschrijving":"omschrijving","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[8.024792,1767614400000]},{"_index":"document","_id":"3916925a-4260-4505-bfbb-0942113efd49","_score":5.412118,"_source":{"uuid":"3916925a-4260-4505-bfbb-0942113efd49","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"titel","verkorte_titel":"snowflake","omschrijving":"omschrijving","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[5.412118,1767614400000]},{"_index":"document","_id":"bdcc4cea-b186-425e-8dcd-9fecb6818563","_score":4.3895,"_source":{"uuid":"bdcc4cea-b186-425e-8dcd-9fecb6818563","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document3","officiele_titel":"titel","verkorte_titel":"verkorte
-        titel","omschrijving":"snowflake","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[4.3895,1767614400000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":4}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":4}]}}}'
+      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":4,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"d49bc304-01a1-4eda-a914-a8dda5c901e2","_score":9.91962,"_source":{"uuid":"d49bc304-01a1-4eda-a914-a8dda5c901e2","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"snowflake","officiele_titel":"titel","verkorte_titel":"verkorte
+        titel","omschrijving":"omschrijving","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[9.91962,1767614400000]},{"_index":"document","_id":"7eade718-bccb-4876-9f00-a095beebc360","_score":8.095149,"_source":{"uuid":"7eade718-bccb-4876-9f00-a095beebc360","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document4","officiele_titel":"snowflake","verkorte_titel":"verkorte
+        titel","omschrijving":"omschrijving","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[8.095149,1767614400000]},{"_index":"document","_id":"3916925a-4260-4505-bfbb-0942113efd49","_score":5.38818,"_source":{"uuid":"3916925a-4260-4505-bfbb-0942113efd49","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"titel","verkorte_titel":"snowflake","omschrijving":"omschrijving","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[5.38818,1767614400000]},{"_index":"document","_id":"bdcc4cea-b186-425e-8dcd-9fecb6818563","_score":4.4429684,"_source":{"uuid":"bdcc4cea-b186-425e-8dcd-9fecb6818563","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document3","officiele_titel":"titel","verkorte_titel":"verkorte
+        titel","omschrijving":"snowflake","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[4.4429684,1767614400000]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":4}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":4}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_result_type.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_result_type.yaml
@@ -33,7 +33,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
+    body: '{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
       test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
       sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
@@ -81,7 +81,7 @@ interactions:
     uri: http://localhost:9201/document/_search
   response:
     body:
-      string: '{"took":3,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","_score":1.0,"_source":{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
+      string: '{"took":5,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","_score":1.0,"_source":{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
         test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
         sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":1}]}}}'
     headers:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_result_type.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_result_type.yaml
@@ -19,7 +19,7 @@ interactions:
     uri: http://localhost:9201/publication/_doc/5fc73bff-3cc2-4619-90d7-74b3eb3e4101?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":20,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":24,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/5fc73bff-3cc2-4619-90d7-74b3eb3e4101
@@ -51,7 +51,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/387d982b-d7c8-48e8-9665-2dbfb6f8688c?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":46,"_primary_term":1}'
+      string: '{"_index":"document","_id":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":50,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/387d982b-d7c8-48e8-9665-2dbfb6f8688c
@@ -65,7 +65,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -81,9 +81,9 @@ interactions:
     uri: http://localhost:9201/document/_search
   response:
     body:
-      string: '{"took":5,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","_score":1.0,"_source":{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
+      string: '{"took":9,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","_score":1.0,"_source":{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
         test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
-        sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":1}]}}}'
+        sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":1}]},"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2ff3d47c-7945-4267-b3b2-e63aca280b8d","WOO"],"key_as_string":"2ff3d47c-7945-4267-b3b2-e63aca280b8d|WOO","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_sort_chronological.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_sort_chronological.yaml
@@ -19,7 +19,7 @@ interactions:
     uri: http://localhost:9201/publication/_doc/0ce718e4-8fb5-42f1-a07e-cbf82a869efd?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":22,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":26,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/0ce718e4-8fb5-42f1-a07e-cbf82a869efd
@@ -51,7 +51,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/3b3f4514-7d8b-4e31-83ca-fa9376ff6522?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":48,"_primary_term":1}'
+      string: '{"_index":"document","_id":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":52,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/3b3f4514-7d8b-4e31-83ca-fa9376ff6522
@@ -65,7 +65,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}},"sort":[{"laatst_gewijzigd_datum":{"order":"desc"}},"_score"],"from":0,"size":10}'
+    body: '{"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":[{"laatst_gewijzigd_datum":{"order":"desc"}},"_score"],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -81,12 +81,12 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":13,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","_score":1.0,"_source":{"uuid":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
+      string: '{"took":15,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","_score":1.0,"_source":{"uuid":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
         test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
         sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1767614400000,1.0]},{"_index":"publication","_id":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","_score":1.0,"_source":{"uuid":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","publisher":{"uuid":"62da7e9d-2481-4d46-9c77-563b490126aa","naam":"Utrecht"},"informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"officiele_titel":"Lorem
         ipsum dolor sit amet, consectetur adipiscing elit.","verkorte_titel":"Donec
         finibus non tortor quis sollicitudin.","omschrijving":"Nulla at nisi at enim
-        eleifend facilisis at vitae velit.","registratiedatum":"2026-01-01T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-02T12:00:00+00:00"},"sort":[1767355200000,1.0]}]},"aggregations":{"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":1},{"key":["62da7e9d-2481-4d46-9c77-563b490126aa","Utrecht"],"key_as_string":"62da7e9d-2481-4d46-9c77-563b490126aa|Utrecht","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+        eleifend facilisis at vitae velit.","registratiedatum":"2026-01-01T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-02T12:00:00+00:00"},"sort":[1767355200000,1.0]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2ff3d47c-7945-4267-b3b2-e63aca280b8d","WOO"],"key_as_string":"2ff3d47c-7945-4267-b3b2-e63aca280b8d|WOO","doc_count":2}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2f809be7-b585-4cb8-8010-9682c4281aec","Utrecht"],"key_as_string":"2f809be7-b585-4cb8-8010-9682c4281aec|Utrecht","doc_count":1},{"key":["62da7e9d-2481-4d46-9c77-563b490126aa","Utrecht"],"key_as_string":"62da7e9d-2481-4d46-9c77-563b490126aa|Utrecht","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_sort_chronological.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_sort_chronological.yaml
@@ -33,7 +33,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
+    body: '{"uuid":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
       test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
       sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
@@ -81,7 +81,7 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","_score":1.0,"_source":{"uuid":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
+      string: '{"took":13,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","_score":1.0,"_source":{"uuid":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","publicatie":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"publisher":{"uuid":"2f809be7-b585-4cb8-8010-9682c4281aec","naam":"Utrecht"},"identifier":"document1","officiele_titel":"A
         test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
         sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1767614400000,1.0]},{"_index":"publication","_id":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","_score":1.0,"_source":{"uuid":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","publisher":{"uuid":"62da7e9d-2481-4d46-9c77-563b490126aa","naam":"Utrecht"},"informatie_categorieen":[{"uuid":"2ff3d47c-7945-4267-b3b2-e63aca280b8d","naam":"WOO"}],"officiele_titel":"Lorem
         ipsum dolor sit amet, consectetur adipiscing elit.","verkorte_titel":"Donec

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/DocumentTaskTest/test_index_document_roundtrip.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/DocumentTaskTest/test_index_document_roundtrip.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"uuid":"0095704d-4216-4de3-83d2-20dba551b0dc","publicatie":"d481bea6-335b-4d90-9b27-ac49f7196633","publisher":{"uuid":"f8b2b355-1d6e-4c1a-ba18-565f422997da","naam":"Utrecht"},"identifier":"https://www.example.com/1","officiele_titel":"A
+    body: '{"uuid":"0095704d-4216-4de3-83d2-20dba551b0dc","publicatie":"d481bea6-335b-4d90-9b27-ac49f7196633","informatie_categorieen":[{"uuid":"3c42a70a-d81d-4143-91d1-ebf62ac8b597","naam":"WOO"}],"publisher":{"uuid":"f8b2b355-1d6e-4c1a-ba18-565f422997da","naam":"Utrecht"},"identifier":"https://www.example.com/1","officiele_titel":"A
       test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
       sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
@@ -46,21 +46,21 @@ interactions:
     uri: http://localhost:9201/document/_doc/0095704d-4216-4de3-83d2-20dba551b0dc
   response:
     body:
-      string: '{"_index":"document","_id":"0095704d-4216-4de3-83d2-20dba551b0dc","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"uuid":"0095704d-4216-4de3-83d2-20dba551b0dc","publicatie":"d481bea6-335b-4d90-9b27-ac49f7196633","publisher":{"uuid":"f8b2b355-1d6e-4c1a-ba18-565f422997da","naam":"Utrecht"},"identifier":"https://www.example.com/1","officiele_titel":"A
+      string: '{"_index":"document","_id":"0095704d-4216-4de3-83d2-20dba551b0dc","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"uuid":"0095704d-4216-4de3-83d2-20dba551b0dc","publicatie":"d481bea6-335b-4d90-9b27-ac49f7196633","informatie_categorieen":[{"uuid":"3c42a70a-d81d-4143-91d1-ebf62ac8b597","naam":"WOO"}],"publisher":{"uuid":"f8b2b355-1d6e-4c1a-ba18-565f422997da","naam":"Utrecht"},"identifier":"https://www.example.com/1","officiele_titel":"A
         test document","verkorte_titel":"A document","omschrijving":"Lorem ipsum dolor
         sit amet, consectetur adipiscing elit.","creatiedatum":"2026-01-01","registratiedatum":"2026-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}}'
     headers:
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '618'
+      - '706'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 200
       message: OK
 - request:
-    body: '{"uuid":"0095704d-4216-4de3-83d2-20dba551b0dc","publicatie":"CHANGED","publisher":{"uuid":"CHANGED","naam":"Amsterdam"},"identifier":"https://www.example.com/999","officiele_titel":"CHANGED
+    body: '{"uuid":"0095704d-4216-4de3-83d2-20dba551b0dc","publicatie":"CHANGED","informatie_categorieen":[{"uuid":"3c42a70a-d81d-4143-91d1-ebf62ac8b597","naam":"WOO"}],"publisher":{"uuid":"CHANGED","naam":"Amsterdam"},"identifier":"https://www.example.com/999","officiele_titel":"CHANGED
       TITLE","verkorte_titel":"CHANGED","omschrijving":"CHANGED OMSCHRIJVING","creatiedatum":"2030-01-01","registratiedatum":"2030-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2030-01-05T12:00:00+00:00"}'
     headers:
       accept:
@@ -103,13 +103,13 @@ interactions:
     uri: http://localhost:9201/document/_doc/0095704d-4216-4de3-83d2-20dba551b0dc
   response:
     body:
-      string: '{"_index":"document","_id":"0095704d-4216-4de3-83d2-20dba551b0dc","_version":2,"_seq_no":1,"_primary_term":1,"found":true,"_source":{"uuid":"0095704d-4216-4de3-83d2-20dba551b0dc","publicatie":"CHANGED","publisher":{"uuid":"CHANGED","naam":"Amsterdam"},"identifier":"https://www.example.com/999","officiele_titel":"CHANGED
+      string: '{"_index":"document","_id":"0095704d-4216-4de3-83d2-20dba551b0dc","_version":2,"_seq_no":1,"_primary_term":1,"found":true,"_source":{"uuid":"0095704d-4216-4de3-83d2-20dba551b0dc","publicatie":"CHANGED","informatie_categorieen":[{"uuid":"3c42a70a-d81d-4143-91d1-ebf62ac8b597","naam":"WOO"}],"publisher":{"uuid":"CHANGED","naam":"Amsterdam"},"identifier":"https://www.example.com/999","officiele_titel":"CHANGED
         TITLE","verkorte_titel":"CHANGED","omschrijving":"CHANGED OMSCHRIJVING","creatiedatum":"2030-01-01","registratiedatum":"2030-01-05T12:00:00+00:00","laatst_gewijzigd_datum":"2030-01-05T12:00:00+00:00"}}'
     headers:
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '523'
+      - '611'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/RemoveFromIndexTaskTests/test_remove_indexed_document.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/RemoveFromIndexTaskTests/test_remove_indexed_document.yaml
@@ -1,9 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publicatie":"50d8f97f-381d-421b-8998-34e9fd468a61","publisher":{"uuid":"7bdba719-5f47-47d1-8567-ff50081702b7","naam":"Ponce
-      Group"},"identifier":"identifier-0","officiele_titel":"Safe radio Mr player
-      half a.","verkorte_titel":"Smile bar never.","omschrijving":"Allow stop medical
-      human another. Follow anyone see although.","creatiedatum":"2025-02-18","registratiedatum":"2025-02-09T00:14:53.177129","laatst_gewijzigd_datum":"2025-01-27T14:55:49.660442"}'
+    body: '{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publicatie":"b00fc249-2c8c-4c96-bfaf-32b9cb6ecd53","informatie_categorieen":[{"uuid":"042eb070-21df-4f62-8b63-31248937907e","naam":"Star
+      year."}],"publisher":{"uuid":"26d52bc4-3a57-47a9-8e6d-3e31a962a003","naam":"Fischer,
+      Larson and Pham"},"identifier":"identifier-15","officiele_titel":"Red join rule
+      huge.","verkorte_titel":"Key believe.","omschrijving":"Even bill crime blood
+      other light range. Government chance whose. Away point people drop.","creatiedatum":"2025-02-18","registratiedatum":"2025-02-12T07:19:55.911362","laatst_gewijzigd_datum":"2025-02-17T16:07:13.355525"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -47,15 +48,16 @@ interactions:
     uri: http://localhost:9201/document/_doc/ad4d66a8-1503-4743-ae55-d1765512530c
   response:
     body:
-      string: '{"_index":"document","_id":"ad4d66a8-1503-4743-ae55-d1765512530c","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publicatie":"50d8f97f-381d-421b-8998-34e9fd468a61","publisher":{"uuid":"7bdba719-5f47-47d1-8567-ff50081702b7","naam":"Ponce
-        Group"},"identifier":"identifier-0","officiele_titel":"Safe radio Mr player
-        half a.","verkorte_titel":"Smile bar never.","omschrijving":"Allow stop medical
-        human another. Follow anyone see although.","creatiedatum":"2025-02-18","registratiedatum":"2025-02-09T00:14:53.177129","laatst_gewijzigd_datum":"2025-01-27T14:55:49.660442"}}'
+      string: '{"_index":"document","_id":"ad4d66a8-1503-4743-ae55-d1765512530c","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publicatie":"b00fc249-2c8c-4c96-bfaf-32b9cb6ecd53","informatie_categorieen":[{"uuid":"042eb070-21df-4f62-8b63-31248937907e","naam":"Star
+        year."}],"publisher":{"uuid":"26d52bc4-3a57-47a9-8e6d-3e31a962a003","naam":"Fischer,
+        Larson and Pham"},"identifier":"identifier-15","officiele_titel":"Red join
+        rule huge.","verkorte_titel":"Key believe.","omschrijving":"Even bill crime
+        blood other light range. Government chance whose. Away point people drop.","creatiedatum":"2025-02-18","registratiedatum":"2025-02-12T07:19:55.911362","laatst_gewijzigd_datum":"2025-02-17T16:07:13.355525"}}'
     headers:
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '635'
+      - '759'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/RemoveFromIndexTaskTests/test_remove_indexed_document.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/RemoveFromIndexTaskTests/test_remove_indexed_document.yaml
@@ -1,10 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publicatie":"b00fc249-2c8c-4c96-bfaf-32b9cb6ecd53","informatie_categorieen":[{"uuid":"042eb070-21df-4f62-8b63-31248937907e","naam":"Star
-      year."}],"publisher":{"uuid":"26d52bc4-3a57-47a9-8e6d-3e31a962a003","naam":"Fischer,
-      Larson and Pham"},"identifier":"identifier-15","officiele_titel":"Red join rule
-      huge.","verkorte_titel":"Key believe.","omschrijving":"Even bill crime blood
-      other light range. Government chance whose. Away point people drop.","creatiedatum":"2025-02-18","registratiedatum":"2025-02-12T07:19:55.911362","laatst_gewijzigd_datum":"2025-02-17T16:07:13.355525"}'
+    body: '{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publicatie":"3e9f721f-767d-4ab7-88b6-51cbba58199e","informatie_categorieen":[{"uuid":"3c8e803f-579f-4ffc-880a-0c1ebc013fd1","naam":"Wide
+      mouth after."}],"publisher":{"uuid":"75097b4f-2f69-408e-b3c6-0444fe723834","naam":"Orozco,
+      Beltran and Stein"},"identifier":"identifier-17","officiele_titel":"Remain line
+      Republican approach contain me.","verkorte_titel":"Line push low.","omschrijving":"At
+      case should thus very. Thus leader your some.","creatiedatum":"2025-01-27","registratiedatum":"2025-01-30T15:19:08.009699","laatst_gewijzigd_datum":"2025-02-08T13:50:31.661767"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -48,16 +48,16 @@ interactions:
     uri: http://localhost:9201/document/_doc/ad4d66a8-1503-4743-ae55-d1765512530c
   response:
     body:
-      string: '{"_index":"document","_id":"ad4d66a8-1503-4743-ae55-d1765512530c","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publicatie":"b00fc249-2c8c-4c96-bfaf-32b9cb6ecd53","informatie_categorieen":[{"uuid":"042eb070-21df-4f62-8b63-31248937907e","naam":"Star
-        year."}],"publisher":{"uuid":"26d52bc4-3a57-47a9-8e6d-3e31a962a003","naam":"Fischer,
-        Larson and Pham"},"identifier":"identifier-15","officiele_titel":"Red join
-        rule huge.","verkorte_titel":"Key believe.","omschrijving":"Even bill crime
-        blood other light range. Government chance whose. Away point people drop.","creatiedatum":"2025-02-18","registratiedatum":"2025-02-12T07:19:55.911362","laatst_gewijzigd_datum":"2025-02-17T16:07:13.355525"}}'
+      string: '{"_index":"document","_id":"ad4d66a8-1503-4743-ae55-d1765512530c","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publicatie":"3e9f721f-767d-4ab7-88b6-51cbba58199e","informatie_categorieen":[{"uuid":"3c8e803f-579f-4ffc-880a-0c1ebc013fd1","naam":"Wide
+        mouth after."}],"publisher":{"uuid":"75097b4f-2f69-408e-b3c6-0444fe723834","naam":"Orozco,
+        Beltran and Stein"},"identifier":"identifier-17","officiele_titel":"Remain
+        line Republican approach contain me.","verkorte_titel":"Line push low.","omschrijving":"At
+        case should thus very. Thus leader your some.","creatiedatum":"2025-01-27","registratiedatum":"2025-01-30T15:19:08.009699","laatst_gewijzigd_datum":"2025-02-08T13:50:31.661767"}}'
     headers:
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '759'
+      - '752'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/RemoveFromIndexTaskTests/test_remove_indexed_publication.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/RemoveFromIndexTaskTests/test_remove_indexed_publication.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publisher":{"uuid":"effd5917-73da-4ba9-89de-eff18bf02cb5","naam":"Sanchez-Anderson"},"informatie_categorieen":[{"uuid":"68f1b1c2-448d-4909-8f27-fe6dc0a1105f","naam":"Plan
-      none."}],"officiele_titel":"Left go policy way full.","verkorte_titel":"Such
-      student fast.","omschrijving":"How common onto ten pattern. Opportunity suddenly
-      number finish. Wear should worry land.","registratiedatum":"2025-01-29T19:02:56.262728","laatst_gewijzigd_datum":"2025-02-21T22:48:05.991390"}'
+    body: '{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publisher":{"uuid":"fa9bde7e-2b6f-435e-88b9-634db74a9a81","naam":"Lewis-Hardy"},"informatie_categorieen":[{"uuid":"52ada0c9-8b54-4b90-bccf-7b419ebbbe52","naam":"Former
+      rather west."}],"officiele_titel":"Thought cost quality buy brother remain.","verkorte_titel":"Guy
+      thus.","omschrijving":"Writer heavy discuss case product director. Enter case
+      degree them authority direction.","registratiedatum":"2025-02-06T02:43:33.080617","laatst_gewijzigd_datum":"2025-02-20T07:30:59.575395"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -47,15 +47,15 @@ interactions:
     uri: http://localhost:9201/publication/_doc/ad4d66a8-1503-4743-ae55-d1765512530c
   response:
     body:
-      string: '{"_index":"publication","_id":"ad4d66a8-1503-4743-ae55-d1765512530c","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publisher":{"uuid":"effd5917-73da-4ba9-89de-eff18bf02cb5","naam":"Sanchez-Anderson"},"informatie_categorieen":[{"uuid":"68f1b1c2-448d-4909-8f27-fe6dc0a1105f","naam":"Plan
-        none."}],"officiele_titel":"Left go policy way full.","verkorte_titel":"Such
-        student fast.","omschrijving":"How common onto ten pattern. Opportunity suddenly
-        number finish. Wear should worry land.","registratiedatum":"2025-01-29T19:02:56.262728","laatst_gewijzigd_datum":"2025-02-21T22:48:05.991390"}}'
+      string: '{"_index":"publication","_id":"ad4d66a8-1503-4743-ae55-d1765512530c","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publisher":{"uuid":"fa9bde7e-2b6f-435e-88b9-634db74a9a81","naam":"Lewis-Hardy"},"informatie_categorieen":[{"uuid":"52ada0c9-8b54-4b90-bccf-7b419ebbbe52","naam":"Former
+        rather west."}],"officiele_titel":"Thought cost quality buy brother remain.","verkorte_titel":"Guy
+        thus.","omschrijving":"Writer heavy discuss case product director. Enter case
+        degree them authority direction.","registratiedatum":"2025-02-06T02:43:33.080617","laatst_gewijzigd_datum":"2025-02-20T07:30:59.575395"}}'
     headers:
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '655'
+      - '665'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/RemoveFromIndexTaskTests/test_remove_indexed_publication.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/RemoveFromIndexTaskTests/test_remove_indexed_publication.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publisher":{"uuid":"011e4163-ada9-4172-b377-073c026ccab8","naam":"Oconnor-Gardner"},"informatie_categorieen":[{"uuid":"a475cd17-711e-489f-ac90-fdd63efe05e1","naam":"Listen
-      owner."}],"officiele_titel":"Term soon finish mind summer.","verkorte_titel":"Source
-      much.","omschrijving":"Shoulder side war clear. Recently ten show full home
-      another store.","registratiedatum":"2025-02-15T21:29:26.213413","laatst_gewijzigd_datum":"2025-02-23T22:33:35.518849"}'
+    body: '{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publisher":{"uuid":"effd5917-73da-4ba9-89de-eff18bf02cb5","naam":"Sanchez-Anderson"},"informatie_categorieen":[{"uuid":"68f1b1c2-448d-4909-8f27-fe6dc0a1105f","naam":"Plan
+      none."}],"officiele_titel":"Left go policy way full.","verkorte_titel":"Such
+      student fast.","omschrijving":"How common onto ten pattern. Opportunity suddenly
+      number finish. Wear should worry land.","registratiedatum":"2025-01-29T19:02:56.262728","laatst_gewijzigd_datum":"2025-02-21T22:48:05.991390"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -47,15 +47,15 @@ interactions:
     uri: http://localhost:9201/publication/_doc/ad4d66a8-1503-4743-ae55-d1765512530c
   response:
     body:
-      string: '{"_index":"publication","_id":"ad4d66a8-1503-4743-ae55-d1765512530c","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publisher":{"uuid":"011e4163-ada9-4172-b377-073c026ccab8","naam":"Oconnor-Gardner"},"informatie_categorieen":[{"uuid":"a475cd17-711e-489f-ac90-fdd63efe05e1","naam":"Listen
-        owner."}],"officiele_titel":"Term soon finish mind summer.","verkorte_titel":"Source
-        much.","omschrijving":"Shoulder side war clear. Recently ten show full home
-        another store.","registratiedatum":"2025-02-15T21:29:26.213413","laatst_gewijzigd_datum":"2025-02-23T22:33:35.518849"}}'
+      string: '{"_index":"publication","_id":"ad4d66a8-1503-4743-ae55-d1765512530c","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publisher":{"uuid":"effd5917-73da-4ba9-89de-eff18bf02cb5","naam":"Sanchez-Anderson"},"informatie_categorieen":[{"uuid":"68f1b1c2-448d-4909-8f27-fe6dc0a1105f","naam":"Plan
+        none."}],"officiele_titel":"Left go policy way full.","verkorte_titel":"Such
+        student fast.","omschrijving":"How common onto ten pattern. Opportunity suddenly
+        number finish. Wear should worry land.","registratiedatum":"2025-01-29T19:02:56.262728","laatst_gewijzigd_datum":"2025-02-21T22:48:05.991390"}}'
     headers:
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '635'
+      - '655'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:

--- a/src/woo_search/search_index/typing.py
+++ b/src/woo_search/search_index/typing.py
@@ -54,3 +54,4 @@ class SearchParameters(TypedDict):
     creatiedatum_vanaf: date | None
     creatiedatum_tot_en_met: date | None
     publishers: Collection[UUID]
+    informatie_categorieen: Collection[UUID]

--- a/src/woo_search/search_index/typing.py
+++ b/src/woo_search/search_index/typing.py
@@ -19,6 +19,7 @@ class InformatieCategorieType(TypedDict):
 class DocumentType(TypedDict):
     uuid: str
     publicatie: str
+    informatie_categorieen: list[InformatieCategorieType]
     publisher: PublisherType
     identifier: str
     officiele_titel: str


### PR DESCRIPTION
Closes #16
Closes #38

**Changes**

* Extended the Document index API endpoint to take in the information category details
* Added filtering on information category UUID to the search parameters
* Added bucket aggregation for information categories

