### PR TITLE
Support custom CA in ES client

### DIFF
--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -52,6 +52,7 @@ Elastic Search
 * ``ELASTICSEARCH_USER``: Username for ES authentication. Defaults to: ``(empty string)``.
 * ``ELASTICSEARCH_PASSWORD``: Password for ES authentication. Defaults to: ``(empty string)``.
 * ``ELASTICSEARCH_TIMEOUT``: HTTP timeout for ES API interactions. Defaults to: ``60``.
+* ``ELASTICSEARCH_CA_CERTS``: Path to CA bundle (in PEM) format if self-signed certificates or a private CA are used to connect to the ES cluster. Alternatively, if EXTRA_VERIFY_CERTS is defined, it will be used. Defaults to: ``(empty string)``.
 * ``ELASTICSEARCH_REFRESH``: Refresh control for ES index, update, delete and bulk APIs. In production, you should leave this to the default of 'false'. Defaults to: ``False``.
 
 

--- a/docs/installation/config.rst
+++ b/docs/installation/config.rst
@@ -92,6 +92,7 @@ Optional
 * ``SHOW_ENVIRONMENT``:  Defaults to: ``True``.
 * ``CELERY_TASK_HARD_TIME_LIMIT``:  Defaults to: ``300``.
 * ``CELERY_TASK_SOFT_TIME_LIMIT``:  Defaults to: ``60``.
+* ``EXTRA_VERIFY_CERTS``: Comma-separated list of additional paths containing certificates (in PEM format) to add to the trust store. Useful when working with self-signed certificates or private certificate authorities. This setting is ignored if 'REQUESTS_CA_BUNDLE' is (already) defined. Defaults to: ``(empty string)``.
 * ``DISABLE_APM_IN_DEV``:  Defaults to: ``True``.
 * ``PROFILE``:  Defaults to: ``False``.
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,6 @@
 # Pure python dependencies
 elasticsearch-dsl~=8.0
+self-certifi
 
 # Django packages
 django-axes[ipware]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,6 +38,7 @@ certifi==2024.8.30
     #   elastic-apm
     #   elastic-transport
     #   requests
+    #   self-certifi
     #   sentry-sdk
 cffi==1.17.1
     # via cryptography
@@ -355,6 +356,8 @@ rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
+self-certifi==1.0.0
+    # via -r requirements/base.in
 sentry-sdk==2.14.0
     # via open-api-framework
 six==1.16.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -73,6 +73,7 @@ certifi==2024.8.30
     #   elastic-apm
     #   elastic-transport
     #   requests
+    #   self-certifi
     #   sentry-sdk
 cffi==1.17.1
     # via
@@ -741,6 +742,10 @@ rpds-py==0.20.0
     #   -r requirements/base.txt
     #   jsonschema
     #   referencing
+self-certifi==1.0.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 sentry-sdk==2.14.0
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -86,6 +86,7 @@ certifi==2024.8.30
     #   elastic-apm
     #   elastic-transport
     #   requests
+    #   self-certifi
     #   sentry-sdk
 cffi==1.17.1
     # via
@@ -817,6 +818,10 @@ rpds-py==0.20.0
     #   -r requirements/ci.txt
     #   jsonschema
     #   referencing
+self-certifi==1.0.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 sentry-sdk==2.14.0
     # via
     #   -c requirements/ci.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -87,6 +87,7 @@ certifi==2024.8.30
     #   elastic-apm
     #   elastic-transport
     #   requests
+    #   self-certifi
     #   sentry-sdk
 cffi==1.17.1
     # via
@@ -828,6 +829,10 @@ rpds-py==0.20.0
     #   -r requirements/ci.txt
     #   jsonschema
     #   referencing
+self-certifi==1.0.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 sentry-sdk==2.14.0
     # via
     #   -c requirements/ci.txt

--- a/src/woo_search/conf/base.py
+++ b/src/woo_search/conf/base.py
@@ -102,6 +102,16 @@ SEARCH_INDEX = {
         group="Elastic Search",
         help_text="HTTP timeout for ES API interactions.",
     ),
+    "CA_CERTS": config(
+        "ELASTICSEARCH_CA_CERTS",
+        default="",
+        group="Elastic Search",
+        help_text=(
+            "Path to CA bundle (in PEM) format if self-signed certificates or "
+            "a private CA are used to connect to the ES cluster. Alternatively, "
+            f"if {_EXTRA_CERTS_ENVVAR} is defined, it will be used."
+        ),
+    ),
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-refresh.html
     "REFRESH": config(
         "ELASTICSEARCH_REFRESH",

--- a/src/woo_search/conf/base.py
+++ b/src/woo_search/conf/base.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 from django.utils.translation import gettext_lazy as _
 
 from open_api_framework.conf.base import *  # noqa
+from self_certifi import EXTRA_CERTS_ENVVAR as _EXTRA_CERTS_ENVVAR
 from vng_api_common.conf.api import BASE_REST_FRAMEWORK
 
 from .utils import config
@@ -265,3 +266,21 @@ CELERY_TASK_ACKS_LATE = True
 # operation, leading to idle workers and backed-up workers. The `-O fair` option
 # *should* have the same effect...
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
+
+#
+# SELF-CERTIFI
+#
+
+# don't assign to a setting, since self-certifi looks directly at the environment. We
+# just hook things up here so they get included in the generated environment
+# documentation.
+config(
+    _EXTRA_CERTS_ENVVAR,
+    default="",
+    help_text=(
+        "Comma-separated list of additional paths containing certificates (in PEM "
+        "format) to add to the trust store. Useful when working with self-signed "
+        "certificates or private certificate authorities. This setting is ignored if "
+        "'REQUESTS_CA_BUNDLE' is (already) defined."
+    ),
+)

--- a/src/woo_search/search_index/tests/base.py
+++ b/src/woo_search/search_index/tests/base.py
@@ -21,6 +21,7 @@ override_es_settings = override_settings(
         "USER": "",
         "PASSWORD": "",
         "TIMEOUT": 3,
+        "CA_CERTS": "",
         "REFRESH": "wait_for",
     }
 )

--- a/src/woo_search/setup.py
+++ b/src/woo_search/setup.py
@@ -12,24 +12,74 @@ they are available for Django settings initialization.
 
 import logging
 import os
+import tempfile
+import threading
 from pathlib import Path
 
 from django.conf import settings
 
 from dotenv import load_dotenv
 from requests import Session
+from self_certifi import (
+    EXTRA_CERTS_ENVVAR,
+    load_self_signed_certs as _load_self_signed_certs,
+)
 
 logger = logging.getLogger(__name__)
 
+_SETUP_DONE = False
+
+env_lock = threading.Lock()
+
 
 def setup_env():
+    global _SETUP_DONE
+
+    if _SETUP_DONE:
+        return
+
     # load the environment variables containing the secrets/config
     dotenv_path = Path(__file__).resolve().parent.parent.parent / ".env"
     load_dotenv(dotenv_path)
 
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "woo_search.conf.dev")
 
+    load_self_signed_certs()
     monkeypatch_requests()
+
+    _SETUP_DONE = True
+
+
+def load_self_signed_certs() -> None:  # pragma: no cover
+    """
+    Load self-signed/private CA bundles in an idempotent manner.
+
+    self-certifi works by setting the ``REQUESTS_CA_BUNDLE`` envvar and errors out if
+    this envvar is already set (as it conflicts with the way it operates). If the setup
+    function runs multiple times, the envvar set by self-certifi would trip self-certifi
+    in the second run.
+
+    The guard clauses here ensure that loading the self-signed certs is done only once.
+    """
+    _certs_initialized = bool(os.environ.get("REQUESTS_CA_BUNDLE"))
+    if _certs_initialized:
+        return
+
+    needs_extra_verify_certs = os.environ.get(EXTRA_CERTS_ENVVAR)
+    if not needs_extra_verify_certs:
+        return
+
+    # don't block - if we can't acquire the lock, another thread already holds it and
+    # will result in the (shared) os.environ being updated.
+    if not env_lock.acquire(blocking=False):
+        return
+
+    try:
+        # create target directory for resulting combined certificate file
+        target_dir = tempfile.mkdtemp()
+        _load_self_signed_certs(target_dir)
+    finally:
+        env_lock.release()
 
 
 def monkeypatch_requests():


### PR DESCRIPTION
Fixes #27 

**Changes**

* Added self-certifi
* Added options to configure CA files for the elastic search client

@felixcicatt you can specify `ELASTICSEARCH_CA_CERTS` or `EXTRA_VERIFY_CERTS` to point to a PEM file with (root) certificates to trust.

The former is limited only to the elastic search client, the latter applies to any outgoing requests, e.g. if you had an in-cluster CA that issues certificates for both elastic search and gpp-publicatiebank, it would be more convenient to specify the latter. The former is a bit more explicit and secure though.

This setup is a bit hard to test properly, so let me know how it goes when you deploy it in-cluster!