### PR TITLE
Search API read permission

### DIFF
--- a/src/woo_search/api/permissions.py
+++ b/src/woo_search/api/permissions.py
@@ -28,3 +28,24 @@ class TokenAuthPermission(BasePermission):
             return True
 
         return False
+
+
+class TokenAuthReadPermission(BasePermission):
+    """
+    Simplified version of the `TokenAuthPermission` permission class.
+    Instead of checking for `read` or `write` based on the request
+    this permission class only checks if the user has read permissions no matter the request.
+    """
+
+    def has_permission(self, request, view) -> bool:
+        token = request.auth
+
+        if not isinstance(token, Application):
+            return False
+
+        assert isinstance(token.permissions, list)
+
+        if PermissionOptions.read in token.permissions:
+            return True
+
+        return False

--- a/src/woo_search/api/tests/test_permissions.py
+++ b/src/woo_search/api/tests/test_permissions.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from rest_framework.test import APITestCase, URLPatternsTestCase
 
 from ..authorization import TokenAuthentication
-from ..permissions import TokenAuthPermission
+from ..permissions import TokenAuthPermission, TokenAuthReadPermission
 from .factories import TokenAuthFactory
 
 
@@ -28,6 +28,21 @@ class TestAutorizationAndPermissionView(views.APIView):
 
     def delete(self, request, pk=None):
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class TestAutorizationAndReadPermissionView(views.APIView):
+    authentication_classes = (TokenAuthentication,)
+    permission_classes = (TokenAuthReadPermission,)
+
+    """
+    A simple ViewSet for listing or retrieving users.
+    """
+
+    def get(self, request):
+        return Response(status=status.HTTP_200_OK)
+
+    def post(self, request):
+        return Response(status=status.HTTP_201_CREATED)
 
 
 class ApiTokenAuthorizationAndPermissionTests(URLPatternsTestCase, APITestCase):
@@ -186,3 +201,89 @@ class ApiTokenAuthorizationAndPermissionTests(URLPatternsTestCase, APITestCase):
                 "/whatever", headers={"Authorization": f"Token {self.read_write_token}"}
             )
             self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+
+class ApiTokenAuthorizationAndReadPermissionTests(URLPatternsTestCase, APITestCase):
+    urlpatterns = [
+        path("whatever", TestAutorizationAndReadPermissionView.as_view()),
+    ]
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.no_permission_token = TokenAuthFactory.create(permissions=[]).token
+        cls.read_token = TokenAuthFactory.create(read_permission=True).token
+        cls.write_token = TokenAuthFactory.create(write_permission=True).token
+        cls.read_write_token = TokenAuthFactory.create(read_write_permission=True).token
+
+    def test_get_endpoint(self):
+        with self.subTest("no token given"):
+            response = self.client.get("/whatever")
+            self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        with self.subTest("none existing token"):
+            response = self.client.get(
+                "/whatever", headers={"Authorization": "Token broken"}
+            )
+            self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        with self.subTest("token with no permission"):
+            response = self.client.get(
+                "/whatever",
+                headers={"Authorization": f"Token {self.no_permission_token}"},
+            )
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("token with wrong permission"):
+            response = self.client.get(
+                "/whatever", headers={"Authorization": f"Token {self.write_token}"}
+            )
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("token with correct permission"):
+            response = self.client.get(
+                "/whatever", headers={"Authorization": f"Token {self.read_token}"}
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        with self.subTest("token with all permissions"):
+            response = self.client.get(
+                "/whatever", headers={"Authorization": f"Token {self.read_write_token}"}
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_post_endpoint(self):
+        with self.subTest("no token given"):
+            response = self.client.post("/whatever")
+            self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        with self.subTest("none existing token"):
+            response = self.client.post(
+                "/whatever", headers={"Authorization": "Token broken"}
+            )
+            self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        with self.subTest("token with no permission"):
+            response = self.client.post(
+                "/whatever",
+                headers={"Authorization": f"Token {self.no_permission_token}"},
+            )
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("token with wrong permission"):
+            response = self.client.post(
+                "/whatever", headers={"Authorization": f"Token {self.write_token}"}
+            )
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with self.subTest("token with correct permission"):
+            response = self.client.post(
+                "/whatever", headers={"Authorization": f"Token {self.read_token}"}
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        with self.subTest("token with all permissions"):
+            response = self.client.post(
+                "/whatever", headers={"Authorization": f"Token {self.read_write_token}"}
+            )
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/src/woo_search/search_index/api/views.py
+++ b/src/woo_search/search_index/api/views.py
@@ -4,12 +4,16 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from woo_search.api.permissions import TokenAuthReadPermission
+
 from ..client import get_search_results
 from ..typing import SearchParameters
 from .serializers import SearchResponseSerializer, SearchSerializer
 
 
 class SearchView(APIView):
+    permission_classes = (TokenAuthReadPermission,)
+
     @extend_schema(
         tags=["search"],
         summary=_("Search"),


### PR DESCRIPTION
Fixes #48 

**Changes**

- Added a DRF permission class for Token auth with only read permission (not read and write)
- Updated the permission class for the search endpoint so it only needs read permission

