### PR TITLE
Apply filters as post_filter and filter aggregation buckets

### DIFF
--- a/src/woo_search/search_index/tests/test_search_api.py
+++ b/src/woo_search/search_index/tests/test_search_api.py
@@ -714,7 +714,7 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
                 publisher["uuid"]: publisher
                 for publisher in data["facets"]["publishers"]
             }
-            self.assertEqual(len(facets_by_id), 2)
+            self.assertGreaterEqual(len(facets_by_id), 2)
             self.assertEqual(
                 facets_by_id["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"],
                 {
@@ -731,6 +731,18 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
                     "count": 1,
                 },
             )
+
+        with self.subTest("filter does not affect facets"):
+            response = self.client.post(
+                self.url,
+                {"publishers": ["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]},
+            )
+
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            self.assertEqual(data["count"], 1)
+            publisher_facets = data["facets"]["publishers"]
+            self.assertGreater(len(publisher_facets), 1)
 
     def test_filter_by_information_category_uuid(self):
         ic_1 = InformationCategoryFactory.build(
@@ -780,7 +792,7 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
                 },
             )
 
-            self.assertEqual(response.status_code, 200)
+            self.assertGreaterEqual(response.status_code, 200)
             data = response.json()
             self.assertEqual(data["count"], 2)
             expected_ids = {
@@ -813,6 +825,18 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
                     "count": 1,
                 },
             )
+
+        with self.subTest("filter does not affect facets"):
+            response = self.client.post(
+                self.url,
+                {"informatieCategorieen": ["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]},
+            )
+
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+            self.assertEqual(data["count"], 1)
+            publisher_facets = data["facets"]["informatieCategorieen"]
+            self.assertGreater(len(publisher_facets), 1)
 
     def test_boost_recently_published_items(self):
         # oldest, but modified more recently

--- a/src/woo_search/search_index/tests/test_search_api.py
+++ b/src/woo_search/search_index/tests/test_search_api.py
@@ -792,7 +792,7 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
                 },
             )
 
-            self.assertGreaterEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 200)
             data = response.json()
             self.assertEqual(data["count"], 2)
             expected_ids = {
@@ -808,7 +808,7 @@ class SearchApiTest(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
                 publisher["uuid"]: publisher
                 for publisher in data["facets"]["informatieCategorieen"]
             }
-            self.assertEqual(len(facets_by_id), 2)
+            self.assertGreaterEqual(len(facets_by_id), 2)
             self.assertEqual(
                 facets_by_id["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"],
                 {

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_boost_publication_over_document.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_boost_publication_over_document.yaml
@@ -1,8 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"ef67a34b-f51d-4a0e-be87-4d20066ac0c7","informatie_categorieen":[{"uuid":"9f11163d-f976-4b76-ad8c-66e0599bbfaa","naam":"Onto
-      city second."}],"publisher":{"uuid":"6732de7e-dcb9-412d-9d67-46724a8f5967","naam":"Lyons-Mitchell"},"identifier":"identifier-1","officiele_titel":"Snowflake","verkorte_titel":"While.","omschrijving":"History
-      position area four. Without often list ready.","creatiedatum":"2025-02-23","registratiedatum":"2025-02-22T00:55:20.171668","laatst_gewijzigd_datum":"2025-01-10T12:00:00+00:00"}'
+    body: '{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"a04a15c2-a47e-45a2-9fbf-145036cb58b1","informatie_categorieen":[{"uuid":"90719f57-38bb-4bdd-8c74-3016444f6b1f","naam":"Rock
+      than."}],"publisher":{"uuid":"1391141a-8002-465c-b120-e9f995904b31","naam":"Matthews,
+      Porter and Davis"},"identifier":"identifier-0","officiele_titel":"Snowflake","verkorte_titel":"Level
+      personal heart.","omschrijving":"Authority write civil product small. Brother
+      treat language ago leader employee. Good above out from color evidence.","creatiedatum":"2025-02-09","registratiedatum":"2025-03-06T06:12:57.017043","laatst_gewijzigd_datum":"2025-01-10T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -32,10 +34,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","publisher":{"uuid":"88703165-f37e-4bcf-a730-95ec46fd3305","naam":"Cardenas
-      Ltd"},"informatie_categorieen":[{"uuid":"fd2e4c13-876c-4abd-8607-eae256fc21e6","naam":"Born
-      quite push."}],"officiele_titel":"Snowflake","verkorte_titel":"Finish soon.","omschrijving":"Month
-      environmental tax. Up reach sing free image.","registratiedatum":"2025-02-23T23:07:43.753351","laatst_gewijzigd_datum":"2025-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","publisher":{"uuid":"8fb42630-4e68-47d2-8269-fe0c0cf0d1d8","naam":"Caldwell,
+      Serrano and Curry"},"informatie_categorieen":[{"uuid":"5c569ffc-7835-4ee7-9e43-9335971ee2a0","naam":"Part
+      president stock."}],"officiele_titel":"Snowflake","verkorte_titel":"Skin factor.","omschrijving":"Sea
+      through gas. Class line picture sit. Will bad able like land prepare.","registratiedatum":"2025-03-01T18:16:04.990381","laatst_gewijzigd_datum":"2025-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -65,7 +67,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"query_string":{"query":"\\\"Snowflake\\\"","fields":["identifier^3","officiele_titel^2","verkorte_titel^1.5","omschrijving"],"fuzziness":2}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"query_string":{"query":"\\\"Snowflake\\\"","fields":["identifier^3","officiele_titel^2","verkorte_titel^1.5","omschrijving"],"fuzziness":2}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -81,17 +83,21 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","_score":1.1507283,"_source":{"uuid":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","publisher":{"uuid":"88703165-f37e-4bcf-a730-95ec46fd3305","naam":"Cardenas
-        Ltd"},"informatie_categorieen":[{"uuid":"fd2e4c13-876c-4abd-8607-eae256fc21e6","naam":"Born
-        quite push."}],"officiele_titel":"Snowflake","verkorte_titel":"Finish soon.","omschrijving":"Month
-        environmental tax. Up reach sing free image.","registratiedatum":"2025-02-23T23:07:43.753351","laatst_gewijzigd_datum":"2025-01-05T12:00:00+00:00"},"sort":[1.1507283,1736078400000]},{"_index":"document","_id":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","_score":0.5753642,"_source":{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"ef67a34b-f51d-4a0e-be87-4d20066ac0c7","informatie_categorieen":[{"uuid":"9f11163d-f976-4b76-ad8c-66e0599bbfaa","naam":"Onto
-        city second."}],"publisher":{"uuid":"6732de7e-dcb9-412d-9d67-46724a8f5967","naam":"Lyons-Mitchell"},"identifier":"identifier-1","officiele_titel":"Snowflake","verkorte_titel":"While.","omschrijving":"History
-        position area four. Without often list ready.","creatiedatum":"2025-02-23","registratiedatum":"2025-02-22T00:55:20.171668","laatst_gewijzigd_datum":"2025-01-10T12:00:00+00:00"},"sort":[0.5753642,1736510400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["9f11163d-f976-4b76-ad8c-66e0599bbfaa","Onto
-        city second."],"key_as_string":"9f11163d-f976-4b76-ad8c-66e0599bbfaa|Onto
-        city second.","doc_count":1},{"key":["fd2e4c13-876c-4abd-8607-eae256fc21e6","Born
-        quite push."],"key_as_string":"fd2e4c13-876c-4abd-8607-eae256fc21e6|Born quite
-        push.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["6732de7e-dcb9-412d-9d67-46724a8f5967","Lyons-Mitchell"],"key_as_string":"6732de7e-dcb9-412d-9d67-46724a8f5967|Lyons-Mitchell","doc_count":1},{"key":["88703165-f37e-4bcf-a730-95ec46fd3305","Cardenas
-        Ltd"],"key_as_string":"88703165-f37e-4bcf-a730-95ec46fd3305|Cardenas Ltd","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":32,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","_score":1.1507283,"_source":{"uuid":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","publisher":{"uuid":"8fb42630-4e68-47d2-8269-fe0c0cf0d1d8","naam":"Caldwell,
+        Serrano and Curry"},"informatie_categorieen":[{"uuid":"5c569ffc-7835-4ee7-9e43-9335971ee2a0","naam":"Part
+        president stock."}],"officiele_titel":"Snowflake","verkorte_titel":"Skin factor.","omschrijving":"Sea
+        through gas. Class line picture sit. Will bad able like land prepare.","registratiedatum":"2025-03-01T18:16:04.990381","laatst_gewijzigd_datum":"2025-01-05T12:00:00+00:00"},"sort":[1.1507283,1736078400000]},{"_index":"document","_id":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","_score":0.5753642,"_source":{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"a04a15c2-a47e-45a2-9fbf-145036cb58b1","informatie_categorieen":[{"uuid":"90719f57-38bb-4bdd-8c74-3016444f6b1f","naam":"Rock
+        than."}],"publisher":{"uuid":"1391141a-8002-465c-b120-e9f995904b31","naam":"Matthews,
+        Porter and Davis"},"identifier":"identifier-0","officiele_titel":"Snowflake","verkorte_titel":"Level
+        personal heart.","omschrijving":"Authority write civil product small. Brother
+        treat language ago leader employee. Good above out from color evidence.","creatiedatum":"2025-02-09","registratiedatum":"2025-03-06T06:12:57.017043","laatst_gewijzigd_datum":"2025-01-10T12:00:00+00:00"},"sort":[0.5753642,1736510400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["5c569ffc-7835-4ee7-9e43-9335971ee2a0","Part
+        president stock."],"key_as_string":"5c569ffc-7835-4ee7-9e43-9335971ee2a0|Part
+        president stock.","doc_count":1},{"key":["90719f57-38bb-4bdd-8c74-3016444f6b1f","Rock
+        than."],"key_as_string":"90719f57-38bb-4bdd-8c74-3016444f6b1f|Rock than.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["1391141a-8002-465c-b120-e9f995904b31","Matthews,
+        Porter and Davis"],"key_as_string":"1391141a-8002-465c-b120-e9f995904b31|Matthews,
+        Porter and Davis","doc_count":1},{"key":["8fb42630-4e68-47d2-8269-fe0c0cf0d1d8","Caldwell,
+        Serrano and Curry"],"key_as_string":"8fb42630-4e68-47d2-8269-fe0c0cf0d1d8|Caldwell,
+        Serrano and Curry","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_boost_recently_published_items.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_boost_recently_published_items.yaml
@@ -1,8 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"79257bd4-79ee-4b26-b0e2-e38baf8f0ff3","naam":"Watson-Brown"},"informatie_categorieen":[{"uuid":"6d14de9f-d962-4743-8f34-472d95e66b82","naam":"Tax."}],"officiele_titel":"Arm
-      go person marriage.","verkorte_titel":"Hot will condition.","omschrijving":"Morning
-      prevent individual staff doctor dog. Who everything record.","registratiedatum":"2024-01-01T12:00:00+00:00","laatst_gewijzigd_datum":"2025-01-26T12:00:00+00:00"}'
+    body: '{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"bd584d03-4a87-448d-ae36-9eb3fd356f46","naam":"Vega
+      Ltd"},"informatie_categorieen":[{"uuid":"0cf5036a-a214-49f6-b3de-ba83dfa58495","naam":"Nearly
+      window statement."}],"officiele_titel":"Window field in any rich.","verkorte_titel":"Kind
+      team.","omschrijving":"Ground nor will. Mrs piece drop everyone onto service
+      quality meeting. What couple daughter window which yourself movie.","registratiedatum":"2024-01-01T12:00:00+00:00","laatst_gewijzigd_datum":"2025-01-26T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -32,10 +34,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publisher":{"uuid":"95207b68-a876-461c-bda8-09ae78911457","naam":"Rodriguez
-      Ltd"},"informatie_categorieen":[{"uuid":"c34b2908-f0e6-4cb9-b9cf-0a4039dd79e9","naam":"Case
-      pull become."}],"officiele_titel":"Project must human expert move walk.","verkorte_titel":"Available
-      word both.","omschrijving":"Others increase early.","registratiedatum":"2025-01-15T12:00:00+00:00","laatst_gewijzigd_datum":"2025-01-15T12:00:00+00:00"}'
+    body: '{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publisher":{"uuid":"cc937727-5e24-41d1-931f-26d0e3e7c433","naam":"Jefferson
+      PLC"},"informatie_categorieen":[{"uuid":"fd8b6a95-e7aa-440a-82fe-f9ba352de8ee","naam":"Big
+      heart."}],"officiele_titel":"Treat partner president provide.","verkorte_titel":"Decision
+      project heart.","omschrijving":"Case onto tonight pretty argue before economy
+      development. Provide lead foreign commercial. Paper if note spring.","registratiedatum":"2025-01-15T12:00:00+00:00","laatst_gewijzigd_datum":"2025-01-15T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -65,7 +68,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -81,15 +84,20 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"525747fd-7e58-4005-8efa-59bcf4403385","_score":0.044222534,"_source":{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publisher":{"uuid":"95207b68-a876-461c-bda8-09ae78911457","naam":"Rodriguez
-        Ltd"},"informatie_categorieen":[{"uuid":"c34b2908-f0e6-4cb9-b9cf-0a4039dd79e9","naam":"Case
-        pull become."}],"officiele_titel":"Project must human expert move walk.","verkorte_titel":"Available
-        word both.","omschrijving":"Others increase early.","registratiedatum":"2025-01-15T12:00:00+00:00","laatst_gewijzigd_datum":"2025-01-15T12:00:00+00:00"},"sort":[0.044222534,1736942400000]},{"_index":"publication","_id":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","_score":0.0,"_source":{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"79257bd4-79ee-4b26-b0e2-e38baf8f0ff3","naam":"Watson-Brown"},"informatie_categorieen":[{"uuid":"6d14de9f-d962-4743-8f34-472d95e66b82","naam":"Tax."}],"officiele_titel":"Arm
-        go person marriage.","verkorte_titel":"Hot will condition.","omschrijving":"Morning
-        prevent individual staff doctor dog. Who everything record.","registratiedatum":"2024-01-01T12:00:00+00:00","laatst_gewijzigd_datum":"2025-01-26T12:00:00+00:00"},"sort":[0.0,1737892800000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["6d14de9f-d962-4743-8f34-472d95e66b82","Tax."],"key_as_string":"6d14de9f-d962-4743-8f34-472d95e66b82|Tax.","doc_count":1},{"key":["c34b2908-f0e6-4cb9-b9cf-0a4039dd79e9","Case
-        pull become."],"key_as_string":"c34b2908-f0e6-4cb9-b9cf-0a4039dd79e9|Case
-        pull become.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["79257bd4-79ee-4b26-b0e2-e38baf8f0ff3","Watson-Brown"],"key_as_string":"79257bd4-79ee-4b26-b0e2-e38baf8f0ff3|Watson-Brown","doc_count":1},{"key":["95207b68-a876-461c-bda8-09ae78911457","Rodriguez
-        Ltd"],"key_as_string":"95207b68-a876-461c-bda8-09ae78911457|Rodriguez Ltd","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"publication","doc_count":2}]}}}'
+      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"525747fd-7e58-4005-8efa-59bcf4403385","_score":0.0067686024,"_source":{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publisher":{"uuid":"cc937727-5e24-41d1-931f-26d0e3e7c433","naam":"Jefferson
+        PLC"},"informatie_categorieen":[{"uuid":"fd8b6a95-e7aa-440a-82fe-f9ba352de8ee","naam":"Big
+        heart."}],"officiele_titel":"Treat partner president provide.","verkorte_titel":"Decision
+        project heart.","omschrijving":"Case onto tonight pretty argue before economy
+        development. Provide lead foreign commercial. Paper if note spring.","registratiedatum":"2025-01-15T12:00:00+00:00","laatst_gewijzigd_datum":"2025-01-15T12:00:00+00:00"},"sort":[0.0067686024,1736942400000]},{"_index":"publication","_id":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","_score":0.0,"_source":{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"bd584d03-4a87-448d-ae36-9eb3fd356f46","naam":"Vega
+        Ltd"},"informatie_categorieen":[{"uuid":"0cf5036a-a214-49f6-b3de-ba83dfa58495","naam":"Nearly
+        window statement."}],"officiele_titel":"Window field in any rich.","verkorte_titel":"Kind
+        team.","omschrijving":"Ground nor will. Mrs piece drop everyone onto service
+        quality meeting. What couple daughter window which yourself movie.","registratiedatum":"2024-01-01T12:00:00+00:00","laatst_gewijzigd_datum":"2025-01-26T12:00:00+00:00"},"sort":[0.0,1737892800000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["0cf5036a-a214-49f6-b3de-ba83dfa58495","Nearly
+        window statement."],"key_as_string":"0cf5036a-a214-49f6-b3de-ba83dfa58495|Nearly
+        window statement.","doc_count":1},{"key":["fd8b6a95-e7aa-440a-82fe-f9ba352de8ee","Big
+        heart."],"key_as_string":"fd8b6a95-e7aa-440a-82fe-f9ba352de8ee|Big heart.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["bd584d03-4a87-448d-ae36-9eb3fd356f46","Vega
+        Ltd"],"key_as_string":"bd584d03-4a87-448d-ae36-9eb3fd356f46|Vega Ltd","doc_count":1},{"key":["cc937727-5e24-41d1-931f-26d0e3e7c433","Jefferson
+        PLC"],"key_as_string":"cc937727-5e24-41d1-931f-26d0e3e7c433|Jefferson PLC","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"publication","doc_count":2}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_information_category_uuid.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_information_category_uuid.yaml
@@ -1,10 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"271bb206-3c64-4db0-914d-6f78b649229a","naam":"Walker
-      Ltd"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Follow
-      fast sometimes.","verkorte_titel":"Reality away sometimes.","omschrijving":"Culture
-      statement place surface safe federal husband environmental. Rest world young
-      whom.","registratiedatum":"2025-03-02T23:41:12.121040","laatst_gewijzigd_datum":"2025-03-02T08:55:34.571818"}'
+    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"525f4670-a7b5-4a71-b5d1-046f0a750901","naam":"Smith
+      Inc"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Grow
+      through late hospital let last American.","verkorte_titel":"Identify large compare.","omschrijving":"After
+      hour officer professor human out would. Large foreign pick room sound much.
+      Financial give though interesting church method moment.","registratiedatum":"2025-03-01T20:22:50.549568","laatst_gewijzigd_datum":"2025-02-13T18:54:41.684137"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -20,7 +20,7 @@ interactions:
     uri: http://localhost:9201/publication/_doc/dd3b8be0-e461-498a-9a18-0f5fc8adc956?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":6,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/dd3b8be0-e461-498a-9a18-0f5fc8adc956
@@ -34,11 +34,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"dc6d8121-dd23-439a-aa3c-5c29201b6a33","naam":"Ford,
-      Meyer and Bennett"},"informatie_categorieen":[{"uuid":"cf7d9da6-cade-4b1c-9652-e2a32475ad24","naam":"Imagine
-      Democrat."}],"officiele_titel":"Senior suggest health window.","verkorte_titel":"Mouth
-      above.","omschrijving":"Fear process fall sign from. His hope expect. Collection
-      middle in skill lot value executive.","registratiedatum":"2025-03-04T14:01:02.612912","laatst_gewijzigd_datum":"2025-02-18T01:26:46.351372"}'
+    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"8f39098b-d2ad-4a59-b9d1-acc6aa434d65","naam":"Holmes
+      Group"},"informatie_categorieen":[{"uuid":"7fcee718-3738-43ab-8702-da5bc510d21b","naam":"She."}],"officiele_titel":"Open
+      together whom writer pressure degree.","verkorte_titel":"Knowledge another.","omschrijving":"Bar
+      fall your. Over relate carry partner talk actually may.","registratiedatum":"2025-03-03T05:57:40.443699","laatst_gewijzigd_datum":"2025-02-28T13:27:47.061357"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -54,7 +53,7 @@ interactions:
     uri: http://localhost:9201/publication/_doc/3d6f91fc-ce3b-45d0-b3d6-c304be03845d?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":7,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/3d6f91fc-ce3b-45d0-b3d6-c304be03845d
@@ -68,10 +67,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"3320480c-62b7-4c25-8139-54ebd4028863","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"28b77d7c-9945-4239-8dab-c7ce21890c17","naam":"Reed,
-      Jones and Boyd"},"identifier":"identifier-0","officiele_titel":"Fear outside
-      writer change realize miss set.","verkorte_titel":"Once it.","omschrijving":"Control
-      who point focus affect. Chair politics someone near rise likely.","creatiedatum":"2025-02-15","registratiedatum":"2025-03-04T03:40:55.040794","laatst_gewijzigd_datum":"2025-02-07T18:23:04.323436"}'
+    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"16c20e39-e834-447d-acd7-89b628f26ddd","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"113af63d-0207-4eb2-9eb5-03ec54493924","naam":"Martinez
+      PLC"},"identifier":"identifier-1","officiele_titel":"Professional yeah early
+      less remain career.","verkorte_titel":"Read fact.","omschrijving":"Begin toward
+      right whether drop though enough. Have push another necessary their. Training
+      develop sing.","creatiedatum":"2025-02-22","registratiedatum":"2025-03-01T18:27:43.087142","laatst_gewijzigd_datum":"2025-02-24T07:08:08.209399"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -87,7 +87,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
+      string: '{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":2,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66
@@ -101,12 +101,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"5d5207a9-1537-4611-ab1c-5afbddef91d4","informatie_categorieen":[{"uuid":"47299f2d-b220-4bbd-bd19-d3a8049218c9","naam":"Different
-      need."}],"publisher":{"uuid":"9bc05108-cec1-4669-a3fd-fc7294a1ca6d","naam":"Hutchinson,
-      Russell and Chase"},"identifier":"identifier-1","officiele_titel":"Trial government
-      least specific imagine agreement certain.","verkorte_titel":"Try pick growth.","omschrijving":"Shoulder
-      history subject table sort. Debate mission child behavior. Central edge subject
-      worker or enjoy.","creatiedatum":"2025-03-02","registratiedatum":"2025-03-05T13:19:58.170279","laatst_gewijzigd_datum":"2025-03-03T18:15:31.769125"}'
+    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"b9dcab70-e0c8-48f2-af46-4cefd912e136","informatie_categorieen":[{"uuid":"20a2d51d-ebb7-441f-8c02-b4c05c64caa8","naam":"Experience
+      whatever."}],"publisher":{"uuid":"e1cffcb2-65cc-4277-b90d-572210133091","naam":"Hendrix
+      PLC"},"identifier":"identifier-2","officiele_titel":"Music yard hundred morning
+      operation look who since.","verkorte_titel":"Recent continue then.","omschrijving":"For
+      item stock drug. Support attack benefit third occur statement toward international.
+      Begin foot key field without certain apply trouble.","creatiedatum":"2025-02-20","registratiedatum":"2025-03-04T04:41:30.907536","laatst_gewijzigd_datum":"2025-02-26T04:50:06.310333"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -122,7 +122,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}'
+      string: '{"_index":"document","_id":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":3,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6
@@ -136,7 +136,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["1934d1db-b5c8-4521-97fe-a2ef969dd84e"]}}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"post_filter":{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["1934d1db-b5c8-4521-97fe-a2ef969dd84e"]}}}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["1934d1db-b5c8-4521-97fe-a2ef969dd84e"]}}}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -152,7 +152,9 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
+      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":4,"Categories":{"doc_count":4,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["20a2d51d-ebb7-441f-8c02-b4c05c64caa8","Experience
+        whatever."],"key_as_string":"20a2d51d-ebb7-441f-8c02-b4c05c64caa8|Experience
+        whatever.","doc_count":1},{"key":["7fcee718-3738-43ab-8702-da5bc510d21b","She."],"key_as_string":"7fcee718-3738-43ab-8702-da5bc510d21b|She.","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}}},"Publisher":{"doc_count":0,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2},{"key":"publication","doc_count":2}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -164,7 +166,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","e0eb40f7-eacb-45dc-973a-2e8480f49b76"]}}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"post_filter":{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","e0eb40f7-eacb-45dc-973a-2e8480f49b76"]}}}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","e0eb40f7-eacb-45dc-973a-2e8480f49b76"]}}}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -180,17 +182,20 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":0.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"271bb206-3c64-4db0-914d-6f78b649229a","naam":"Walker
-        Ltd"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Follow
-        fast sometimes.","verkorte_titel":"Reality away sometimes.","omschrijving":"Culture
-        statement place surface safe federal husband environmental. Rest world young
-        whom.","registratiedatum":"2025-03-02T23:41:12.121040","laatst_gewijzigd_datum":"2025-03-02T08:55:34.571818"},"sort":[0.0,1740905734571]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"3320480c-62b7-4c25-8139-54ebd4028863","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"28b77d7c-9945-4239-8dab-c7ce21890c17","naam":"Reed,
-        Jones and Boyd"},"identifier":"identifier-0","officiele_titel":"Fear outside
-        writer change realize miss set.","verkorte_titel":"Once it.","omschrijving":"Control
-        who point focus affect. Chair politics someone near rise likely.","creatiedatum":"2025-02-15","registratiedatum":"2025-03-04T03:40:55.040794","laatst_gewijzigd_datum":"2025-02-07T18:23:04.323436"},"sort":[0.0,1738952584323]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["271bb206-3c64-4db0-914d-6f78b649229a","Walker
-        Ltd"],"key_as_string":"271bb206-3c64-4db0-914d-6f78b649229a|Walker Ltd","doc_count":1},{"key":["28b77d7c-9945-4239-8dab-c7ce21890c17","Reed,
-        Jones and Boyd"],"key_as_string":"28b77d7c-9945-4239-8dab-c7ce21890c17|Reed,
-        Jones and Boyd","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":2.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"525f4670-a7b5-4a71-b5d1-046f0a750901","naam":"Smith
+        Inc"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Grow
+        through late hospital let last American.","verkorte_titel":"Identify large
+        compare.","omschrijving":"After hour officer professor human out would. Large
+        foreign pick room sound much. Financial give though interesting church method
+        moment.","registratiedatum":"2025-03-01T20:22:50.549568","laatst_gewijzigd_datum":"2025-02-13T18:54:41.684137"},"sort":[2.0,1739472881684]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":1.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"16c20e39-e834-447d-acd7-89b628f26ddd","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"113af63d-0207-4eb2-9eb5-03ec54493924","naam":"Martinez
+        PLC"},"identifier":"identifier-1","officiele_titel":"Professional yeah early
+        less remain career.","verkorte_titel":"Read fact.","omschrijving":"Begin toward
+        right whether drop though enough. Have push another necessary their. Training
+        develop sing.","creatiedatum":"2025-02-22","registratiedatum":"2025-03-01T18:27:43.087142","laatst_gewijzigd_datum":"2025-02-24T07:08:08.209399"},"sort":[1.0,1740380888209]}]},"aggregations":{"InformationCategories":{"doc_count":4,"Categories":{"doc_count":4,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["20a2d51d-ebb7-441f-8c02-b4c05c64caa8","Experience
+        whatever."],"key_as_string":"20a2d51d-ebb7-441f-8c02-b4c05c64caa8|Experience
+        whatever.","doc_count":1},{"key":["7fcee718-3738-43ab-8702-da5bc510d21b","She."],"key_as_string":"7fcee718-3738-43ab-8702-da5bc510d21b|She.","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["113af63d-0207-4eb2-9eb5-03ec54493924","Martinez
+        PLC"],"key_as_string":"113af63d-0207-4eb2-9eb5-03ec54493924|Martinez PLC","doc_count":1},{"key":["525f4670-a7b5-4a71-b5d1-046f0a750901","Smith
+        Inc"],"key_as_string":"525f4670-a7b5-4a71-b5d1-046f0a750901|Smith Inc","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2},{"key":"publication","doc_count":2}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -202,7 +207,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"post_filter":{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}}}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}}}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -218,12 +223,14 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"3320480c-62b7-4c25-8139-54ebd4028863","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"28b77d7c-9945-4239-8dab-c7ce21890c17","naam":"Reed,
-        Jones and Boyd"},"identifier":"identifier-0","officiele_titel":"Fear outside
-        writer change realize miss set.","verkorte_titel":"Once it.","omschrijving":"Control
-        who point focus affect. Chair politics someone near rise likely.","creatiedatum":"2025-02-15","registratiedatum":"2025-03-04T03:40:55.040794","laatst_gewijzigd_datum":"2025-02-07T18:23:04.323436"},"sort":[0.0,1738952584323]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["28b77d7c-9945-4239-8dab-c7ce21890c17","Reed,
-        Jones and Boyd"],"key_as_string":"28b77d7c-9945-4239-8dab-c7ce21890c17|Reed,
-        Jones and Boyd","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
+      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":1.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"16c20e39-e834-447d-acd7-89b628f26ddd","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"113af63d-0207-4eb2-9eb5-03ec54493924","naam":"Martinez
+        PLC"},"identifier":"identifier-1","officiele_titel":"Professional yeah early
+        less remain career.","verkorte_titel":"Read fact.","omschrijving":"Begin toward
+        right whether drop though enough. Have push another necessary their. Training
+        develop sing.","creatiedatum":"2025-02-22","registratiedatum":"2025-03-01T18:27:43.087142","laatst_gewijzigd_datum":"2025-02-24T07:08:08.209399"},"sort":[1.0,1740380888209]}]},"aggregations":{"InformationCategories":{"doc_count":4,"Categories":{"doc_count":4,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["20a2d51d-ebb7-441f-8c02-b4c05c64caa8","Experience
+        whatever."],"key_as_string":"20a2d51d-ebb7-441f-8c02-b4c05c64caa8|Experience
+        whatever.","doc_count":1},{"key":["7fcee718-3738-43ab-8702-da5bc510d21b","She."],"key_as_string":"7fcee718-3738-43ab-8702-da5bc510d21b|She.","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["113af63d-0207-4eb2-9eb5-03ec54493924","Martinez
+        PLC"],"key_as_string":"113af63d-0207-4eb2-9eb5-03ec54493924|Martinez PLC","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2},{"key":"publication","doc_count":2}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_information_category_uuid.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_information_category_uuid.yaml
@@ -1,10 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"736963bb-85f4-483f-816f-3ce5113e1050","naam":"Daniels,
-      Robinson and Thomas"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Or
-      far dinner research.","verkorte_titel":"Fact their.","omschrijving":"More effect
-      upon action one technology. Scientist identify senior wide spend research. Statement
-      particular major parent full thank.","registratiedatum":"2025-02-23T04:33:58.379817","laatst_gewijzigd_datum":"2025-02-15T04:11:42.442389"}'
+    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"271bb206-3c64-4db0-914d-6f78b649229a","naam":"Walker
+      Ltd"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Follow
+      fast sometimes.","verkorte_titel":"Reality away sometimes.","omschrijving":"Culture
+      statement place surface safe federal husband environmental. Rest world young
+      whom.","registratiedatum":"2025-03-02T23:41:12.121040","laatst_gewijzigd_datum":"2025-03-02T08:55:34.571818"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -20,7 +20,7 @@ interactions:
     uri: http://localhost:9201/publication/_doc/dd3b8be0-e461-498a-9a18-0f5fc8adc956?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":6,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/dd3b8be0-e461-498a-9a18-0f5fc8adc956
@@ -34,12 +34,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"07550a20-266b-4c2c-abc8-6a6e4e14fcb0","naam":"Butler,
-      Clay and Small"},"informatie_categorieen":[{"uuid":"05a4cd05-0190-4def-bb7d-07c54fc607f9","naam":"Coach
-      medical writer."}],"officiele_titel":"Say teacher study above whole hour.","verkorte_titel":"Form
-      memory she land.","omschrijving":"Reflect dark case just pick why. Somebody
-      discover red central defense agreement north develop. Several professor once
-      me maintain.","registratiedatum":"2025-02-26T03:19:00.392497","laatst_gewijzigd_datum":"2025-02-04T05:36:17.253786"}'
+    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"dc6d8121-dd23-439a-aa3c-5c29201b6a33","naam":"Ford,
+      Meyer and Bennett"},"informatie_categorieen":[{"uuid":"cf7d9da6-cade-4b1c-9652-e2a32475ad24","naam":"Imagine
+      Democrat."}],"officiele_titel":"Senior suggest health window.","verkorte_titel":"Mouth
+      above.","omschrijving":"Fear process fall sign from. His hope expect. Collection
+      middle in skill lot value executive.","registratiedatum":"2025-03-04T14:01:02.612912","laatst_gewijzigd_datum":"2025-02-18T01:26:46.351372"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -55,7 +54,7 @@ interactions:
     uri: http://localhost:9201/publication/_doc/3d6f91fc-ce3b-45d0-b3d6-c304be03845d?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":7,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/3d6f91fc-ce3b-45d0-b3d6-c304be03845d
@@ -69,10 +68,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"4fc1e679-d96b-4a21-9918-f8922301ae77","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"8e081027-d40e-4eea-8619-cb7499704e37","naam":"Hancock,
-      Hughes and Torres"},"identifier":"identifier-2","officiele_titel":"List doctor
-      clearly she rock.","verkorte_titel":"Leave son role.","omschrijving":"Like should
-      personal painting.","creatiedatum":"2025-02-02","registratiedatum":"2025-02-23T14:33:26.912184","laatst_gewijzigd_datum":"2025-02-24T17:26:25.660971"}'
+    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"3320480c-62b7-4c25-8139-54ebd4028863","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"28b77d7c-9945-4239-8dab-c7ce21890c17","naam":"Reed,
+      Jones and Boyd"},"identifier":"identifier-0","officiele_titel":"Fear outside
+      writer change realize miss set.","verkorte_titel":"Once it.","omschrijving":"Control
+      who point focus affect. Chair politics someone near rise likely.","creatiedatum":"2025-02-15","registratiedatum":"2025-03-04T03:40:55.040794","laatst_gewijzigd_datum":"2025-02-07T18:23:04.323436"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -88,7 +87,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":2,"_primary_term":1}'
+      string: '{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66
@@ -102,11 +101,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"27975710-74cd-4cf9-a463-af90b0eea864","informatie_categorieen":[{"uuid":"ad39c206-48e5-48c7-9332-0c0ab590ff84","naam":"Hotel
-      quickly half."}],"publisher":{"uuid":"565a3efb-322a-40f1-b8f6-661d9d9a36ec","naam":"Brooks
-      Ltd"},"identifier":"identifier-3","officiele_titel":"Fall future determine several.","verkorte_titel":"Move
-      save.","omschrijving":"Each summer recently speak role hospital. Billion miss
-      might throw since end. Subject keep talk choice if.","creatiedatum":"2025-02-23","registratiedatum":"2025-02-21T22:15:55.970130","laatst_gewijzigd_datum":"2025-02-01T15:42:49.885834"}'
+    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"5d5207a9-1537-4611-ab1c-5afbddef91d4","informatie_categorieen":[{"uuid":"47299f2d-b220-4bbd-bd19-d3a8049218c9","naam":"Different
+      need."}],"publisher":{"uuid":"9bc05108-cec1-4669-a3fd-fc7294a1ca6d","naam":"Hutchinson,
+      Russell and Chase"},"identifier":"identifier-1","officiele_titel":"Trial government
+      least specific imagine agreement certain.","verkorte_titel":"Try pick growth.","omschrijving":"Shoulder
+      history subject table sort. Debate mission child behavior. Central edge subject
+      worker or enjoy.","creatiedatum":"2025-03-02","registratiedatum":"2025-03-05T13:19:58.170279","laatst_gewijzigd_datum":"2025-03-03T18:15:31.769125"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -122,7 +122,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":3,"_primary_term":1}'
+      string: '{"_index":"document","_id":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6
@@ -152,7 +152,7 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":4,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
+      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -180,18 +180,50 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"4fc1e679-d96b-4a21-9918-f8922301ae77","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"8e081027-d40e-4eea-8619-cb7499704e37","naam":"Hancock,
-        Hughes and Torres"},"identifier":"identifier-2","officiele_titel":"List doctor
-        clearly she rock.","verkorte_titel":"Leave son role.","omschrijving":"Like
-        should personal painting.","creatiedatum":"2025-02-02","registratiedatum":"2025-02-23T14:33:26.912184","laatst_gewijzigd_datum":"2025-02-24T17:26:25.660971"},"sort":[0.0,1740417985660]},{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":0.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"736963bb-85f4-483f-816f-3ce5113e1050","naam":"Daniels,
-        Robinson and Thomas"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Or
-        far dinner research.","verkorte_titel":"Fact their.","omschrijving":"More
-        effect upon action one technology. Scientist identify senior wide spend research.
-        Statement particular major parent full thank.","registratiedatum":"2025-02-23T04:33:58.379817","laatst_gewijzigd_datum":"2025-02-15T04:11:42.442389"},"sort":[0.0,1739592702442]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["736963bb-85f4-483f-816f-3ce5113e1050","Daniels,
-        Robinson and Thomas"],"key_as_string":"736963bb-85f4-483f-816f-3ce5113e1050|Daniels,
-        Robinson and Thomas","doc_count":1},{"key":["8e081027-d40e-4eea-8619-cb7499704e37","Hancock,
-        Hughes and Torres"],"key_as_string":"8e081027-d40e-4eea-8619-cb7499704e37|Hancock,
-        Hughes and Torres","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":0.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"271bb206-3c64-4db0-914d-6f78b649229a","naam":"Walker
+        Ltd"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Follow
+        fast sometimes.","verkorte_titel":"Reality away sometimes.","omschrijving":"Culture
+        statement place surface safe federal husband environmental. Rest world young
+        whom.","registratiedatum":"2025-03-02T23:41:12.121040","laatst_gewijzigd_datum":"2025-03-02T08:55:34.571818"},"sort":[0.0,1740905734571]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"3320480c-62b7-4c25-8139-54ebd4028863","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"28b77d7c-9945-4239-8dab-c7ce21890c17","naam":"Reed,
+        Jones and Boyd"},"identifier":"identifier-0","officiele_titel":"Fear outside
+        writer change realize miss set.","verkorte_titel":"Once it.","omschrijving":"Control
+        who point focus affect. Chair politics someone near rise likely.","creatiedatum":"2025-02-15","registratiedatum":"2025-03-04T03:40:55.040794","laatst_gewijzigd_datum":"2025-02-07T18:23:04.323436"},"sort":[0.0,1738952584323]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["271bb206-3c64-4db0-914d-6f78b649229a","Walker
+        Ltd"],"key_as_string":"271bb206-3c64-4db0-914d-6f78b649229a|Walker Ltd","doc_count":1},{"key":["28b77d7c-9945-4239-8dab-c7ce21890c17","Reed,
+        Jones and Boyd"],"key_as_string":"28b77d7c-9945-4239-8dab-c7ce21890c17|Reed,
+        Jones and Boyd","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+    headers:
+      Transfer-Encoding:
+      - chunked
+      X-elastic-product:
+      - Elasticsearch
+      content-type:
+      - application/vnd.elasticsearch+json;compatible-with=8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    headers:
+      accept:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      connection:
+      - keep-alive
+      content-type:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      user-agent:
+      - elasticsearch-dsl-py/8.17.1
+      x-elastic-client-meta:
+      - es=8.17.1,py=3.12.8,t=8.17.0,ur=2.2.2
+    method: POST
+    uri: http://localhost:9201/publication,document/_search
+  response:
+    body:
+      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"3320480c-62b7-4c25-8139-54ebd4028863","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"28b77d7c-9945-4239-8dab-c7ce21890c17","naam":"Reed,
+        Jones and Boyd"},"identifier":"identifier-0","officiele_titel":"Fear outside
+        writer change realize miss set.","verkorte_titel":"Once it.","omschrijving":"Control
+        who point focus affect. Chair politics someone near rise likely.","creatiedatum":"2025-02-15","registratiedatum":"2025-03-04T03:40:55.040794","laatst_gewijzigd_datum":"2025-02-07T18:23:04.323436"},"sort":[0.0,1738952584323]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["28b77d7c-9945-4239-8dab-c7ce21890c17","Reed,
+        Jones and Boyd"],"key_as_string":"28b77d7c-9945-4239-8dab-c7ce21890c17|Reed,
+        Jones and Boyd","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_publisher_and_information_category.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_publisher_and_information_category.yaml
@@ -1,9 +1,8 @@
 interactions:
 - request:
-    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"ef3bb377-79d4-43ac-8d36-7d8d4593d959","informatie_categorieen":[{"uuid":"c9001845-aef0-4150-bbf0-a5f5c096e603","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-0","officiele_titel":"Agency
-      north weight later.","verkorte_titel":"Believe rather commercial.","omschrijving":"Increase
-      find hair region decide sell. Sure student fight see send term. My culture much
-      design two more out.","creatiedatum":"2025-02-27","registratiedatum":"2025-03-05T11:17:18.804324","laatst_gewijzigd_datum":"2025-02-23T03:52:29.190143"}'
+    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"78312c42-4a08-4a91-aaab-a5307d54a850","informatie_categorieen":[{"uuid":"c9001845-aef0-4150-bbf0-a5f5c096e603","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-0","officiele_titel":"Instead
+      official voice cut.","verkorte_titel":"Like two cell.","omschrijving":"Life
+      discuss hope. Both who machine.","creatiedatum":"2025-03-04","registratiedatum":"2025-03-03T09:40:08.268261","laatst_gewijzigd_datum":"2025-02-13T11:20:36.788802"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,9 +32,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"19cfac57-4d89-469a-9540-fcdf034e26cd","informatie_categorieen":[{"uuid":"70aa62cf-f404-47c6-92a5-78cb40cedc41","naam":"WOO"}],"publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"identifier":"identifier-1","officiele_titel":"Follow
-      plan paper half last range.","verkorte_titel":"North not better.","omschrijving":"Firm
-      specific blood land concern ability. Teach wrong billion.","creatiedatum":"2025-02-23","registratiedatum":"2025-03-03T13:20:34.819931","laatst_gewijzigd_datum":"2025-02-10T13:39:41.961047"}'
+    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"08875d2a-206e-40ea-8743-9f3434bfdb06","informatie_categorieen":[{"uuid":"70aa62cf-f404-47c6-92a5-78cb40cedc41","naam":"WOO"}],"publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"identifier":"identifier-1","officiele_titel":"Ok
+      interest else yet side yourself challenge.","verkorte_titel":"Go hope far.","omschrijving":"Election
+      detail ability sport debate financial hard. Job contain improve. Life group
+      administration anyone authority.","creatiedatum":"2025-02-25","registratiedatum":"2025-03-04T08:12:34.023211","laatst_gewijzigd_datum":"2025-02-27T23:22:51.617088"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -65,7 +65,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}},{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["70aa62cf-f404-47c6-92a5-78cb40cedc41"]}}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"post_filter":{"bool":{"must":[{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}},{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["70aa62cf-f404-47c6-92a5-78cb40cedc41"]}}}}]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["70aa62cf-f404-47c6-92a5-78cb40cedc41"]}}}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -81,7 +81,7 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":3,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
+      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c9001845-aef0-4150-bbf0-a5f5c096e603","Inspanningsverplichting"],"key_as_string":"c9001845-aef0-4150-bbf0-a5f5c096e603|Inspanningsverplichting","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_publisher_and_information_category.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_publisher_and_information_category.yaml
@@ -1,0 +1,95 @@
+interactions:
+- request:
+    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"ef3bb377-79d4-43ac-8d36-7d8d4593d959","informatie_categorieen":[{"uuid":"c9001845-aef0-4150-bbf0-a5f5c096e603","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-0","officiele_titel":"Agency
+      north weight later.","verkorte_titel":"Believe rather commercial.","omschrijving":"Increase
+      find hair region decide sell. Sure student fight see send term. My culture much
+      design two more out.","creatiedatum":"2025-02-27","registratiedatum":"2025-03-05T11:17:18.804324","laatst_gewijzigd_datum":"2025-02-23T03:52:29.190143"}'
+    headers:
+      accept:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      connection:
+      - keep-alive
+      content-type:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      user-agent:
+      - elasticsearch-dsl-py/8.17.1
+      x-elastic-client-meta:
+      - es=8.17.1,py=3.12.8,t=8.17.0,ur=2.2.2
+    method: PUT
+    uri: http://localhost:9201/document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66?refresh=wait_for
+  response:
+    body:
+      string: '{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
+    headers:
+      Location:
+      - /document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66
+      X-elastic-product:
+      - Elasticsearch
+      content-length:
+      - '176'
+      content-type:
+      - application/vnd.elasticsearch+json;compatible-with=8
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"19cfac57-4d89-469a-9540-fcdf034e26cd","informatie_categorieen":[{"uuid":"70aa62cf-f404-47c6-92a5-78cb40cedc41","naam":"WOO"}],"publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"identifier":"identifier-1","officiele_titel":"Follow
+      plan paper half last range.","verkorte_titel":"North not better.","omschrijving":"Firm
+      specific blood land concern ability. Teach wrong billion.","creatiedatum":"2025-02-23","registratiedatum":"2025-03-03T13:20:34.819931","laatst_gewijzigd_datum":"2025-02-10T13:39:41.961047"}'
+    headers:
+      accept:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      connection:
+      - keep-alive
+      content-type:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      user-agent:
+      - elasticsearch-dsl-py/8.17.1
+      x-elastic-client-meta:
+      - es=8.17.1,py=3.12.8,t=8.17.0,ur=2.2.2
+    method: PUT
+    uri: http://localhost:9201/document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6?refresh=wait_for
+  response:
+    body:
+      string: '{"_index":"document","_id":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}'
+    headers:
+      Location:
+      - /document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6
+      X-elastic-product:
+      - Elasticsearch
+      content-length:
+      - '176'
+      content-type:
+      - application/vnd.elasticsearch+json;compatible-with=8
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}},{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["70aa62cf-f404-47c6-92a5-78cb40cedc41"]}}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    headers:
+      accept:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      connection:
+      - keep-alive
+      content-type:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      user-agent:
+      - elasticsearch-dsl-py/8.17.1
+      x-elastic-client-meta:
+      - es=8.17.1,py=3.12.8,t=8.17.0,ur=2.2.2
+    method: POST
+    uri: http://localhost:9201/publication,document/_search
+  response:
+    body:
+      string: '{"took":3,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
+    headers:
+      Transfer-Encoding:
+      - chunked
+      X-elastic-product:
+      - Elasticsearch
+      content-type:
+      - application/vnd.elasticsearch+json;compatible-with=8
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_publisher_uuid.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_publisher_uuid.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"004556b2-f53b-4e21-8209-047d30c002c6","naam":"Would
-      security."}],"officiele_titel":"Myself world rock return in and.","verkorte_titel":"Identify
-      want network.","omschrijving":"Hair above note site. Democrat make threat and
-      fly summer.","registratiedatum":"2025-02-25T12:18:37.318691","laatst_gewijzigd_datum":"2025-01-29T12:22:38.003228"}'
+    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"78787447-00c1-421b-bdc1-c4de02ca6130","naam":"Spring
+      respond state already."}],"officiele_titel":"Action guy responsibility order.","verkorte_titel":"Action
+      three.","omschrijving":"Someone purpose somebody expect sing job. Poor child
+      final avoid hot. Common exist read pattern pretty significant always.","registratiedatum":"2025-03-04T11:06:03.929206","laatst_gewijzigd_datum":"2025-02-19T05:58:39.992983"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -19,26 +19,24 @@ interactions:
     uri: http://localhost:9201/publication/_doc/dd3b8be0-e461-498a-9a18-0f5fc8adc956?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":10,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":4,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/dd3b8be0-e461-498a-9a18-0f5fc8adc956
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '180'
+      - '179'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"c3b7e7e4-75bf-453e-b11d-00008c48d440","naam":"Cowan,
-      Jones and Bernard"},"informatie_categorieen":[{"uuid":"bab6bc0d-076b-4816-826f-01686c4126cd","naam":"Get
-      available."}],"officiele_titel":"Sea still century notice.","verkorte_titel":"Indeed
-      before card.","omschrijving":"Set site occur example benefit whether. Hotel
-      hundred newspaper like friend feel involve. Race fire mother quality inside
-      decision. With quite fine travel.","registratiedatum":"2025-02-24T09:43:48.197604","laatst_gewijzigd_datum":"2025-02-20T02:21:05.468147"}'
+    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"6a31f480-0338-4e94-9b32-85092075b2fa","naam":"Rowe
+      Inc"},"informatie_categorieen":[{"uuid":"0ca16bdb-128b-42fa-9a07-b85d4f5eb3b3","naam":"Much
+      establish."}],"officiele_titel":"Shake practice training often Congress degree.","verkorte_titel":"Example.","omschrijving":"Only
+      girl believe central school. Mean past employee miss say interesting.","registratiedatum":"2025-03-01T19:15:55.754719","laatst_gewijzigd_datum":"2025-03-01T14:47:47.467721"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -54,24 +52,25 @@ interactions:
     uri: http://localhost:9201/publication/_doc/3d6f91fc-ce3b-45d0-b3d6-c304be03845d?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":11,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":5,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/3d6f91fc-ce3b-45d0-b3d6-c304be03845d
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '180'
+      - '179'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"b1717b5f-8f53-4064-85b4-0fdbdd822d3e","informatie_categorieen":[{"uuid":"e30fcc39-15a3-4bed-b577-c9c5a01a3f2f","naam":"Matter
-      any."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-4","officiele_titel":"Road
-      gas foot trade.","verkorte_titel":"Skin eye capital.","omschrijving":"Explain
-      because since issue heavy. Term clearly exist everything item.","creatiedatum":"2025-02-06","registratiedatum":"2025-02-22T19:12:48.182641","laatst_gewijzigd_datum":"2025-02-05T03:06:57.835556"}'
+    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"a1d93fd7-5e70-4fd0-8547-e09e2cfc787a","informatie_categorieen":[{"uuid":"c5947751-4c31-4c70-bd1c-b099929ab37b","naam":"Fast
+      ask."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-2","officiele_titel":"Cut
+      involve compare reflect fear trial.","verkorte_titel":"Price exist stuff.","omschrijving":"Chance
+      cut region behavior yourself. Order certainly beautiful. View attack camera
+      follow family.","creatiedatum":"2025-02-22","registratiedatum":"2025-03-01T11:19:04.858970","laatst_gewijzigd_datum":"2025-02-11T04:15:19.308772"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -87,7 +86,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":6,"_primary_term":1}'
+      string: '{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":4,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66
@@ -101,9 +100,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"b882c203-b376-4a69-90e5-a0e0714f3977","informatie_categorieen":[{"uuid":"33a70c3b-1a27-4227-a6a7-8b8ffb945a8e","naam":"Bit."}],"publisher":{"uuid":"cf195038-32ab-4f90-9a70-dc1495be9673","naam":"Bennett-Levine"},"identifier":"identifier-5","officiele_titel":"Recent
-      low white get glass ball old.","verkorte_titel":"Thus far.","omschrijving":"Decision
-      man ability study trade capital phone.","creatiedatum":"2025-01-30","registratiedatum":"2025-02-26T01:33:43.877590","laatst_gewijzigd_datum":"2025-02-21T05:44:17.162774"}'
+    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"bee6d358-732f-48e2-a592-ae29e73c2c83","informatie_categorieen":[{"uuid":"6e2afc52-2920-4134-981f-f40b9b508292","naam":"Series
+      real property."}],"publisher":{"uuid":"b58b8a0c-08a8-4483-852a-b713aaa6ff7f","naam":"Marshall
+      PLC"},"identifier":"identifier-3","officiele_titel":"Former two size method
+      easy across.","verkorte_titel":"Action hot.","omschrijving":"Oil to often message
+      day view capital. Course rule cultural guess tough. Hot buy population bring
+      investment kind week.","creatiedatum":"2025-02-23","registratiedatum":"2025-03-03T17:02:29.604937","laatst_gewijzigd_datum":"2025-02-16T14:50:11.142421"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -119,7 +121,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":7,"_primary_term":1}'
+      string: '{"_index":"document","_id":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":5,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6
@@ -149,7 +151,7 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":4,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
+      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -177,15 +179,50 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"b1717b5f-8f53-4064-85b4-0fdbdd822d3e","informatie_categorieen":[{"uuid":"e30fcc39-15a3-4bed-b577-c9c5a01a3f2f","naam":"Matter
-        any."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-4","officiele_titel":"Road
-        gas foot trade.","verkorte_titel":"Skin eye capital.","omschrijving":"Explain
-        because since issue heavy. Term clearly exist everything item.","creatiedatum":"2025-02-06","registratiedatum":"2025-02-22T19:12:48.182641","laatst_gewijzigd_datum":"2025-02-05T03:06:57.835556"},"sort":[0.0,1738724817835]},{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":0.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"004556b2-f53b-4e21-8209-047d30c002c6","naam":"Would
-        security."}],"officiele_titel":"Myself world rock return in and.","verkorte_titel":"Identify
-        want network.","omschrijving":"Hair above note site. Democrat make threat
-        and fly summer.","registratiedatum":"2025-02-25T12:18:37.318691","laatst_gewijzigd_datum":"2025-01-29T12:22:38.003228"},"sort":[0.0,1738153358003]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["004556b2-f53b-4e21-8209-047d30c002c6","Would
-        security."],"key_as_string":"004556b2-f53b-4e21-8209-047d30c002c6|Would security.","doc_count":1},{"key":["e30fcc39-15a3-4bed-b577-c9c5a01a3f2f","Matter
-        any."],"key_as_string":"e30fcc39-15a3-4bed-b577-c9c5a01a3f2f|Matter any.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":0.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"78787447-00c1-421b-bdc1-c4de02ca6130","naam":"Spring
+        respond state already."}],"officiele_titel":"Action guy responsibility order.","verkorte_titel":"Action
+        three.","omschrijving":"Someone purpose somebody expect sing job. Poor child
+        final avoid hot. Common exist read pattern pretty significant always.","registratiedatum":"2025-03-04T11:06:03.929206","laatst_gewijzigd_datum":"2025-02-19T05:58:39.992983"},"sort":[0.0,1739944719992]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"a1d93fd7-5e70-4fd0-8547-e09e2cfc787a","informatie_categorieen":[{"uuid":"c5947751-4c31-4c70-bd1c-b099929ab37b","naam":"Fast
+        ask."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-2","officiele_titel":"Cut
+        involve compare reflect fear trial.","verkorte_titel":"Price exist stuff.","omschrijving":"Chance
+        cut region behavior yourself. Order certainly beautiful. View attack camera
+        follow family.","creatiedatum":"2025-02-22","registratiedatum":"2025-03-01T11:19:04.858970","laatst_gewijzigd_datum":"2025-02-11T04:15:19.308772"},"sort":[0.0,1739247319308]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["78787447-00c1-421b-bdc1-c4de02ca6130","Spring
+        respond state already."],"key_as_string":"78787447-00c1-421b-bdc1-c4de02ca6130|Spring
+        respond state already.","doc_count":1},{"key":["c5947751-4c31-4c70-bd1c-b099929ab37b","Fast
+        ask."],"key_as_string":"c5947751-4c31-4c70-bd1c-b099929ab37b|Fast ask.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+    headers:
+      Transfer-Encoding:
+      - chunked
+      X-elastic-product:
+      - Elasticsearch
+      content-type:
+      - application/vnd.elasticsearch+json;compatible-with=8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    headers:
+      accept:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      connection:
+      - keep-alive
+      content-type:
+      - application/vnd.elasticsearch+json; compatible-with=8
+      user-agent:
+      - elasticsearch-dsl-py/8.17.1
+      x-elastic-client-meta:
+      - es=8.17.1,py=3.12.8,t=8.17.0,ur=2.2.2
+    method: POST
+    uri: http://localhost:9201/publication,document/_search
+  response:
+    body:
+      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"a1d93fd7-5e70-4fd0-8547-e09e2cfc787a","informatie_categorieen":[{"uuid":"c5947751-4c31-4c70-bd1c-b099929ab37b","naam":"Fast
+        ask."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-2","officiele_titel":"Cut
+        involve compare reflect fear trial.","verkorte_titel":"Price exist stuff.","omschrijving":"Chance
+        cut region behavior yourself. Order certainly beautiful. View attack camera
+        follow family.","creatiedatum":"2025-02-22","registratiedatum":"2025-03-01T11:19:04.858970","laatst_gewijzigd_datum":"2025-02-11T04:15:19.308772"},"sort":[0.0,1739247319308]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c5947751-4c31-4c70-bd1c-b099929ab37b","Fast
+        ask."],"key_as_string":"c5947751-4c31-4c70-bd1c-b099929ab37b|Fast ask.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_publisher_uuid.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_by_publisher_uuid.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"78787447-00c1-421b-bdc1-c4de02ca6130","naam":"Spring
-      respond state already."}],"officiele_titel":"Action guy responsibility order.","verkorte_titel":"Action
-      three.","omschrijving":"Someone purpose somebody expect sing job. Poor child
-      final avoid hot. Common exist read pattern pretty significant always.","registratiedatum":"2025-03-04T11:06:03.929206","laatst_gewijzigd_datum":"2025-02-19T05:58:39.992983"}'
+    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"3f29bef0-ad91-4c9f-9a46-70939745a6a8","naam":"Process
+      speak."}],"officiele_titel":"Resource government life off rise.","verkorte_titel":"Someone
+      leave.","omschrijving":"Where large explain hit dinner similar camera. High
+      investment any say.","registratiedatum":"2025-03-05T04:32:38.774460","laatst_gewijzigd_datum":"2025-03-05T03:12:20.239774"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -19,24 +19,26 @@ interactions:
     uri: http://localhost:9201/publication/_doc/dd3b8be0-e461-498a-9a18-0f5fc8adc956?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":4,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":10,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/dd3b8be0-e461-498a-9a18-0f5fc8adc956
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '179'
+      - '180'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"6a31f480-0338-4e94-9b32-85092075b2fa","naam":"Rowe
-      Inc"},"informatie_categorieen":[{"uuid":"0ca16bdb-128b-42fa-9a07-b85d4f5eb3b3","naam":"Much
-      establish."}],"officiele_titel":"Shake practice training often Congress degree.","verkorte_titel":"Example.","omschrijving":"Only
-      girl believe central school. Mean past employee miss say interesting.","registratiedatum":"2025-03-01T19:15:55.754719","laatst_gewijzigd_datum":"2025-03-01T14:47:47.467721"}'
+    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"c31db9d5-1401-4d7d-8d6c-bc7251be6411","naam":"Myers,
+      Little and Ryan"},"informatie_categorieen":[{"uuid":"53ff53eb-0aec-459d-bb8d-b9018f6bb062","naam":"Believe
+      throw budget."}],"officiele_titel":"Law audience run head.","verkorte_titel":"Seem
+      everything rest discussion.","omschrijving":"Safe author difference help own
+      operation lay. Themselves institution ability player right list. Defense fire
+      him protect.","registratiedatum":"2025-03-02T04:36:01.688313","laatst_gewijzigd_datum":"2025-02-18T04:28:46.146926"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -52,25 +54,25 @@ interactions:
     uri: http://localhost:9201/publication/_doc/3d6f91fc-ce3b-45d0-b3d6-c304be03845d?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":5,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":11,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/3d6f91fc-ce3b-45d0-b3d6-c304be03845d
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '179'
+      - '180'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"a1d93fd7-5e70-4fd0-8547-e09e2cfc787a","informatie_categorieen":[{"uuid":"c5947751-4c31-4c70-bd1c-b099929ab37b","naam":"Fast
-      ask."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-2","officiele_titel":"Cut
-      involve compare reflect fear trial.","verkorte_titel":"Price exist stuff.","omschrijving":"Chance
-      cut region behavior yourself. Order certainly beautiful. View attack camera
-      follow family.","creatiedatum":"2025-02-22","registratiedatum":"2025-03-01T11:19:04.858970","laatst_gewijzigd_datum":"2025-02-11T04:15:19.308772"}'
+    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"798083d3-94c7-43f2-b90e-10cbb2fc36c4","informatie_categorieen":[{"uuid":"5b2fc289-394d-4e24-966c-0cc8e91f223b","naam":"Minute
+      full."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-5","officiele_titel":"Drug
+      suffer teach begin.","verkorte_titel":"Wide church.","omschrijving":"Result
+      deep name play campaign themselves beautiful. Door check rest type. Interest
+      air bit second rich. Federal whom window security.","creatiedatum":"2025-02-17","registratiedatum":"2025-03-03T18:01:38.514496","laatst_gewijzigd_datum":"2025-02-09T19:01:34.730117"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -86,7 +88,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":4,"_primary_term":1}'
+      string: '{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":6,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66
@@ -100,12 +102,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"bee6d358-732f-48e2-a592-ae29e73c2c83","informatie_categorieen":[{"uuid":"6e2afc52-2920-4134-981f-f40b9b508292","naam":"Series
-      real property."}],"publisher":{"uuid":"b58b8a0c-08a8-4483-852a-b713aaa6ff7f","naam":"Marshall
-      PLC"},"identifier":"identifier-3","officiele_titel":"Former two size method
-      easy across.","verkorte_titel":"Action hot.","omschrijving":"Oil to often message
-      day view capital. Course rule cultural guess tough. Hot buy population bring
-      investment kind week.","creatiedatum":"2025-02-23","registratiedatum":"2025-03-03T17:02:29.604937","laatst_gewijzigd_datum":"2025-02-16T14:50:11.142421"}'
+    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"47e8951b-7722-49d1-81a8-b4d3c21e118d","informatie_categorieen":[{"uuid":"aa27bf58-93dd-4c06-8e36-5562e35c5aaf","naam":"Cut
+      goal."}],"publisher":{"uuid":"9051f590-d926-478a-833c-c3d25842ff47","naam":"Hodges,
+      Ramos and Wang"},"identifier":"identifier-6","officiele_titel":"Nice wall continue
+      minute factor picture nearly all.","verkorte_titel":"Visit successful.","omschrijving":"Official
+      same cultural character that. Report effort politics military bill difficult.","creatiedatum":"2025-02-18","registratiedatum":"2025-03-03T06:40:25.529458","laatst_gewijzigd_datum":"2025-02-16T21:07:07.062021"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -121,7 +122,7 @@ interactions:
     uri: http://localhost:9201/document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6?refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":5,"_primary_term":1}'
+      string: '{"_index":"document","_id":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","_version":3,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":7,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6
@@ -135,7 +136,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"terms":{"publisher.uuid.keyword":["1934d1db-b5c8-4521-97fe-a2ef969dd84e"]}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"post_filter":{"terms":{"publisher.uuid.keyword":["1934d1db-b5c8-4521-97fe-a2ef969dd84e"]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"terms":{"publisher.uuid.keyword":["1934d1db-b5c8-4521-97fe-a2ef969dd84e"]}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -151,7 +152,11 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}'
+      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count":0,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}},"Publisher":{"doc_count":4,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["9051f590-d926-478a-833c-c3d25842ff47","Hodges,
+        Ramos and Wang"],"key_as_string":"9051f590-d926-478a-833c-c3d25842ff47|Hodges,
+        Ramos and Wang","doc_count":1},{"key":["c31db9d5-1401-4d7d-8d6c-bc7251be6411","Myers,
+        Little and Ryan"],"key_as_string":"c31db9d5-1401-4d7d-8d6c-bc7251be6411|Myers,
+        Little and Ryan","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2},{"key":"publication","doc_count":2}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -163,7 +168,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","e0eb40f7-eacb-45dc-973a-2e8480f49b76"]}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"post_filter":{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","e0eb40f7-eacb-45dc-973a-2e8480f49b76"]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","e0eb40f7-eacb-45dc-973a-2e8480f49b76"]}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -179,17 +184,20 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":0.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"78787447-00c1-421b-bdc1-c4de02ca6130","naam":"Spring
-        respond state already."}],"officiele_titel":"Action guy responsibility order.","verkorte_titel":"Action
-        three.","omschrijving":"Someone purpose somebody expect sing job. Poor child
-        final avoid hot. Common exist read pattern pretty significant always.","registratiedatum":"2025-03-04T11:06:03.929206","laatst_gewijzigd_datum":"2025-02-19T05:58:39.992983"},"sort":[0.0,1739944719992]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"a1d93fd7-5e70-4fd0-8547-e09e2cfc787a","informatie_categorieen":[{"uuid":"c5947751-4c31-4c70-bd1c-b099929ab37b","naam":"Fast
-        ask."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-2","officiele_titel":"Cut
-        involve compare reflect fear trial.","verkorte_titel":"Price exist stuff.","omschrijving":"Chance
-        cut region behavior yourself. Order certainly beautiful. View attack camera
-        follow family.","creatiedatum":"2025-02-22","registratiedatum":"2025-03-01T11:19:04.858970","laatst_gewijzigd_datum":"2025-02-11T04:15:19.308772"},"sort":[0.0,1739247319308]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["78787447-00c1-421b-bdc1-c4de02ca6130","Spring
-        respond state already."],"key_as_string":"78787447-00c1-421b-bdc1-c4de02ca6130|Spring
-        respond state already.","doc_count":1},{"key":["c5947751-4c31-4c70-bd1c-b099929ab37b","Fast
-        ask."],"key_as_string":"c5947751-4c31-4c70-bd1c-b099929ab37b|Fast ask.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":2.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"3f29bef0-ad91-4c9f-9a46-70939745a6a8","naam":"Process
+        speak."}],"officiele_titel":"Resource government life off rise.","verkorte_titel":"Someone
+        leave.","omschrijving":"Where large explain hit dinner similar camera. High
+        investment any say.","registratiedatum":"2025-03-05T04:32:38.774460","laatst_gewijzigd_datum":"2025-03-05T03:12:20.239774"},"sort":[2.0,1741144340239]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":1.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"798083d3-94c7-43f2-b90e-10cbb2fc36c4","informatie_categorieen":[{"uuid":"5b2fc289-394d-4e24-966c-0cc8e91f223b","naam":"Minute
+        full."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-5","officiele_titel":"Drug
+        suffer teach begin.","verkorte_titel":"Wide church.","omschrijving":"Result
+        deep name play campaign themselves beautiful. Door check rest type. Interest
+        air bit second rich. Federal whom window security.","creatiedatum":"2025-02-17","registratiedatum":"2025-03-03T18:01:38.514496","laatst_gewijzigd_datum":"2025-02-09T19:01:34.730117"},"sort":[1.0,1739127694730]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3f29bef0-ad91-4c9f-9a46-70939745a6a8","Process
+        speak."],"key_as_string":"3f29bef0-ad91-4c9f-9a46-70939745a6a8|Process speak.","doc_count":1},{"key":["5b2fc289-394d-4e24-966c-0cc8e91f223b","Minute
+        full."],"key_as_string":"5b2fc289-394d-4e24-966c-0cc8e91f223b|Minute full.","doc_count":1}]}}},"Publisher":{"doc_count":4,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["9051f590-d926-478a-833c-c3d25842ff47","Hodges,
+        Ramos and Wang"],"key_as_string":"9051f590-d926-478a-833c-c3d25842ff47|Hodges,
+        Ramos and Wang","doc_count":1},{"key":["c31db9d5-1401-4d7d-8d6c-bc7251be6411","Myers,
+        Little and Ryan"],"key_as_string":"c31db9d5-1401-4d7d-8d6c-bc7251be6411|Myers,
+        Little and Ryan","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2},{"key":"publication","doc_count":2}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -201,7 +209,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"post_filter":{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -217,12 +225,16 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":0.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"a1d93fd7-5e70-4fd0-8547-e09e2cfc787a","informatie_categorieen":[{"uuid":"c5947751-4c31-4c70-bd1c-b099929ab37b","naam":"Fast
-        ask."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-2","officiele_titel":"Cut
-        involve compare reflect fear trial.","verkorte_titel":"Price exist stuff.","omschrijving":"Chance
-        cut region behavior yourself. Order certainly beautiful. View attack camera
-        follow family.","creatiedatum":"2025-02-22","registratiedatum":"2025-03-01T11:19:04.858970","laatst_gewijzigd_datum":"2025-02-11T04:15:19.308772"},"sort":[0.0,1739247319308]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c5947751-4c31-4c70-bd1c-b099929ab37b","Fast
-        ask."],"key_as_string":"c5947751-4c31-4c70-bd1c-b099929ab37b|Fast ask.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
+      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":1.0,"_source":{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"798083d3-94c7-43f2-b90e-10cbb2fc36c4","informatie_categorieen":[{"uuid":"5b2fc289-394d-4e24-966c-0cc8e91f223b","naam":"Minute
+        full."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-5","officiele_titel":"Drug
+        suffer teach begin.","verkorte_titel":"Wide church.","omschrijving":"Result
+        deep name play campaign themselves beautiful. Door check rest type. Interest
+        air bit second rich. Federal whom window security.","creatiedatum":"2025-02-17","registratiedatum":"2025-03-03T18:01:38.514496","laatst_gewijzigd_datum":"2025-02-09T19:01:34.730117"},"sort":[1.0,1739127694730]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["5b2fc289-394d-4e24-966c-0cc8e91f223b","Minute
+        full."],"key_as_string":"5b2fc289-394d-4e24-966c-0cc8e91f223b|Minute full.","doc_count":1}]}}},"Publisher":{"doc_count":4,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["9051f590-d926-478a-833c-c3d25842ff47","Hodges,
+        Ramos and Wang"],"key_as_string":"9051f590-d926-478a-833c-c3d25842ff47|Hodges,
+        Ramos and Wang","doc_count":1},{"key":["c31db9d5-1401-4d7d-8d6c-bc7251be6411","Myers,
+        Little and Ryan"],"key_as_string":"c31db9d5-1401-4d7d-8d6c-bc7251be6411|Myers,
+        Little and Ryan","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2},{"key":"publication","doc_count":2}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_creatiedatum.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_creatiedatum.yaml
@@ -1,11 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"edd49d5f-f72b-4dae-a1e4-18c8604158ea","informatie_categorieen":[{"uuid":"fbff896e-053a-40ee-980a-95b85d158b01","naam":"Recent
-      television recently."}],"publisher":{"uuid":"3b77a4dc-da74-4efd-ba17-b5c0448a3d45","naam":"Perry
-      Ltd"},"identifier":"identifier-6","officiele_titel":"Hit treatment structure
-      upon power different better.","verkorte_titel":"Him seek.","omschrijving":"Glass
-      ahead despite remain live attack next. Where certainly job herself pay. American
-      perform agency easy seat. Hand back someone month himself area.","creatiedatum":"2024-02-11","registratiedatum":"2025-02-26T06:59:31.388484","laatst_gewijzigd_datum":"2025-01-31T16:24:01.267446"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"50fae005-7bb3-4b03-981c-98d60105ead8","informatie_categorieen":[{"uuid":"28ca490e-258a-4c74-9350-4bebe63110f7","naam":"More
+      general force."}],"publisher":{"uuid":"34ae4590-d1fd-4e8d-a760-b7d54773bb65","naam":"Velasquez
+      LLC"},"identifier":"identifier-7","officiele_titel":"Republican official sure.","verkorte_titel":"Value
+      light.","omschrijving":"Number rock those piece why job. Hard woman class hit
+      brother.","creatiedatum":"2024-02-11","registratiedatum":"2025-03-02T22:02:49.414089","laatst_gewijzigd_datum":"2025-02-16T10:38:18.139377"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -35,10 +34,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"e4b84630-4e5a-474c-9e10-e681cbfe1940","informatie_categorieen":[{"uuid":"05f756e9-477c-43ce-b191-7c65cd0e58ab","naam":"Become
-      crime heavy."}],"publisher":{"uuid":"1525dbcc-6c92-4b15-84e3-71aaa9d531ac","naam":"Rodriguez-Mccoy"},"identifier":"identifier-7","officiele_titel":"Prevent
-      meeting capital nature important.","verkorte_titel":"Yes allow.","omschrijving":"Investment
-      middle country suddenly law trouble.","creatiedatum":"2022-12-10","registratiedatum":"2025-02-26T16:56:57.765772","laatst_gewijzigd_datum":"2025-02-18T01:06:54.028434"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"dc5d1198-3ba9-4be0-8f1e-ec42b74a9b12","informatie_categorieen":[{"uuid":"53063bd1-1450-4261-a6d8-9a2e56122587","naam":"Role."}],"publisher":{"uuid":"dcf9c93d-5972-4b25-93e4-67b729dea53e","naam":"Abbott,
+      Sanchez and Bishop"},"identifier":"identifier-8","officiele_titel":"Physical
+      would degree line.","verkorte_titel":"Appear system rate.","omschrijving":"Agreement
+      nothing easy blue game opportunity ahead. Prepare share trouble assume radio
+      accept wait each.","creatiedatum":"2022-12-10","registratiedatum":"2025-03-02T15:13:27.757294","laatst_gewijzigd_datum":"2025-02-22T02:21:05.581204"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -68,11 +68,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"9a0d100c-02f7-4e15-ac35-a3aa0167482a","informatie_categorieen":[{"uuid":"c5be889a-6c98-467a-a078-62d84f8c6a85","naam":"Environmental
-      nor agency."}],"publisher":{"uuid":"f8ca9800-fbd8-403b-b8af-90316653a153","naam":"Meyer,
-      Matthews and Rich"},"identifier":"identifier-8","officiele_titel":"Answer age
-      daughter.","verkorte_titel":"Represent week.","omschrijving":"Would argue list
-      structure allow base. Thought book nature hotel building. Morning bar so daughter.","creatiedatum":"2025-01-14","registratiedatum":"2025-02-22T10:28:32.163828","laatst_gewijzigd_datum":"2025-02-01T19:40:29.605412"}'
+    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"01f758a3-cb8d-410b-9319-7ea7b462596b","informatie_categorieen":[{"uuid":"5c23afb2-e3ae-4cde-ba53-30aaf3006680","naam":"Drive
+      nothing."}],"publisher":{"uuid":"ca7dbeec-6f96-4a86-9807-e0830ddf3fea","naam":"Johnson,
+      Washington and Schwartz"},"identifier":"identifier-9","officiele_titel":"Power
+      change choose like.","verkorte_titel":"Save field glass.","omschrijving":"Five
+      father despite member. Future enough billion indeed magazine care. Lose strategy
+      mother hospital every guy.","creatiedatum":"2025-01-14","registratiedatum":"2025-03-03T12:58:39.439670","laatst_gewijzigd_datum":"2025-02-05T22:58:37.161366"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -102,7 +103,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":"2024-02-11","lte":null}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":"2024-02-11","lte":null}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -118,24 +119,22 @@ interactions:
     uri: http://localhost:9201/document/_search
   response:
     body:
-      string: '{"took":3,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"9a0d100c-02f7-4e15-ac35-a3aa0167482a","informatie_categorieen":[{"uuid":"c5be889a-6c98-467a-a078-62d84f8c6a85","naam":"Environmental
-        nor agency."}],"publisher":{"uuid":"f8ca9800-fbd8-403b-b8af-90316653a153","naam":"Meyer,
-        Matthews and Rich"},"identifier":"identifier-8","officiele_titel":"Answer
-        age daughter.","verkorte_titel":"Represent week.","omschrijving":"Would argue
-        list structure allow base. Thought book nature hotel building. Morning bar
-        so daughter.","creatiedatum":"2025-01-14","registratiedatum":"2025-02-22T10:28:32.163828","laatst_gewijzigd_datum":"2025-02-01T19:40:29.605412"},"sort":[0.0,1738438829605]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"edd49d5f-f72b-4dae-a1e4-18c8604158ea","informatie_categorieen":[{"uuid":"fbff896e-053a-40ee-980a-95b85d158b01","naam":"Recent
-        television recently."}],"publisher":{"uuid":"3b77a4dc-da74-4efd-ba17-b5c0448a3d45","naam":"Perry
-        Ltd"},"identifier":"identifier-6","officiele_titel":"Hit treatment structure
-        upon power different better.","verkorte_titel":"Him seek.","omschrijving":"Glass
-        ahead despite remain live attack next. Where certainly job herself pay. American
-        perform agency easy seat. Hand back someone month himself area.","creatiedatum":"2024-02-11","registratiedatum":"2025-02-26T06:59:31.388484","laatst_gewijzigd_datum":"2025-01-31T16:24:01.267446"},"sort":[0.0,1738340641267]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3b77a4dc-da74-4efd-ba17-b5c0448a3d45","Perry
-        Ltd"],"key_as_string":"3b77a4dc-da74-4efd-ba17-b5c0448a3d45|Perry Ltd","doc_count":1},{"key":["f8ca9800-fbd8-403b-b8af-90316653a153","Meyer,
-        Matthews and Rich"],"key_as_string":"f8ca9800-fbd8-403b-b8af-90316653a153|Meyer,
-        Matthews and Rich","doc_count":1}]},"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c5be889a-6c98-467a-a078-62d84f8c6a85","Environmental
-        nor agency."],"key_as_string":"c5be889a-6c98-467a-a078-62d84f8c6a85|Environmental
-        nor agency.","doc_count":1},{"key":["fbff896e-053a-40ee-980a-95b85d158b01","Recent
-        television recently."],"key_as_string":"fbff896e-053a-40ee-980a-95b85d158b01|Recent
-        television recently.","doc_count":1}]}}}}'
+      string: '{"took":18,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"50fae005-7bb3-4b03-981c-98d60105ead8","informatie_categorieen":[{"uuid":"28ca490e-258a-4c74-9350-4bebe63110f7","naam":"More
+        general force."}],"publisher":{"uuid":"34ae4590-d1fd-4e8d-a760-b7d54773bb65","naam":"Velasquez
+        LLC"},"identifier":"identifier-7","officiele_titel":"Republican official sure.","verkorte_titel":"Value
+        light.","omschrijving":"Number rock those piece why job. Hard woman class
+        hit brother.","creatiedatum":"2024-02-11","registratiedatum":"2025-03-02T22:02:49.414089","laatst_gewijzigd_datum":"2025-02-16T10:38:18.139377"},"sort":[0.0,1739702298139]},{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"01f758a3-cb8d-410b-9319-7ea7b462596b","informatie_categorieen":[{"uuid":"5c23afb2-e3ae-4cde-ba53-30aaf3006680","naam":"Drive
+        nothing."}],"publisher":{"uuid":"ca7dbeec-6f96-4a86-9807-e0830ddf3fea","naam":"Johnson,
+        Washington and Schwartz"},"identifier":"identifier-9","officiele_titel":"Power
+        change choose like.","verkorte_titel":"Save field glass.","omschrijving":"Five
+        father despite member. Future enough billion indeed magazine care. Lose strategy
+        mother hospital every guy.","creatiedatum":"2025-01-14","registratiedatum":"2025-03-03T12:58:39.439670","laatst_gewijzigd_datum":"2025-02-05T22:58:37.161366"},"sort":[0.0,1738796317161]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["34ae4590-d1fd-4e8d-a760-b7d54773bb65","Velasquez
+        LLC"],"key_as_string":"34ae4590-d1fd-4e8d-a760-b7d54773bb65|Velasquez LLC","doc_count":1},{"key":["ca7dbeec-6f96-4a86-9807-e0830ddf3fea","Johnson,
+        Washington and Schwartz"],"key_as_string":"ca7dbeec-6f96-4a86-9807-e0830ddf3fea|Johnson,
+        Washington and Schwartz","doc_count":1}]}},"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["28ca490e-258a-4c74-9350-4bebe63110f7","More
+        general force."],"key_as_string":"28ca490e-258a-4c74-9350-4bebe63110f7|More
+        general force.","doc_count":1},{"key":["5c23afb2-e3ae-4cde-ba53-30aaf3006680","Drive
+        nothing."],"key_as_string":"5c23afb2-e3ae-4cde-ba53-30aaf3006680|Drive nothing.","doc_count":1}]}}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -147,7 +146,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":null,"lte":"2022-12-10"}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":null,"lte":"2022-12-10"}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -163,12 +162,13 @@ interactions:
     uri: http://localhost:9201/document/_search
   response:
     body:
-      string: '{"took":5,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"e4b84630-4e5a-474c-9e10-e681cbfe1940","informatie_categorieen":[{"uuid":"05f756e9-477c-43ce-b191-7c65cd0e58ab","naam":"Become
-        crime heavy."}],"publisher":{"uuid":"1525dbcc-6c92-4b15-84e3-71aaa9d531ac","naam":"Rodriguez-Mccoy"},"identifier":"identifier-7","officiele_titel":"Prevent
-        meeting capital nature important.","verkorte_titel":"Yes allow.","omschrijving":"Investment
-        middle country suddenly law trouble.","creatiedatum":"2022-12-10","registratiedatum":"2025-02-26T16:56:57.765772","laatst_gewijzigd_datum":"2025-02-18T01:06:54.028434"},"sort":[0.0,1739840814028]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["1525dbcc-6c92-4b15-84e3-71aaa9d531ac","Rodriguez-Mccoy"],"key_as_string":"1525dbcc-6c92-4b15-84e3-71aaa9d531ac|Rodriguez-Mccoy","doc_count":1}]},"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["05f756e9-477c-43ce-b191-7c65cd0e58ab","Become
-        crime heavy."],"key_as_string":"05f756e9-477c-43ce-b191-7c65cd0e58ab|Become
-        crime heavy.","doc_count":1}]}}}}'
+      string: '{"took":8,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"dc5d1198-3ba9-4be0-8f1e-ec42b74a9b12","informatie_categorieen":[{"uuid":"53063bd1-1450-4261-a6d8-9a2e56122587","naam":"Role."}],"publisher":{"uuid":"dcf9c93d-5972-4b25-93e4-67b729dea53e","naam":"Abbott,
+        Sanchez and Bishop"},"identifier":"identifier-8","officiele_titel":"Physical
+        would degree line.","verkorte_titel":"Appear system rate.","omschrijving":"Agreement
+        nothing easy blue game opportunity ahead. Prepare share trouble assume radio
+        accept wait each.","creatiedatum":"2022-12-10","registratiedatum":"2025-03-02T15:13:27.757294","laatst_gewijzigd_datum":"2025-02-22T02:21:05.581204"},"sort":[0.0,1740190865581]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["dcf9c93d-5972-4b25-93e4-67b729dea53e","Abbott,
+        Sanchez and Bishop"],"key_as_string":"dcf9c93d-5972-4b25-93e4-67b729dea53e|Abbott,
+        Sanchez and Bishop","doc_count":1}]}},"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["53063bd1-1450-4261-a6d8-9a2e56122587","Role."],"key_as_string":"53063bd1-1450-4261-a6d8-9a2e56122587|Role.","doc_count":1}]}}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -180,7 +180,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":"2024-01-01","lte":"2024-12-31"}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":"2024-01-01","lte":"2024-12-31"}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -196,15 +196,14 @@ interactions:
     uri: http://localhost:9201/document/_search
   response:
     body:
-      string: '{"took":12,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"edd49d5f-f72b-4dae-a1e4-18c8604158ea","informatie_categorieen":[{"uuid":"fbff896e-053a-40ee-980a-95b85d158b01","naam":"Recent
-        television recently."}],"publisher":{"uuid":"3b77a4dc-da74-4efd-ba17-b5c0448a3d45","naam":"Perry
-        Ltd"},"identifier":"identifier-6","officiele_titel":"Hit treatment structure
-        upon power different better.","verkorte_titel":"Him seek.","omschrijving":"Glass
-        ahead despite remain live attack next. Where certainly job herself pay. American
-        perform agency easy seat. Hand back someone month himself area.","creatiedatum":"2024-02-11","registratiedatum":"2025-02-26T06:59:31.388484","laatst_gewijzigd_datum":"2025-01-31T16:24:01.267446"},"sort":[0.0,1738340641267]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3b77a4dc-da74-4efd-ba17-b5c0448a3d45","Perry
-        Ltd"],"key_as_string":"3b77a4dc-da74-4efd-ba17-b5c0448a3d45|Perry Ltd","doc_count":1}]},"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["fbff896e-053a-40ee-980a-95b85d158b01","Recent
-        television recently."],"key_as_string":"fbff896e-053a-40ee-980a-95b85d158b01|Recent
-        television recently.","doc_count":1}]}}}}'
+      string: '{"took":5,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"50fae005-7bb3-4b03-981c-98d60105ead8","informatie_categorieen":[{"uuid":"28ca490e-258a-4c74-9350-4bebe63110f7","naam":"More
+        general force."}],"publisher":{"uuid":"34ae4590-d1fd-4e8d-a760-b7d54773bb65","naam":"Velasquez
+        LLC"},"identifier":"identifier-7","officiele_titel":"Republican official sure.","verkorte_titel":"Value
+        light.","omschrijving":"Number rock those piece why job. Hard woman class
+        hit brother.","creatiedatum":"2024-02-11","registratiedatum":"2025-03-02T22:02:49.414089","laatst_gewijzigd_datum":"2025-02-16T10:38:18.139377"},"sort":[0.0,1739702298139]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["34ae4590-d1fd-4e8d-a760-b7d54773bb65","Velasquez
+        LLC"],"key_as_string":"34ae4590-d1fd-4e8d-a760-b7d54773bb65|Velasquez LLC","doc_count":1}]}},"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["28ca490e-258a-4c74-9350-4bebe63110f7","More
+        general force."],"key_as_string":"28ca490e-258a-4c74-9350-4bebe63110f7|More
+        general force.","doc_count":1}]}}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_last_modified_date.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_last_modified_date.yaml
@@ -1,10 +1,11 @@
 interactions:
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"a100aa79-ea50-4e3b-b30a-1a88c8928b2a","informatie_categorieen":[{"uuid":"15435107-72d0-4ac3-9caa-b9b2f40355dc","naam":"Long
-      remain."}],"publisher":{"uuid":"3a7084e2-55da-4857-aba6-cc0c2c0f937f","naam":"Goodwin-Smith"},"identifier":"identifier-9","officiele_titel":"Matter
-      partner total support the activity science.","verkorte_titel":"Religious study.","omschrijving":"Decision
-      serious note small leg. Focus already teacher training. Turn not investment
-      themselves best can.","creatiedatum":"2025-02-22","registratiedatum":"2025-02-26T17:01:18.907165","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"b4390a92-bc31-4c37-bed0-5a1bab08f067","informatie_categorieen":[{"uuid":"5cf09c40-ca42-4276-b59a-fb58d634bf57","naam":"Myself
+      property light."}],"publisher":{"uuid":"98438386-99d2-468b-92d6-955ed7787c01","naam":"Campos,
+      Powell and Bernard"},"identifier":"identifier-10","officiele_titel":"Meeting
+      risk heart when cause stop two rise.","verkorte_titel":"Check unit.","omschrijving":"Nothing
+      race make successful final. Focus control again two college. Body music evidence
+      piece chair tend artist. Food everything identify way role director laugh.","creatiedatum":"2025-02-25","registratiedatum":"2025-03-04T06:58:28.288822","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -34,12 +35,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"68220407-e648-4230-bd60-ad975782a6f9","informatie_categorieen":[{"uuid":"52fa12b3-091d-415a-ab76-8a658dafc04b","naam":"Out
-      writer some."}],"publisher":{"uuid":"f817ce70-6a08-49df-b63f-97651c729a68","naam":"Scott
-      and Sons"},"identifier":"identifier-10","officiele_titel":"He western quickly
-      wish.","verkorte_titel":"Believe ask.","omschrijving":"Simply moment as machine
-      physical realize act. Career discover road put. Security member hotel film.
-      Specific pretty site seven.","creatiedatum":"2025-02-17","registratiedatum":"2025-02-22T07:39:57.865579","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"db0d1430-9293-4ddf-9748-ce7714249804","informatie_categorieen":[{"uuid":"0d17de0a-377a-4cff-99d2-0b1b87503925","naam":"Couple
+      arm despite."}],"publisher":{"uuid":"11de5864-1036-483f-aa52-bf4cd68629a4","naam":"White,
+      Conley and Clay"},"identifier":"identifier-11","officiele_titel":"Rest clear
+      kind seem foot conference.","verkorte_titel":"Dog while.","omschrijving":"Southern
+      generation knowledge staff anything radio them. Something collection party all
+      candidate skin marriage. Professor probably simply I.","creatiedatum":"2025-02-10","registratiedatum":"2025-03-05T18:03:33.355959","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -69,10 +70,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"e24d3b84-54a2-40dd-b452-d10ae4e0232c","informatie_categorieen":[{"uuid":"e555008d-e752-4fb0-b90f-62785cc77279","naam":"Role
-      around range."}],"publisher":{"uuid":"6f2c646e-4c0d-4b2f-8aad-7036b911a3a6","naam":"Mathews-French"},"identifier":"identifier-11","officiele_titel":"Message
-      form heart third.","verkorte_titel":"Consumer have.","omschrijving":"Left suddenly
-      tend state subject summer order. Physical president make.","creatiedatum":"2025-02-14","registratiedatum":"2025-02-26T06:41:31.328720","laatst_gewijzigd_datum":"2025-01-14T21:12:00+00:00"}'
+    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"a47cddfd-cd2d-43f4-be57-9f802cb793e9","informatie_categorieen":[{"uuid":"4ac85187-9e16-40b8-8598-1ab5e81f02f6","naam":"Happy
+      three."}],"publisher":{"uuid":"de22454c-8311-41ab-b077-2f213e02bf68","naam":"Jones,
+      Porter and Trujillo"},"identifier":"identifier-12","officiele_titel":"Bring
+      opportunity interest form rich.","verkorte_titel":"Pay make current.","omschrijving":"Office
+      real we scene baby. Who act when break begin. Number area thought product hit.","creatiedatum":"2025-02-26","registratiedatum":"2025-03-05T02:00:20.395535","laatst_gewijzigd_datum":"2025-01-14T21:12:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -102,7 +104,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"laatst_gewijzigd_datum":{"gte":"2024-01-01T00:00:00+01:00","lt":null}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"laatst_gewijzigd_datum":{"gte":"2024-01-01T00:00:00+01:00","lt":null}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -118,17 +120,24 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"e24d3b84-54a2-40dd-b452-d10ae4e0232c","informatie_categorieen":[{"uuid":"e555008d-e752-4fb0-b90f-62785cc77279","naam":"Role
-        around range."}],"publisher":{"uuid":"6f2c646e-4c0d-4b2f-8aad-7036b911a3a6","naam":"Mathews-French"},"identifier":"identifier-11","officiele_titel":"Message
-        form heart third.","verkorte_titel":"Consumer have.","omschrijving":"Left
-        suddenly tend state subject summer order. Physical president make.","creatiedatum":"2025-02-14","registratiedatum":"2025-02-26T06:41:31.328720","laatst_gewijzigd_datum":"2025-01-14T21:12:00+00:00"},"sort":[0.0,1736889120000]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"a100aa79-ea50-4e3b-b30a-1a88c8928b2a","informatie_categorieen":[{"uuid":"15435107-72d0-4ac3-9caa-b9b2f40355dc","naam":"Long
-        remain."}],"publisher":{"uuid":"3a7084e2-55da-4857-aba6-cc0c2c0f937f","naam":"Goodwin-Smith"},"identifier":"identifier-9","officiele_titel":"Matter
-        partner total support the activity science.","verkorte_titel":"Religious study.","omschrijving":"Decision
-        serious note small leg. Focus already teacher training. Turn not investment
-        themselves best can.","creatiedatum":"2025-02-22","registratiedatum":"2025-02-26T17:01:18.907165","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["15435107-72d0-4ac3-9caa-b9b2f40355dc","Long
-        remain."],"key_as_string":"15435107-72d0-4ac3-9caa-b9b2f40355dc|Long remain.","doc_count":1},{"key":["e555008d-e752-4fb0-b90f-62785cc77279","Role
-        around range."],"key_as_string":"e555008d-e752-4fb0-b90f-62785cc77279|Role
-        around range.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3a7084e2-55da-4857-aba6-cc0c2c0f937f","Goodwin-Smith"],"key_as_string":"3a7084e2-55da-4857-aba6-cc0c2c0f937f|Goodwin-Smith","doc_count":1},{"key":["6f2c646e-4c0d-4b2f-8aad-7036b911a3a6","Mathews-French"],"key_as_string":"6f2c646e-4c0d-4b2f-8aad-7036b911a3a6|Mathews-French","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}'
+      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"a47cddfd-cd2d-43f4-be57-9f802cb793e9","informatie_categorieen":[{"uuid":"4ac85187-9e16-40b8-8598-1ab5e81f02f6","naam":"Happy
+        three."}],"publisher":{"uuid":"de22454c-8311-41ab-b077-2f213e02bf68","naam":"Jones,
+        Porter and Trujillo"},"identifier":"identifier-12","officiele_titel":"Bring
+        opportunity interest form rich.","verkorte_titel":"Pay make current.","omschrijving":"Office
+        real we scene baby. Who act when break begin. Number area thought product
+        hit.","creatiedatum":"2025-02-26","registratiedatum":"2025-03-05T02:00:20.395535","laatst_gewijzigd_datum":"2025-01-14T21:12:00+00:00"},"sort":[0.0,1736889120000]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"b4390a92-bc31-4c37-bed0-5a1bab08f067","informatie_categorieen":[{"uuid":"5cf09c40-ca42-4276-b59a-fb58d634bf57","naam":"Myself
+        property light."}],"publisher":{"uuid":"98438386-99d2-468b-92d6-955ed7787c01","naam":"Campos,
+        Powell and Bernard"},"identifier":"identifier-10","officiele_titel":"Meeting
+        risk heart when cause stop two rise.","verkorte_titel":"Check unit.","omschrijving":"Nothing
+        race make successful final. Focus control again two college. Body music evidence
+        piece chair tend artist. Food everything identify way role director laugh.","creatiedatum":"2025-02-25","registratiedatum":"2025-03-04T06:58:28.288822","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["4ac85187-9e16-40b8-8598-1ab5e81f02f6","Happy
+        three."],"key_as_string":"4ac85187-9e16-40b8-8598-1ab5e81f02f6|Happy three.","doc_count":1},{"key":["5cf09c40-ca42-4276-b59a-fb58d634bf57","Myself
+        property light."],"key_as_string":"5cf09c40-ca42-4276-b59a-fb58d634bf57|Myself
+        property light.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["98438386-99d2-468b-92d6-955ed7787c01","Campos,
+        Powell and Bernard"],"key_as_string":"98438386-99d2-468b-92d6-955ed7787c01|Campos,
+        Powell and Bernard","doc_count":1},{"key":["de22454c-8311-41ab-b077-2f213e02bf68","Jones,
+        Porter and Trujillo"],"key_as_string":"de22454c-8311-41ab-b077-2f213e02bf68|Jones,
+        Porter and Trujillo","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -140,7 +149,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"laatst_gewijzigd_datum":{"gte":null,"lt":"2022-12-31T23:59:59.999999+01:00"}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"laatst_gewijzigd_datum":{"gte":null,"lt":"2022-12-31T23:59:59.999999+01:00"}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -156,16 +165,16 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"68220407-e648-4230-bd60-ad975782a6f9","informatie_categorieen":[{"uuid":"52fa12b3-091d-415a-ab76-8a658dafc04b","naam":"Out
-        writer some."}],"publisher":{"uuid":"f817ce70-6a08-49df-b63f-97651c729a68","naam":"Scott
-        and Sons"},"identifier":"identifier-10","officiele_titel":"He western quickly
-        wish.","verkorte_titel":"Believe ask.","omschrijving":"Simply moment as machine
-        physical realize act. Career discover road put. Security member hotel film.
-        Specific pretty site seven.","creatiedatum":"2025-02-17","registratiedatum":"2025-02-22T07:39:57.865579","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"},"sort":[0.0,1670695200000]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["52fa12b3-091d-415a-ab76-8a658dafc04b","Out
-        writer some."],"key_as_string":"52fa12b3-091d-415a-ab76-8a658dafc04b|Out writer
-        some.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["f817ce70-6a08-49df-b63f-97651c729a68","Scott
-        and Sons"],"key_as_string":"f817ce70-6a08-49df-b63f-97651c729a68|Scott and
-        Sons","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
+      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"db0d1430-9293-4ddf-9748-ce7714249804","informatie_categorieen":[{"uuid":"0d17de0a-377a-4cff-99d2-0b1b87503925","naam":"Couple
+        arm despite."}],"publisher":{"uuid":"11de5864-1036-483f-aa52-bf4cd68629a4","naam":"White,
+        Conley and Clay"},"identifier":"identifier-11","officiele_titel":"Rest clear
+        kind seem foot conference.","verkorte_titel":"Dog while.","omschrijving":"Southern
+        generation knowledge staff anything radio them. Something collection party
+        all candidate skin marriage. Professor probably simply I.","creatiedatum":"2025-02-10","registratiedatum":"2025-03-05T18:03:33.355959","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"},"sort":[0.0,1670695200000]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["0d17de0a-377a-4cff-99d2-0b1b87503925","Couple
+        arm despite."],"key_as_string":"0d17de0a-377a-4cff-99d2-0b1b87503925|Couple
+        arm despite.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["11de5864-1036-483f-aa52-bf4cd68629a4","White,
+        Conley and Clay"],"key_as_string":"11de5864-1036-483f-aa52-bf4cd68629a4|White,
+        Conley and Clay","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -177,7 +186,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"laatst_gewijzigd_datum":{"gte":"2024-01-01T00:00:00+01:00","lt":"2024-12-31T23:59:59.999999+01:00"}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"laatst_gewijzigd_datum":{"gte":"2024-01-01T00:00:00+01:00","lt":"2024-12-31T23:59:59.999999+01:00"}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -193,12 +202,16 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"a100aa79-ea50-4e3b-b30a-1a88c8928b2a","informatie_categorieen":[{"uuid":"15435107-72d0-4ac3-9caa-b9b2f40355dc","naam":"Long
-        remain."}],"publisher":{"uuid":"3a7084e2-55da-4857-aba6-cc0c2c0f937f","naam":"Goodwin-Smith"},"identifier":"identifier-9","officiele_titel":"Matter
-        partner total support the activity science.","verkorte_titel":"Religious study.","omschrijving":"Decision
-        serious note small leg. Focus already teacher training. Turn not investment
-        themselves best can.","creatiedatum":"2025-02-22","registratiedatum":"2025-02-26T17:01:18.907165","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["15435107-72d0-4ac3-9caa-b9b2f40355dc","Long
-        remain."],"key_as_string":"15435107-72d0-4ac3-9caa-b9b2f40355dc|Long remain.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3a7084e2-55da-4857-aba6-cc0c2c0f937f","Goodwin-Smith"],"key_as_string":"3a7084e2-55da-4857-aba6-cc0c2c0f937f|Goodwin-Smith","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
+      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"b4390a92-bc31-4c37-bed0-5a1bab08f067","informatie_categorieen":[{"uuid":"5cf09c40-ca42-4276-b59a-fb58d634bf57","naam":"Myself
+        property light."}],"publisher":{"uuid":"98438386-99d2-468b-92d6-955ed7787c01","naam":"Campos,
+        Powell and Bernard"},"identifier":"identifier-10","officiele_titel":"Meeting
+        risk heart when cause stop two rise.","verkorte_titel":"Check unit.","omschrijving":"Nothing
+        race make successful final. Focus control again two college. Body music evidence
+        piece chair tend artist. Food everything identify way role director laugh.","creatiedatum":"2025-02-25","registratiedatum":"2025-03-04T06:58:28.288822","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["5cf09c40-ca42-4276-b59a-fb58d634bf57","Myself
+        property light."],"key_as_string":"5cf09c40-ca42-4276-b59a-fb58d634bf57|Myself
+        property light.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["98438386-99d2-468b-92d6-955ed7787c01","Campos,
+        Powell and Bernard"],"key_as_string":"98438386-99d2-468b-92d6-955ed7787c01|Campos,
+        Powell and Bernard","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_last_modified_date_both_indexes.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_last_modified_date_both_indexes.yaml
@@ -1,9 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"9832cbd6-ccc1-450e-b060-6ea947490f7e","naam":"Murphy,
-      Mccarty and Bell"},"informatie_categorieen":[{"uuid":"13c43bfd-c563-4efd-ae31-2fdee21e98f2","naam":"Listen."}],"officiele_titel":"Side
-      fire son let stock into.","verkorte_titel":"Spring chance drive.","omschrijving":"Gun
-      here coach knowledge statement move. Keep expect beat. Action wish before.","registratiedatum":"2025-02-21T17:21:21.497797","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
+    body: '{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"a36dfc40-52ce-496c-96be-21b429298797","naam":"Martinez,
+      Lopez and Mann"},"informatie_categorieen":[{"uuid":"fc923b0f-c32c-4b43-8199-88f13d0d04b0","naam":"Trouble
+      represent."}],"officiele_titel":"Glass want tell rock he reality suddenly around.","verkorte_titel":"Form.","omschrijving":"Institution
+      meeting yeah especially mind democratic direction. Pull among necessary wear
+      short son. Concern this piece world.","registratiedatum":"2025-03-05T22:49:42.853808","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,10 +34,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"de225c2e-2700-4fee-a6ea-efa276db42d4","publisher":{"uuid":"8a8ba2c8-fca0-4bb5-90a3-c35951115c3e","naam":"Fox-Carter"},"informatie_categorieen":[{"uuid":"2e78e636-76e3-4096-a4d9-9b893fec4b18","naam":"Low
-      during."}],"officiele_titel":"Hundred data another.","verkorte_titel":"Those
-      oil drop.","omschrijving":"Way newspaper news you work. End executive trade
-      wide cell to.","registratiedatum":"2025-02-24T13:01:57.069394","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
+    body: '{"uuid":"de225c2e-2700-4fee-a6ea-efa276db42d4","publisher":{"uuid":"d0d0e6c5-9874-430f-8b47-87628d687587","naam":"Carlson-Wood"},"informatie_categorieen":[{"uuid":"86f8ae93-3bd0-4451-93d9-931939f92f67","naam":"Myself
+      guy until."}],"officiele_titel":"Study rather sea process produce ago by.","verkorte_titel":"Our
+      despite.","omschrijving":"Produce human anyone fund food girl. Owner nor item
+      describe husband nice. Tend whether country drive kid newspaper.","registratiedatum":"2025-03-02T22:19:53.169442","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -66,10 +67,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"e0afe737-49a3-460c-bcc8-c2ed0ccfa822","informatie_categorieen":[{"uuid":"3f75ad19-7f8c-4683-9a70-db2f51365a14","naam":"Process
-      despite."}],"publisher":{"uuid":"80497cab-c368-4cac-8179-d3b9addd334c","naam":"Harris-Ryan"},"identifier":"identifier-12","officiele_titel":"Third
-      team want main forget stand nature take.","verkorte_titel":"Result speech.","omschrijving":"Shake
-      ever car because degree art. Than table customer wrong.","creatiedatum":"2025-01-29","registratiedatum":"2025-02-23T01:07:14.404732","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"2efa4aa6-6f90-4371-9acb-3dcf627ee277","informatie_categorieen":[{"uuid":"3a61f7f7-b1cb-4fff-8970-7d56342e9361","naam":"So."}],"publisher":{"uuid":"5e333b49-3a3d-4f72-a2a3-18ef0d13171e","naam":"Murillo,
+      Parker and Gordon"},"identifier":"identifier-13","officiele_titel":"Job animal
+      middle glass.","verkorte_titel":"Theory artist.","omschrijving":"Possible somebody
+      treat over even laugh. Raise send recently budget young.","creatiedatum":"2025-03-03","registratiedatum":"2025-03-04T20:21:36.360047","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -99,11 +100,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"c2b8bca7-f904-4d2d-b786-ac04cf72d007","informatie_categorieen":[{"uuid":"4441e6b4-868c-4ee6-9a1f-b3d1754d9f2f","naam":"Lose
-      two."}],"publisher":{"uuid":"789737b9-db3e-4288-b278-d74c2be09c60","naam":"Brown-Decker"},"identifier":"identifier-13","officiele_titel":"Personal
-      inside become good two woman.","verkorte_titel":"Among worry.","omschrijving":"Attack
-      wonder pattern modern. Church two practice teach agreement action morning. Simple
-      a voice bank hold.","creatiedatum":"2025-02-16","registratiedatum":"2025-02-24T12:20:29.995246","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"6430b811-2dce-49f7-b955-9f172b924ebd","informatie_categorieen":[{"uuid":"e892a3fe-e0f6-44f6-9f84-d1fad49fc7fa","naam":"Her
+      day."}],"publisher":{"uuid":"84c8ef13-ffa9-454b-806f-61219253f7f9","naam":"Vaughn
+      Group"},"identifier":"identifier-14","officiele_titel":"Surface also think act.","verkorte_titel":"Sister
+      budget.","omschrijving":"Ten experience reflect friend. Each bank if people
+      particular term system. Once security ask hair you.","creatiedatum":"2025-02-12","registratiedatum":"2025-03-03T23:56:57.608438","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -133,7 +134,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"laatst_gewijzigd_datum":{"gte":"2024-01-01T00:00:00+01:00","lt":"2024-12-31T23:59:59.999999+01:00"}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"laatst_gewijzigd_datum":{"gte":"2024-01-01T00:00:00+01:00","lt":"2024-12-31T23:59:59.999999+01:00"}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -149,16 +150,21 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"e0afe737-49a3-460c-bcc8-c2ed0ccfa822","informatie_categorieen":[{"uuid":"3f75ad19-7f8c-4683-9a70-db2f51365a14","naam":"Process
-        despite."}],"publisher":{"uuid":"80497cab-c368-4cac-8179-d3b9addd334c","naam":"Harris-Ryan"},"identifier":"identifier-12","officiele_titel":"Third
-        team want main forget stand nature take.","verkorte_titel":"Result speech.","omschrijving":"Shake
-        ever car because degree art. Than table customer wrong.","creatiedatum":"2025-01-29","registratiedatum":"2025-02-23T01:07:14.404732","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]},{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_score":0.0,"_source":{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"9832cbd6-ccc1-450e-b060-6ea947490f7e","naam":"Murphy,
-        Mccarty and Bell"},"informatie_categorieen":[{"uuid":"13c43bfd-c563-4efd-ae31-2fdee21e98f2","naam":"Listen."}],"officiele_titel":"Side
-        fire son let stock into.","verkorte_titel":"Spring chance drive.","omschrijving":"Gun
-        here coach knowledge statement move. Keep expect beat. Action wish before.","registratiedatum":"2025-02-21T17:21:21.497797","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["13c43bfd-c563-4efd-ae31-2fdee21e98f2","Listen."],"key_as_string":"13c43bfd-c563-4efd-ae31-2fdee21e98f2|Listen.","doc_count":1},{"key":["3f75ad19-7f8c-4683-9a70-db2f51365a14","Process
-        despite."],"key_as_string":"3f75ad19-7f8c-4683-9a70-db2f51365a14|Process despite.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["80497cab-c368-4cac-8179-d3b9addd334c","Harris-Ryan"],"key_as_string":"80497cab-c368-4cac-8179-d3b9addd334c|Harris-Ryan","doc_count":1},{"key":["9832cbd6-ccc1-450e-b060-6ea947490f7e","Murphy,
-        Mccarty and Bell"],"key_as_string":"9832cbd6-ccc1-450e-b060-6ea947490f7e|Murphy,
-        Mccarty and Bell","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"2efa4aa6-6f90-4371-9acb-3dcf627ee277","informatie_categorieen":[{"uuid":"3a61f7f7-b1cb-4fff-8970-7d56342e9361","naam":"So."}],"publisher":{"uuid":"5e333b49-3a3d-4f72-a2a3-18ef0d13171e","naam":"Murillo,
+        Parker and Gordon"},"identifier":"identifier-13","officiele_titel":"Job animal
+        middle glass.","verkorte_titel":"Theory artist.","omschrijving":"Possible
+        somebody treat over even laugh. Raise send recently budget young.","creatiedatum":"2025-03-03","registratiedatum":"2025-03-04T20:21:36.360047","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]},{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_score":0.0,"_source":{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"a36dfc40-52ce-496c-96be-21b429298797","naam":"Martinez,
+        Lopez and Mann"},"informatie_categorieen":[{"uuid":"fc923b0f-c32c-4b43-8199-88f13d0d04b0","naam":"Trouble
+        represent."}],"officiele_titel":"Glass want tell rock he reality suddenly
+        around.","verkorte_titel":"Form.","omschrijving":"Institution meeting yeah
+        especially mind democratic direction. Pull among necessary wear short son.
+        Concern this piece world.","registratiedatum":"2025-03-05T22:49:42.853808","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3a61f7f7-b1cb-4fff-8970-7d56342e9361","So."],"key_as_string":"3a61f7f7-b1cb-4fff-8970-7d56342e9361|So.","doc_count":1},{"key":["fc923b0f-c32c-4b43-8199-88f13d0d04b0","Trouble
+        represent."],"key_as_string":"fc923b0f-c32c-4b43-8199-88f13d0d04b0|Trouble
+        represent.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["5e333b49-3a3d-4f72-a2a3-18ef0d13171e","Murillo,
+        Parker and Gordon"],"key_as_string":"5e333b49-3a3d-4f72-a2a3-18ef0d13171e|Murillo,
+        Parker and Gordon","doc_count":1},{"key":["a36dfc40-52ce-496c-96be-21b429298797","Martinez,
+        Lopez and Mann"],"key_as_string":"a36dfc40-52ce-496c-96be-21b429298797|Martinez,
+        Lopez and Mann","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_registration_date.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_registration_date.yaml
@@ -1,10 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"bafbeb2d-eaf2-41ea-a301-79e61210cfe8","informatie_categorieen":[{"uuid":"0c34afb8-29e6-4a1f-b78d-3aaa08908352","naam":"System
-      almost would."}],"publisher":{"uuid":"cde5c26f-c64e-4cfa-81d2-bb31e98f3b49","naam":"Jones-Myers"},"identifier":"identifier-14","officiele_titel":"Night
-      message white enough around all thousand.","verkorte_titel":"Discussion they
-      value.","omschrijving":"May share picture industry how. Least lot happy sign
-      together himself coach wonder.","creatiedatum":"2025-01-28","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-01-30T19:27:27.881043"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"86a27400-78b5-4340-9d00-990ad25d84f7","informatie_categorieen":[{"uuid":"9c2adb76-4f40-46af-a46c-7cea7e8ab660","naam":"Important
+      standard most dark."}],"publisher":{"uuid":"c5539032-06fc-4c36-a482-98779a443179","naam":"Carpenter,
+      Moore and Richardson"},"identifier":"identifier-15","officiele_titel":"Finally
+      well ok weight student six argue.","verkorte_titel":"Happy nor.","omschrijving":"Near
+      training difference it listen individual. Time exist break analysis.","creatiedatum":"2025-02-21","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-03-04T03:31:53.447587"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -34,12 +34,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"e63a65b4-7f92-46b1-8898-06be2c86836b","informatie_categorieen":[{"uuid":"6210845c-1ef5-4ae9-a7de-34f4617011e6","naam":"Class
-      half."}],"publisher":{"uuid":"b99121c3-3ff1-4572-b5c4-ec8a20e3f011","naam":"Moore,
-      Beasley and Burke"},"identifier":"identifier-15","officiele_titel":"Marriage
-      young moment provide forward.","verkorte_titel":"Financial fund.","omschrijving":"Although
-      young unit close kind cup present after. Pretty practice us sing realize green
-      do.","creatiedatum":"2025-02-02","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-02-12T10:02:20.089827"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"5575e833-9238-46f1-a073-f0dde48684b9","informatie_categorieen":[{"uuid":"ea126bf4-d0c2-4d0d-b487-e9307f763a73","naam":"Theory
+      computer so smile."}],"publisher":{"uuid":"c4edf968-4832-47e1-891a-8e0e51436fa8","naam":"Scott-Jackson"},"identifier":"identifier-16","officiele_titel":"Away
+      her give particularly practice west inside.","verkorte_titel":"Measure subject.","omschrijving":"Beautiful
+      machine magazine girl walk only available.","creatiedatum":"2025-02-10","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-03-05T18:51:59.125425"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -69,11 +67,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"7aab192a-a2e5-48d5-b3f2-ca64c5351aba","informatie_categorieen":[{"uuid":"2710d5fb-7d13-4cb6-93fc-1032f3189f88","naam":"Turn
-      want from growth."}],"publisher":{"uuid":"53fc6289-17bc-44a3-8980-8922b9a9675c","naam":"Winters-Stark"},"identifier":"identifier-16","officiele_titel":"Bad
-      middle evening.","verkorte_titel":"Democrat indicate.","omschrijving":"Here
-      much hour that true possible kid. School another available prove gas natural.
-      Cause response up draw direction space these.","creatiedatum":"2025-02-16","registratiedatum":"2025-01-14T21:12:00+00:00","laatst_gewijzigd_datum":"2025-02-02T13:47:32.523223"}'
+    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"b527cb3d-8276-4f97-8199-1e9086457cdc","informatie_categorieen":[{"uuid":"857e0b15-b580-4a4d-a40a-d81dbb8c19dd","naam":"Tree
+      student."}],"publisher":{"uuid":"cb3112ec-41e4-4542-8e8c-d7d193f75c5f","naam":"Bernard
+      LLC"},"identifier":"identifier-17","officiele_titel":"She mission remain surface
+      consider.","verkorte_titel":"Health my democratic.","omschrijving":"Most able
+      southern goal part large direction. Strategy enjoy focus spring from.","creatiedatum":"2025-02-11","registratiedatum":"2025-01-14T21:12:00+00:00","laatst_gewijzigd_datum":"2025-02-18T03:30:05.474385"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -103,7 +101,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"registratiedatum":{"gte":"2024-01-01T00:00:00+01:00","lt":null}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"registratiedatum":{"gte":"2024-01-01T00:00:00+01:00","lt":null}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -119,19 +117,21 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"7aab192a-a2e5-48d5-b3f2-ca64c5351aba","informatie_categorieen":[{"uuid":"2710d5fb-7d13-4cb6-93fc-1032f3189f88","naam":"Turn
-        want from growth."}],"publisher":{"uuid":"53fc6289-17bc-44a3-8980-8922b9a9675c","naam":"Winters-Stark"},"identifier":"identifier-16","officiele_titel":"Bad
-        middle evening.","verkorte_titel":"Democrat indicate.","omschrijving":"Here
-        much hour that true possible kid. School another available prove gas natural.
-        Cause response up draw direction space these.","creatiedatum":"2025-02-16","registratiedatum":"2025-01-14T21:12:00+00:00","laatst_gewijzigd_datum":"2025-02-02T13:47:32.523223"},"sort":[0.0,1738504052523]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"bafbeb2d-eaf2-41ea-a301-79e61210cfe8","informatie_categorieen":[{"uuid":"0c34afb8-29e6-4a1f-b78d-3aaa08908352","naam":"System
-        almost would."}],"publisher":{"uuid":"cde5c26f-c64e-4cfa-81d2-bb31e98f3b49","naam":"Jones-Myers"},"identifier":"identifier-14","officiele_titel":"Night
-        message white enough around all thousand.","verkorte_titel":"Discussion they
-        value.","omschrijving":"May share picture industry how. Least lot happy sign
-        together himself coach wonder.","creatiedatum":"2025-01-28","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-01-30T19:27:27.881043"},"sort":[0.0,1738265247881]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["0c34afb8-29e6-4a1f-b78d-3aaa08908352","System
-        almost would."],"key_as_string":"0c34afb8-29e6-4a1f-b78d-3aaa08908352|System
-        almost would.","doc_count":1},{"key":["2710d5fb-7d13-4cb6-93fc-1032f3189f88","Turn
-        want from growth."],"key_as_string":"2710d5fb-7d13-4cb6-93fc-1032f3189f88|Turn
-        want from growth.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["53fc6289-17bc-44a3-8980-8922b9a9675c","Winters-Stark"],"key_as_string":"53fc6289-17bc-44a3-8980-8922b9a9675c|Winters-Stark","doc_count":1},{"key":["cde5c26f-c64e-4cfa-81d2-bb31e98f3b49","Jones-Myers"],"key_as_string":"cde5c26f-c64e-4cfa-81d2-bb31e98f3b49|Jones-Myers","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}'
+      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"86a27400-78b5-4340-9d00-990ad25d84f7","informatie_categorieen":[{"uuid":"9c2adb76-4f40-46af-a46c-7cea7e8ab660","naam":"Important
+        standard most dark."}],"publisher":{"uuid":"c5539032-06fc-4c36-a482-98779a443179","naam":"Carpenter,
+        Moore and Richardson"},"identifier":"identifier-15","officiele_titel":"Finally
+        well ok weight student six argue.","verkorte_titel":"Happy nor.","omschrijving":"Near
+        training difference it listen individual. Time exist break analysis.","creatiedatum":"2025-02-21","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-03-04T03:31:53.447587"},"sort":[0.0,1741059113447]},{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"b527cb3d-8276-4f97-8199-1e9086457cdc","informatie_categorieen":[{"uuid":"857e0b15-b580-4a4d-a40a-d81dbb8c19dd","naam":"Tree
+        student."}],"publisher":{"uuid":"cb3112ec-41e4-4542-8e8c-d7d193f75c5f","naam":"Bernard
+        LLC"},"identifier":"identifier-17","officiele_titel":"She mission remain surface
+        consider.","verkorte_titel":"Health my democratic.","omschrijving":"Most able
+        southern goal part large direction. Strategy enjoy focus spring from.","creatiedatum":"2025-02-11","registratiedatum":"2025-01-14T21:12:00+00:00","laatst_gewijzigd_datum":"2025-02-18T03:30:05.474385"},"sort":[0.0,1739849405474]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["857e0b15-b580-4a4d-a40a-d81dbb8c19dd","Tree
+        student."],"key_as_string":"857e0b15-b580-4a4d-a40a-d81dbb8c19dd|Tree student.","doc_count":1},{"key":["9c2adb76-4f40-46af-a46c-7cea7e8ab660","Important
+        standard most dark."],"key_as_string":"9c2adb76-4f40-46af-a46c-7cea7e8ab660|Important
+        standard most dark.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c5539032-06fc-4c36-a482-98779a443179","Carpenter,
+        Moore and Richardson"],"key_as_string":"c5539032-06fc-4c36-a482-98779a443179|Carpenter,
+        Moore and Richardson","doc_count":1},{"key":["cb3112ec-41e4-4542-8e8c-d7d193f75c5f","Bernard
+        LLC"],"key_as_string":"cb3112ec-41e4-4542-8e8c-d7d193f75c5f|Bernard LLC","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -143,7 +143,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"registratiedatum":{"gte":null,"lt":"2022-12-31T23:59:59.999999+01:00"}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"registratiedatum":{"gte":null,"lt":"2022-12-31T23:59:59.999999+01:00"}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -159,15 +159,12 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"e63a65b4-7f92-46b1-8898-06be2c86836b","informatie_categorieen":[{"uuid":"6210845c-1ef5-4ae9-a7de-34f4617011e6","naam":"Class
-        half."}],"publisher":{"uuid":"b99121c3-3ff1-4572-b5c4-ec8a20e3f011","naam":"Moore,
-        Beasley and Burke"},"identifier":"identifier-15","officiele_titel":"Marriage
-        young moment provide forward.","verkorte_titel":"Financial fund.","omschrijving":"Although
-        young unit close kind cup present after. Pretty practice us sing realize green
-        do.","creatiedatum":"2025-02-02","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-02-12T10:02:20.089827"},"sort":[0.0,1739354540089]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["6210845c-1ef5-4ae9-a7de-34f4617011e6","Class
-        half."],"key_as_string":"6210845c-1ef5-4ae9-a7de-34f4617011e6|Class half.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["b99121c3-3ff1-4572-b5c4-ec8a20e3f011","Moore,
-        Beasley and Burke"],"key_as_string":"b99121c3-3ff1-4572-b5c4-ec8a20e3f011|Moore,
-        Beasley and Burke","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
+      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"5575e833-9238-46f1-a073-f0dde48684b9","informatie_categorieen":[{"uuid":"ea126bf4-d0c2-4d0d-b487-e9307f763a73","naam":"Theory
+        computer so smile."}],"publisher":{"uuid":"c4edf968-4832-47e1-891a-8e0e51436fa8","naam":"Scott-Jackson"},"identifier":"identifier-16","officiele_titel":"Away
+        her give particularly practice west inside.","verkorte_titel":"Measure subject.","omschrijving":"Beautiful
+        machine magazine girl walk only available.","creatiedatum":"2025-02-10","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-03-05T18:51:59.125425"},"sort":[0.0,1741200719125]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["ea126bf4-d0c2-4d0d-b487-e9307f763a73","Theory
+        computer so smile."],"key_as_string":"ea126bf4-d0c2-4d0d-b487-e9307f763a73|Theory
+        computer so smile.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c4edf968-4832-47e1-891a-8e0e51436fa8","Scott-Jackson"],"key_as_string":"c4edf968-4832-47e1-891a-8e0e51436fa8|Scott-Jackson","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -179,7 +176,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"registratiedatum":{"gte":"2024-01-01T00:00:00+01:00","lt":"2024-12-31T23:59:59.999999+01:00"}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"registratiedatum":{"gte":"2024-01-01T00:00:00+01:00","lt":"2024-12-31T23:59:59.999999+01:00"}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -195,13 +192,15 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"bafbeb2d-eaf2-41ea-a301-79e61210cfe8","informatie_categorieen":[{"uuid":"0c34afb8-29e6-4a1f-b78d-3aaa08908352","naam":"System
-        almost would."}],"publisher":{"uuid":"cde5c26f-c64e-4cfa-81d2-bb31e98f3b49","naam":"Jones-Myers"},"identifier":"identifier-14","officiele_titel":"Night
-        message white enough around all thousand.","verkorte_titel":"Discussion they
-        value.","omschrijving":"May share picture industry how. Least lot happy sign
-        together himself coach wonder.","creatiedatum":"2025-01-28","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-01-30T19:27:27.881043"},"sort":[0.0,1738265247881]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["0c34afb8-29e6-4a1f-b78d-3aaa08908352","System
-        almost would."],"key_as_string":"0c34afb8-29e6-4a1f-b78d-3aaa08908352|System
-        almost would.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["cde5c26f-c64e-4cfa-81d2-bb31e98f3b49","Jones-Myers"],"key_as_string":"cde5c26f-c64e-4cfa-81d2-bb31e98f3b49|Jones-Myers","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
+      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"86a27400-78b5-4340-9d00-990ad25d84f7","informatie_categorieen":[{"uuid":"9c2adb76-4f40-46af-a46c-7cea7e8ab660","naam":"Important
+        standard most dark."}],"publisher":{"uuid":"c5539032-06fc-4c36-a482-98779a443179","naam":"Carpenter,
+        Moore and Richardson"},"identifier":"identifier-15","officiele_titel":"Finally
+        well ok weight student six argue.","verkorte_titel":"Happy nor.","omschrijving":"Near
+        training difference it listen individual. Time exist break analysis.","creatiedatum":"2025-02-21","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-03-04T03:31:53.447587"},"sort":[0.0,1741059113447]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["9c2adb76-4f40-46af-a46c-7cea7e8ab660","Important
+        standard most dark."],"key_as_string":"9c2adb76-4f40-46af-a46c-7cea7e8ab660|Important
+        standard most dark.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c5539032-06fc-4c36-a482-98779a443179","Carpenter,
+        Moore and Richardson"],"key_as_string":"c5539032-06fc-4c36-a482-98779a443179|Carpenter,
+        Moore and Richardson","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_registration_date_both_indexes.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_filter_on_registration_date_both_indexes.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"9fd09f6e-ce72-4f4b-95d9-c599ba732862","naam":"Williams,
-      Casey and Sullivan"},"informatie_categorieen":[{"uuid":"35411965-c9a6-4594-91c1-de46246327c5","naam":"For
-      yet suggest."}],"officiele_titel":"Provide last call boy spend ability upon.","verkorte_titel":"Street
-      tree.","omschrijving":"Term land run watch. Glass lawyer away them push wear.","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-05T22:41:07.470293"}'
+    body: '{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"c0e5e9af-d670-4fa4-a133-a777282dcc60","naam":"Brown-Flowers"},"informatie_categorieen":[{"uuid":"38acf5ac-ea10-491a-b75f-65a503ef4d17","naam":"Success
+      model possible."}],"officiele_titel":"Ever evening management.","verkorte_titel":"Why
+      near.","omschrijving":"Quite its that maybe foot. Make respond hundred accept
+      without my. Simple knowledge read design remain central son.","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-12T12:17:44.542970"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,11 +33,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"de225c2e-2700-4fee-a6ea-efa276db42d4","publisher":{"uuid":"230ebd52-f4a1-4e9b-8f5e-ea4fda13099e","naam":"Perry,
-      Ray and Butler"},"informatie_categorieen":[{"uuid":"633ca134-577c-44ab-9d3c-45d8d6d95544","naam":"Somebody
-      beat development."}],"officiele_titel":"Weight say read carry.","verkorte_titel":"Action
-      theory for.","omschrijving":"Little dog war practice forget. Name evening tend
-      campaign five.","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-02-05T14:53:31.963485"}'
+    body: '{"uuid":"de225c2e-2700-4fee-a6ea-efa276db42d4","publisher":{"uuid":"a3a3ce19-3628-4b7a-a8ab-7343990c1663","naam":"Noble-Blair"},"informatie_categorieen":[{"uuid":"7613e215-ee60-45ab-862d-1d699f930eaf","naam":"Might
+      community."}],"officiele_titel":"Word no vote think unit instead base.","verkorte_titel":"Enter
+      idea go.","omschrijving":"Significant probably us fact teacher perhaps. Answer
+      radio yes conference subject budget. Feeling rock role about model several hear.","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-03-04T05:51:53.385151"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -67,10 +66,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"9eab7a74-efb4-4066-ae97-e7ea0ddfc41a","informatie_categorieen":[{"uuid":"3985f332-3fa9-48a4-be3a-4b4cadc28e6d","naam":"Lawyer
-      too."}],"publisher":{"uuid":"6c5dc64f-7e0d-47d8-bfcb-ba7f03538d15","naam":"Cook-Francis"},"identifier":"identifier-17","officiele_titel":"Head
-      help particularly.","verkorte_titel":"Decade hospital.","omschrijving":"Under
-      trade cause enough other although. Evening however detail high.","creatiedatum":"2025-02-24","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-22T02:07:58.802931"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"5674bfef-35ff-42b5-80c6-970f9e8f6445","informatie_categorieen":[{"uuid":"f30e4447-91a7-448c-a264-520b0a26a296","naam":"To
+      single."}],"publisher":{"uuid":"82ae2704-2792-4588-9c3a-490c0727a4af","naam":"Cohen,
+      Barber and Moore"},"identifier":"identifier-18","officiele_titel":"Reach someone
+      create change picture.","verkorte_titel":"Watch from above.","omschrijving":"Of
+      fast together whether manage should toward. Visit result report international
+      series look. Claim commercial husband good health in everything.","creatiedatum":"2025-02-23","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-25T07:26:23.522321"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -100,10 +101,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"10334dc8-43d6-4e3d-bb99-fe3ef42fa414","informatie_categorieen":[{"uuid":"66a91629-42d2-482f-af2e-40f52941f4b6","naam":"There
-      against."}],"publisher":{"uuid":"f04a6379-a758-4af3-b173-268edda366fa","naam":"Castillo-Jackson"},"identifier":"identifier-18","officiele_titel":"Whom
-      on career against senior home act.","verkorte_titel":"Drop wide eye.","omschrijving":"Hope
-      owner indeed offer. Few become camera value although.","creatiedatum":"2025-02-06","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-02-17T17:38:25.376275"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"ee365a87-8158-469b-8f14-35b0aea7344e","informatie_categorieen":[{"uuid":"d975f932-9aff-4db1-a790-59babf47ddd9","naam":"Pay
+      wear."}],"publisher":{"uuid":"2aa4b1f0-2c21-4019-971a-ffe6a2a42205","naam":"Page-Good"},"identifier":"identifier-19","officiele_titel":"Plan
+      trial eat former task door.","verkorte_titel":"Affect policy between.","omschrijving":"Left
+      family interview something deep father. Foreign while clearly black such step.
+      Stock dinner spend without high third.","creatiedatum":"2025-03-03","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-02-05T05:04:05.477752"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -133,7 +135,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"registratiedatum":{"gte":"2024-01-01T00:00:00+01:00","lt":"2024-12-31T23:59:59.999999+01:00"}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"registratiedatum":{"gte":"2024-01-01T00:00:00+01:00","lt":"2024-12-31T23:59:59.999999+01:00"}}}]}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -149,18 +151,20 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"9eab7a74-efb4-4066-ae97-e7ea0ddfc41a","informatie_categorieen":[{"uuid":"3985f332-3fa9-48a4-be3a-4b4cadc28e6d","naam":"Lawyer
-        too."}],"publisher":{"uuid":"6c5dc64f-7e0d-47d8-bfcb-ba7f03538d15","naam":"Cook-Francis"},"identifier":"identifier-17","officiele_titel":"Head
-        help particularly.","verkorte_titel":"Decade hospital.","omschrijving":"Under
-        trade cause enough other although. Evening however detail high.","creatiedatum":"2025-02-24","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-22T02:07:58.802931"},"sort":[0.0,1740190078802]},{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_score":0.0,"_source":{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"9fd09f6e-ce72-4f4b-95d9-c599ba732862","naam":"Williams,
-        Casey and Sullivan"},"informatie_categorieen":[{"uuid":"35411965-c9a6-4594-91c1-de46246327c5","naam":"For
-        yet suggest."}],"officiele_titel":"Provide last call boy spend ability upon.","verkorte_titel":"Street
-        tree.","omschrijving":"Term land run watch. Glass lawyer away them push wear.","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-05T22:41:07.470293"},"sort":[0.0,1738795267470]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["35411965-c9a6-4594-91c1-de46246327c5","For
-        yet suggest."],"key_as_string":"35411965-c9a6-4594-91c1-de46246327c5|For yet
-        suggest.","doc_count":1},{"key":["3985f332-3fa9-48a4-be3a-4b4cadc28e6d","Lawyer
-        too."],"key_as_string":"3985f332-3fa9-48a4-be3a-4b4cadc28e6d|Lawyer too.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["6c5dc64f-7e0d-47d8-bfcb-ba7f03538d15","Cook-Francis"],"key_as_string":"6c5dc64f-7e0d-47d8-bfcb-ba7f03538d15|Cook-Francis","doc_count":1},{"key":["9fd09f6e-ce72-4f4b-95d9-c599ba732862","Williams,
-        Casey and Sullivan"],"key_as_string":"9fd09f6e-ce72-4f4b-95d9-c599ba732862|Williams,
-        Casey and Sullivan","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"5674bfef-35ff-42b5-80c6-970f9e8f6445","informatie_categorieen":[{"uuid":"f30e4447-91a7-448c-a264-520b0a26a296","naam":"To
+        single."}],"publisher":{"uuid":"82ae2704-2792-4588-9c3a-490c0727a4af","naam":"Cohen,
+        Barber and Moore"},"identifier":"identifier-18","officiele_titel":"Reach someone
+        create change picture.","verkorte_titel":"Watch from above.","omschrijving":"Of
+        fast together whether manage should toward. Visit result report international
+        series look. Claim commercial husband good health in everything.","creatiedatum":"2025-02-23","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-25T07:26:23.522321"},"sort":[0.0,1740468383522]},{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_score":0.0,"_source":{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"c0e5e9af-d670-4fa4-a133-a777282dcc60","naam":"Brown-Flowers"},"informatie_categorieen":[{"uuid":"38acf5ac-ea10-491a-b75f-65a503ef4d17","naam":"Success
+        model possible."}],"officiele_titel":"Ever evening management.","verkorte_titel":"Why
+        near.","omschrijving":"Quite its that maybe foot. Make respond hundred accept
+        without my. Simple knowledge read design remain central son.","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-12T12:17:44.542970"},"sort":[0.0,1739362664542]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["38acf5ac-ea10-491a-b75f-65a503ef4d17","Success
+        model possible."],"key_as_string":"38acf5ac-ea10-491a-b75f-65a503ef4d17|Success
+        model possible.","doc_count":1},{"key":["f30e4447-91a7-448c-a264-520b0a26a296","To
+        single."],"key_as_string":"f30e4447-91a7-448c-a264-520b0a26a296|To single.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["82ae2704-2792-4588-9c3a-490c0727a4af","Cohen,
+        Barber and Moore"],"key_as_string":"82ae2704-2792-4588-9c3a-490c0727a4af|Cohen,
+        Barber and Moore","doc_count":1},{"key":["c0e5e9af-d670-4fa4-a133-a777282dcc60","Brown-Flowers"],"key_as_string":"c0e5e9af-d670-4fa4-a133-a777282dcc60|Brown-Flowers","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_no_body.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_no_body.yaml
@@ -1,11 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"724daeaf-307f-45d5-b34e-f05eb9a49b2c","naam":"White,
-      Williams and Davis"},"informatie_categorieen":[{"uuid":"6c90374e-b9f5-48e3-8859-5cdeb7f388a1","naam":"Feeling
-      everybody knowledge."}],"officiele_titel":"Hard when rate plan usually through
-      color.","verkorte_titel":"Use rule.","omschrijving":"Involve smile development
-      tax pull. Executive kitchen report behavior involve from do. None audience choose
-      although.","registratiedatum":"2025-02-26T13:34:17.115834","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2958f200-4f2d-4d8d-9e20-2c18257f7ce7","naam":"Best,
+      Silva and Jimenez"},"informatie_categorieen":[{"uuid":"d36426dc-d6b2-44b2-bc33-fe9c39990353","naam":"Key
+      computer court."}],"officiele_titel":"Forget week tell address evidence make.","verkorte_titel":"Young.","omschrijving":"Relate
+      suddenly throw democratic. Real difference interesting. Our ever pass century
+      sign everything network identify.","registratiedatum":"2025-03-03T12:48:36.682922","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -35,11 +34,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publicatie":"263a21ff-4d09-443d-8104-b459c3160bfc","informatie_categorieen":[{"uuid":"c567bac6-2a0c-4f88-8893-689913fc7df6","naam":"Eight
-      west leader."}],"publisher":{"uuid":"2e03c948-53e4-44ca-8d16-5204caf079b4","naam":"Weaver
-      LLC"},"identifier":"identifier-19","officiele_titel":"Success quickly discussion.","verkorte_titel":"Nation
-      with section certainly.","omschrijving":"Open push simple speech move their
-      suddenly. Wind difficult everything word responsibility total.","creatiedatum":"2025-02-07","registratiedatum":"2025-02-25T09:34:12.963872","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publicatie":"bfe85290-c23c-43cf-bba0-a691ab05f7e1","informatie_categorieen":[{"uuid":"f2c7ce40-466a-4448-984e-57348cbf99fe","naam":"Line."}],"publisher":{"uuid":"b05786e7-68e0-4828-948f-b9a7d4281ee7","naam":"Gibbs
+      PLC"},"identifier":"identifier-20","officiele_titel":"Research around second
+      agent stay age.","verkorte_titel":"Often another law.","omschrijving":"Experience
+      want social remember money question grow. Bar foreign full garden law its involve.
+      Popular challenge window just final really.","creatiedatum":"2025-02-25","registratiedatum":"2025-03-06T05:14:49.389646","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -69,7 +68,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -85,23 +84,20 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","_score":2.0,"_source":{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"724daeaf-307f-45d5-b34e-f05eb9a49b2c","naam":"White,
-        Williams and Davis"},"informatie_categorieen":[{"uuid":"6c90374e-b9f5-48e3-8859-5cdeb7f388a1","naam":"Feeling
-        everybody knowledge."}],"officiele_titel":"Hard when rate plan usually through
-        color.","verkorte_titel":"Use rule.","omschrijving":"Involve smile development
-        tax pull. Executive kitchen report behavior involve from do. None audience
-        choose although.","registratiedatum":"2025-02-26T13:34:17.115834","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[2.0,1767614400000]},{"_index":"document","_id":"525747fd-7e58-4005-8efa-59bcf4403385","_score":1.0,"_source":{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publicatie":"263a21ff-4d09-443d-8104-b459c3160bfc","informatie_categorieen":[{"uuid":"c567bac6-2a0c-4f88-8893-689913fc7df6","naam":"Eight
-        west leader."}],"publisher":{"uuid":"2e03c948-53e4-44ca-8d16-5204caf079b4","naam":"Weaver
-        LLC"},"identifier":"identifier-19","officiele_titel":"Success quickly discussion.","verkorte_titel":"Nation
-        with section certainly.","omschrijving":"Open push simple speech move their
-        suddenly. Wind difficult everything word responsibility total.","creatiedatum":"2025-02-07","registratiedatum":"2025-02-25T09:34:12.963872","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["6c90374e-b9f5-48e3-8859-5cdeb7f388a1","Feeling
-        everybody knowledge."],"key_as_string":"6c90374e-b9f5-48e3-8859-5cdeb7f388a1|Feeling
-        everybody knowledge.","doc_count":1},{"key":["c567bac6-2a0c-4f88-8893-689913fc7df6","Eight
-        west leader."],"key_as_string":"c567bac6-2a0c-4f88-8893-689913fc7df6|Eight
-        west leader.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2e03c948-53e4-44ca-8d16-5204caf079b4","Weaver
-        LLC"],"key_as_string":"2e03c948-53e4-44ca-8d16-5204caf079b4|Weaver LLC","doc_count":1},{"key":["724daeaf-307f-45d5-b34e-f05eb9a49b2c","White,
-        Williams and Davis"],"key_as_string":"724daeaf-307f-45d5-b34e-f05eb9a49b2c|White,
-        Williams and Davis","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","_score":2.0,"_source":{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"2958f200-4f2d-4d8d-9e20-2c18257f7ce7","naam":"Best,
+        Silva and Jimenez"},"informatie_categorieen":[{"uuid":"d36426dc-d6b2-44b2-bc33-fe9c39990353","naam":"Key
+        computer court."}],"officiele_titel":"Forget week tell address evidence make.","verkorte_titel":"Young.","omschrijving":"Relate
+        suddenly throw democratic. Real difference interesting. Our ever pass century
+        sign everything network identify.","registratiedatum":"2025-03-03T12:48:36.682922","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[2.0,1767614400000]},{"_index":"document","_id":"525747fd-7e58-4005-8efa-59bcf4403385","_score":1.0,"_source":{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publicatie":"bfe85290-c23c-43cf-bba0-a691ab05f7e1","informatie_categorieen":[{"uuid":"f2c7ce40-466a-4448-984e-57348cbf99fe","naam":"Line."}],"publisher":{"uuid":"b05786e7-68e0-4828-948f-b9a7d4281ee7","naam":"Gibbs
+        PLC"},"identifier":"identifier-20","officiele_titel":"Research around second
+        agent stay age.","verkorte_titel":"Often another law.","omschrijving":"Experience
+        want social remember money question grow. Bar foreign full garden law its
+        involve. Popular challenge window just final really.","creatiedatum":"2025-02-25","registratiedatum":"2025-03-06T05:14:49.389646","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["d36426dc-d6b2-44b2-bc33-fe9c39990353","Key
+        computer court."],"key_as_string":"d36426dc-d6b2-44b2-bc33-fe9c39990353|Key
+        computer court.","doc_count":1},{"key":["f2c7ce40-466a-4448-984e-57348cbf99fe","Line."],"key_as_string":"f2c7ce40-466a-4448-984e-57348cbf99fe|Line.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2958f200-4f2d-4d8d-9e20-2c18257f7ce7","Best,
+        Silva and Jimenez"],"key_as_string":"2958f200-4f2d-4d8d-9e20-2c18257f7ce7|Best,
+        Silva and Jimenez","doc_count":1},{"key":["b05786e7-68e0-4828-948f-b9a7d4281ee7","Gibbs
+        PLC"],"key_as_string":"b05786e7-68e0-4828-948f-b9a7d4281ee7|Gibbs PLC","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_pagination_next_and_page_size.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_pagination_next_and_page_size.yaml
@@ -1,8 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"1aa78d62-0cc7-4273-86b4-8c6bf4f28a98","publisher":{"uuid":"d44df14e-c115-48f2-b19c-0ca5ae25855a","naam":"Garrett-Rodriguez"},"informatie_categorieen":[{"uuid":"fa8dbf1f-8ff0-48fb-8f89-70d4cd7061d7","naam":"Owner
-      gun."}],"officiele_titel":"Mission never interesting.","verkorte_titel":"Many
-      table.","omschrijving":"Behavior read project less expert result probably.","registratiedatum":"2025-02-24T14:15:14.492254","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"1aa78d62-0cc7-4273-86b4-8c6bf4f28a98","publisher":{"uuid":"fef25042-94a8-4fac-957c-74d3accbfc0e","naam":"Hart
+      Ltd"},"informatie_categorieen":[{"uuid":"5bd81508-2bd2-43bb-b186-7e486714f581","naam":"Outside
+      notice movie."}],"officiele_titel":"Down camera newspaper instead site certainly.","verkorte_titel":"Per.","omschrijving":"Since
+      respond short name. Stage reflect front response by ten. Among score upon knowledge
+      various whole event. That project success friend his computer value one.","registratiedatum":"2025-03-03T03:17:06.370644","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -32,10 +34,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"85a095ea-e1fa-438c-9e05-1862874f57a0","publicatie":"35bcf277-b5a2-42ad-9a35-fa951667497e","informatie_categorieen":[{"uuid":"ec65e0df-a83a-4704-abca-2c33195b7c68","naam":"Rich
-      along through."}],"publisher":{"uuid":"1ba370fc-7a22-4c7c-aa9d-6d0f60eabce9","naam":"Todd-Foster"},"identifier":"identifier-20","officiele_titel":"Page
-      quality detail across draw message hear.","verkorte_titel":"Something alone.","omschrijving":"Service
-      mind rate region. Agency where build property responsibility itself early.","creatiedatum":"2025-02-15","registratiedatum":"2025-02-26T11:43:53.285750","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"85a095ea-e1fa-438c-9e05-1862874f57a0","publicatie":"48a2e4bf-e1a0-4576-82a5-8bc905db275a","informatie_categorieen":[{"uuid":"777186a1-dc30-4cd1-9313-61ecf644d916","naam":"Measure."}],"publisher":{"uuid":"9366a89a-2c30-474a-9a42-7c79e4a72d8d","naam":"Robinson-Roman"},"identifier":"identifier-21","officiele_titel":"Fire
+      present fall physical use difficult.","verkorte_titel":"Thank compare impact
+      structure.","omschrijving":"Face ready teacher tax new tree total. Near suffer
+      change drop clearly when material.","creatiedatum":"2025-02-08","registratiedatum":"2025-03-03T08:48:52.162482","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -65,7 +67,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":1}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":1}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -81,12 +83,15 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"1aa78d62-0cc7-4273-86b4-8c6bf4f28a98","_score":2.0,"_source":{"uuid":"1aa78d62-0cc7-4273-86b4-8c6bf4f28a98","publisher":{"uuid":"d44df14e-c115-48f2-b19c-0ca5ae25855a","naam":"Garrett-Rodriguez"},"informatie_categorieen":[{"uuid":"fa8dbf1f-8ff0-48fb-8f89-70d4cd7061d7","naam":"Owner
-        gun."}],"officiele_titel":"Mission never interesting.","verkorte_titel":"Many
-        table.","omschrijving":"Behavior read project less expert result probably.","registratiedatum":"2025-02-24T14:15:14.492254","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[2.0,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["ec65e0df-a83a-4704-abca-2c33195b7c68","Rich
-        along through."],"key_as_string":"ec65e0df-a83a-4704-abca-2c33195b7c68|Rich
-        along through.","doc_count":1},{"key":["fa8dbf1f-8ff0-48fb-8f89-70d4cd7061d7","Owner
-        gun."],"key_as_string":"fa8dbf1f-8ff0-48fb-8f89-70d4cd7061d7|Owner gun.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["1ba370fc-7a22-4c7c-aa9d-6d0f60eabce9","Todd-Foster"],"key_as_string":"1ba370fc-7a22-4c7c-aa9d-6d0f60eabce9|Todd-Foster","doc_count":1},{"key":["d44df14e-c115-48f2-b19c-0ca5ae25855a","Garrett-Rodriguez"],"key_as_string":"d44df14e-c115-48f2-b19c-0ca5ae25855a|Garrett-Rodriguez","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"1aa78d62-0cc7-4273-86b4-8c6bf4f28a98","_score":2.0,"_source":{"uuid":"1aa78d62-0cc7-4273-86b4-8c6bf4f28a98","publisher":{"uuid":"fef25042-94a8-4fac-957c-74d3accbfc0e","naam":"Hart
+        Ltd"},"informatie_categorieen":[{"uuid":"5bd81508-2bd2-43bb-b186-7e486714f581","naam":"Outside
+        notice movie."}],"officiele_titel":"Down camera newspaper instead site certainly.","verkorte_titel":"Per.","omschrijving":"Since
+        respond short name. Stage reflect front response by ten. Among score upon
+        knowledge various whole event. That project success friend his computer value
+        one.","registratiedatum":"2025-03-03T03:17:06.370644","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[2.0,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["5bd81508-2bd2-43bb-b186-7e486714f581","Outside
+        notice movie."],"key_as_string":"5bd81508-2bd2-43bb-b186-7e486714f581|Outside
+        notice movie.","doc_count":1},{"key":["777186a1-dc30-4cd1-9313-61ecf644d916","Measure."],"key_as_string":"777186a1-dc30-4cd1-9313-61ecf644d916|Measure.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["9366a89a-2c30-474a-9a42-7c79e4a72d8d","Robinson-Roman"],"key_as_string":"9366a89a-2c30-474a-9a42-7c79e4a72d8d|Robinson-Roman","doc_count":1},{"key":["fef25042-94a8-4fac-957c-74d3accbfc0e","Hart
+        Ltd"],"key_as_string":"fef25042-94a8-4fac-957c-74d3accbfc0e|Hart Ltd","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_pagination_previous.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_pagination_previous.yaml
@@ -1,9 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"80485d67-0b97-4ed5-8483-f2d03d012e19","publisher":{"uuid":"c52e5a61-ea5f-46cf-931f-1d244b0f9ed5","naam":"Ward-Taylor"},"informatie_categorieen":[{"uuid":"986e832b-c130-4cb4-b92d-4c89511815a5","naam":"Everybody
-      account hot."}],"officiele_titel":"Somebody teacher power market live.","verkorte_titel":"Become
-      despite up.","omschrijving":"Visit quite away six stock. Husband positive person
-      believe fly happy hair. Establish traditional policy different learn five firm.","registratiedatum":"2025-02-24T00:42:49.096397","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"80485d67-0b97-4ed5-8483-f2d03d012e19","publisher":{"uuid":"271dbc78-282d-40a9-909c-f2373bf27c38","naam":"Banks,
+      Burns and Jones"},"informatie_categorieen":[{"uuid":"e16c9f33-6588-4446-9a0a-064f3508f055","naam":"Cover
+      population."}],"officiele_titel":"Western possible talk foot every mind detail.","verkorte_titel":"Market
+      prevent night easy.","omschrijving":"Leader bed voice describe modern like simple
+      early. Almost increase argue.","registratiedatum":"2025-03-04T10:46:28.285018","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,10 +34,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"48981334-b480-4e7d-8c8d-925bbc67a969","publicatie":"8a2a0c03-8374-455f-8310-426c5b668ff6","informatie_categorieen":[{"uuid":"fe668288-ede7-4f14-9d9e-8d5ad8a9e0be","naam":"Floor
-      top."}],"publisher":{"uuid":"3f741147-fe62-4929-86b4-c0410c13aa56","naam":"Harris-Baker"},"identifier":"identifier-21","officiele_titel":"Top
-      level determine physical note though gun.","verkorte_titel":"Stay everybody.","omschrijving":"Media
-      down vote carry view sell. Amount establish direction question during kitchen.","creatiedatum":"2025-02-20","registratiedatum":"2025-02-23T01:36:52.953730","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"48981334-b480-4e7d-8c8d-925bbc67a969","publicatie":"7e13a76e-b7b3-4ca8-b7d8-625e8afda784","informatie_categorieen":[{"uuid":"f58a2843-2da2-4e32-87cb-7bb37830069f","naam":"Bit
+      business."}],"publisher":{"uuid":"ab518e9a-7cdc-4b1c-a190-2072abe3091b","naam":"Ramirez
+      Ltd"},"identifier":"identifier-22","officiele_titel":"Exist discover cultural
+      service box.","verkorte_titel":"Feeling strategy significant.","omschrijving":"Difference
+      group another simply.","creatiedatum":"2025-02-05","registratiedatum":"2025-03-02T20:51:27.599242","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -66,7 +68,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":1,"size":1}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":1,"size":1}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -82,13 +84,17 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"48981334-b480-4e7d-8c8d-925bbc67a969","_score":1.0,"_source":{"uuid":"48981334-b480-4e7d-8c8d-925bbc67a969","publicatie":"8a2a0c03-8374-455f-8310-426c5b668ff6","informatie_categorieen":[{"uuid":"fe668288-ede7-4f14-9d9e-8d5ad8a9e0be","naam":"Floor
-        top."}],"publisher":{"uuid":"3f741147-fe62-4929-86b4-c0410c13aa56","naam":"Harris-Baker"},"identifier":"identifier-21","officiele_titel":"Top
-        level determine physical note though gun.","verkorte_titel":"Stay everybody.","omschrijving":"Media
-        down vote carry view sell. Amount establish direction question during kitchen.","creatiedatum":"2025-02-20","registratiedatum":"2025-02-23T01:36:52.953730","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["986e832b-c130-4cb4-b92d-4c89511815a5","Everybody
-        account hot."],"key_as_string":"986e832b-c130-4cb4-b92d-4c89511815a5|Everybody
-        account hot.","doc_count":1},{"key":["fe668288-ede7-4f14-9d9e-8d5ad8a9e0be","Floor
-        top."],"key_as_string":"fe668288-ede7-4f14-9d9e-8d5ad8a9e0be|Floor top.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3f741147-fe62-4929-86b4-c0410c13aa56","Harris-Baker"],"key_as_string":"3f741147-fe62-4929-86b4-c0410c13aa56|Harris-Baker","doc_count":1},{"key":["c52e5a61-ea5f-46cf-931f-1d244b0f9ed5","Ward-Taylor"],"key_as_string":"c52e5a61-ea5f-46cf-931f-1d244b0f9ed5|Ward-Taylor","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"48981334-b480-4e7d-8c8d-925bbc67a969","_score":1.0,"_source":{"uuid":"48981334-b480-4e7d-8c8d-925bbc67a969","publicatie":"7e13a76e-b7b3-4ca8-b7d8-625e8afda784","informatie_categorieen":[{"uuid":"f58a2843-2da2-4e32-87cb-7bb37830069f","naam":"Bit
+        business."}],"publisher":{"uuid":"ab518e9a-7cdc-4b1c-a190-2072abe3091b","naam":"Ramirez
+        Ltd"},"identifier":"identifier-22","officiele_titel":"Exist discover cultural
+        service box.","verkorte_titel":"Feeling strategy significant.","omschrijving":"Difference
+        group another simply.","creatiedatum":"2025-02-05","registratiedatum":"2025-03-02T20:51:27.599242","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e16c9f33-6588-4446-9a0a-064f3508f055","Cover
+        population."],"key_as_string":"e16c9f33-6588-4446-9a0a-064f3508f055|Cover
+        population.","doc_count":1},{"key":["f58a2843-2da2-4e32-87cb-7bb37830069f","Bit
+        business."],"key_as_string":"f58a2843-2da2-4e32-87cb-7bb37830069f|Bit business.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["271dbc78-282d-40a9-909c-f2373bf27c38","Banks,
+        Burns and Jones"],"key_as_string":"271dbc78-282d-40a9-909c-f2373bf27c38|Banks,
+        Burns and Jones","doc_count":1},{"key":["ab518e9a-7cdc-4b1c-a190-2072abe3091b","Ramirez
+        Ltd"],"key_as_string":"ab518e9a-7cdc-4b1c-a190-2072abe3091b|Ramirez Ltd","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query.yaml
@@ -1,10 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"50e32c44-515e-4c48-ae57-3aae82fc9cf1","publisher":{"uuid":"55725d7d-9938-4d67-ba69-341c98a007bb","naam":"David,
-      Hess and Warren"},"informatie_categorieen":[{"uuid":"17615228-b01f-473d-811c-a928c93d58b5","naam":"Crime
-      activity class."}],"officiele_titel":"Democratic trouble part maybe medical
-      again citizen so.","verkorte_titel":"Race quite.","omschrijving":"Grow month
-      his while budget. There computer girl sign three.","registratiedatum":"2025-02-24T11:20:43.157484","laatst_gewijzigd_datum":"2025-02-16T18:53:36.137299"}'
+    body: '{"uuid":"50e32c44-515e-4c48-ae57-3aae82fc9cf1","publisher":{"uuid":"7e6e831e-311e-46fd-8929-521838765a0f","naam":"Roberson-Obrien"},"informatie_categorieen":[{"uuid":"36688dbe-93dd-414e-ac02-e37344ec5dd0","naam":"But."}],"officiele_titel":"Generation
+      image or full scientist then.","verkorte_titel":"Scene goal.","omschrijving":"View
+      rest science. Realize agree and manage bank rise. Month those grow. Us store
+      certain goal cut.","registratiedatum":"2025-03-03T00:43:01.846450","laatst_gewijzigd_datum":"2025-02-19T12:41:56.046319"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -34,12 +33,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","publicatie":"b5c0de94-419a-4cba-879e-83d863305907","informatie_categorieen":[{"uuid":"599a8965-b8eb-452f-a230-d39cc015a8f3","naam":"Easy
-      my."}],"publisher":{"uuid":"198f0865-aad2-4f7a-85ef-b09fee4fe134","naam":"Bates,
-      Espinoza and Green"},"identifier":"document1","officiele_titel":"I week lawyer
-      need research.","verkorte_titel":"Nearly pressure.","omschrijving":"Ball think
-      party near idea modern. Lot program her anyone. Agree spend house serious play.
-      Television difference vote.","creatiedatum":"2025-02-09","registratiedatum":"2025-02-22T18:26:18.209185","laatst_gewijzigd_datum":"2025-02-11T08:53:01.870609"}'
+    body: '{"uuid":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","publicatie":"39d070fc-f268-456f-b9ca-5f40fb28d661","informatie_categorieen":[{"uuid":"938e419c-c10d-4e4b-8d28-89821725c690","naam":"Ball
+      live yes."}],"publisher":{"uuid":"93d98fda-2a8b-4749-8266-0ca025d2cdf7","naam":"Steele-Edwards"},"identifier":"document1","officiele_titel":"Two
+      human human voice.","verkorte_titel":"Wall.","omschrijving":"Give customer with
+      section view college mind. Staff or somebody southern born computer usually.
+      School loss indicate science another benefit.","creatiedatum":"2025-02-07","registratiedatum":"2025-03-01T16:04:30.122109","laatst_gewijzigd_datum":"2025-03-04T21:44:37.051935"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -69,7 +67,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"query_string":{"query":"document1","fields":["identifier^3","officiele_titel^2","verkorte_titel^1.5","omschrijving"],"fuzziness":2}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"query_string":{"query":"document1","fields":["identifier^3","officiele_titel^2","verkorte_titel^1.5","omschrijving"],"fuzziness":2}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -85,15 +83,13 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","_score":10.234905,"_source":{"uuid":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","publicatie":"b5c0de94-419a-4cba-879e-83d863305907","informatie_categorieen":[{"uuid":"599a8965-b8eb-452f-a230-d39cc015a8f3","naam":"Easy
-        my."}],"publisher":{"uuid":"198f0865-aad2-4f7a-85ef-b09fee4fe134","naam":"Bates,
-        Espinoza and Green"},"identifier":"document1","officiele_titel":"I week lawyer
-        need research.","verkorte_titel":"Nearly pressure.","omschrijving":"Ball think
-        party near idea modern. Lot program her anyone. Agree spend house serious
-        play. Television difference vote.","creatiedatum":"2025-02-09","registratiedatum":"2025-02-22T18:26:18.209185","laatst_gewijzigd_datum":"2025-02-11T08:53:01.870609"},"sort":[10.234905,1739263981870]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["599a8965-b8eb-452f-a230-d39cc015a8f3","Easy
-        my."],"key_as_string":"599a8965-b8eb-452f-a230-d39cc015a8f3|Easy my.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["198f0865-aad2-4f7a-85ef-b09fee4fe134","Bates,
-        Espinoza and Green"],"key_as_string":"198f0865-aad2-4f7a-85ef-b09fee4fe134|Bates,
-        Espinoza and Green","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
+      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","_score":10.234905,"_source":{"uuid":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","publicatie":"39d070fc-f268-456f-b9ca-5f40fb28d661","informatie_categorieen":[{"uuid":"938e419c-c10d-4e4b-8d28-89821725c690","naam":"Ball
+        live yes."}],"publisher":{"uuid":"93d98fda-2a8b-4749-8266-0ca025d2cdf7","naam":"Steele-Edwards"},"identifier":"document1","officiele_titel":"Two
+        human human voice.","verkorte_titel":"Wall.","omschrijving":"Give customer
+        with section view college mind. Staff or somebody southern born computer usually.
+        School loss indicate science another benefit.","creatiedatum":"2025-02-07","registratiedatum":"2025-03-01T16:04:30.122109","laatst_gewijzigd_datum":"2025-03-04T21:44:37.051935"},"sort":[10.234905,1741124677051]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["938e419c-c10d-4e4b-8d28-89821725c690","Ball
+        live yes."],"key_as_string":"938e419c-c10d-4e4b-8d28-89821725c690|Ball live
+        yes.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["93d98fda-2a8b-4749-8266-0ca025d2cdf7","Steele-Edwards"],"key_as_string":"93d98fda-2a8b-4749-8266-0ca025d2cdf7|Steele-Edwards","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query_field_boosts.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query_field_boosts.yaml
@@ -1,7 +1,8 @@
 interactions:
 - request:
-    body: '{"uuid":"3916925a-4260-4505-bfbb-0942113efd49","publicatie":"d0562c42-0a98-4975-a5b5-5a6aaba963de","informatie_categorieen":[{"uuid":"9048c8c4-fb64-45ba-8f2e-ee29662caa39","naam":"Wide
-      official phone."}],"publisher":{"uuid":"282adcb0-0400-404a-8e5a-7ba5a07ef414","naam":"Dyer-Moyer"},"identifier":"document1","officiele_titel":"titel","verkorte_titel":"snowflake","omschrijving":"omschrijving","creatiedatum":"2025-02-24","registratiedatum":"2025-02-25T19:01:54.863743","laatst_gewijzigd_datum":"2025-01-28T22:41:19.859488"}'
+    body: '{"uuid":"3916925a-4260-4505-bfbb-0942113efd49","publicatie":"96ada08b-e560-48b8-82a5-29203b9d5724","informatie_categorieen":[{"uuid":"b82a63e5-8c63-4b05-b90c-94bc77df6771","naam":"Sure
+      southern."}],"publisher":{"uuid":"bd54404d-d8b3-4794-adba-d50ff00bf435","naam":"Butler,
+      Castillo and James"},"identifier":"document1","officiele_titel":"titel","verkorte_titel":"snowflake","omschrijving":"omschrijving","creatiedatum":"2025-02-28","registratiedatum":"2025-03-06T10:36:40.081871","laatst_gewijzigd_datum":"2025-02-18T12:17:21.345582"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -31,10 +32,9 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"d49bc304-01a1-4eda-a914-a8dda5c901e2","publicatie":"eab10737-b29e-4704-bc50-e4f7aa0c6f65","informatie_categorieen":[{"uuid":"205e2b95-7392-42d9-9c87-5ba362d176e9","naam":"Any
-      defense seek."}],"publisher":{"uuid":"229754f1-41e7-4fa6-b63d-b9f120e8a717","naam":"Burns,
-      Dickson and Hunter"},"identifier":"snowflake","officiele_titel":"titel","verkorte_titel":"verkorte
-      titel","omschrijving":"omschrijving","creatiedatum":"2025-02-17","registratiedatum":"2025-02-21T22:59:54.897722","laatst_gewijzigd_datum":"2025-02-15T11:28:09.932433"}'
+    body: '{"uuid":"d49bc304-01a1-4eda-a914-a8dda5c901e2","publicatie":"3c3eb5e4-1ff4-42e8-a39d-02ce4d68303a","informatie_categorieen":[{"uuid":"ff65c845-d532-442a-abfb-6c013f1657eb","naam":"Professional
+      pressure."}],"publisher":{"uuid":"4f68c9dc-0b01-4050-a510-b20b0a7d5fb7","naam":"Lee-Jacobs"},"identifier":"snowflake","officiele_titel":"titel","verkorte_titel":"verkorte
+      titel","omschrijving":"omschrijving","creatiedatum":"2025-02-26","registratiedatum":"2025-03-05T18:43:03.103605","laatst_gewijzigd_datum":"2025-02-26T02:05:43.675701"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -64,9 +64,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"bdcc4cea-b186-425e-8dcd-9fecb6818563","publicatie":"dceca05e-1d05-442c-a4ae-2d13f96ecfeb","informatie_categorieen":[{"uuid":"08d2aebf-37e3-47d5-b985-c20e766bb49e","naam":"Should
-      too manager."}],"publisher":{"uuid":"634bd44a-c9e2-4f5c-b674-ff963bd6201b","naam":"Thomas-Moss"},"identifier":"document3","officiele_titel":"titel","verkorte_titel":"verkorte
-      titel","omschrijving":"snowflake","creatiedatum":"2025-02-12","registratiedatum":"2025-02-22T17:15:51.249595","laatst_gewijzigd_datum":"2025-02-02T02:47:36.727796"}'
+    body: '{"uuid":"bdcc4cea-b186-425e-8dcd-9fecb6818563","publicatie":"5878d120-2bd2-4744-9671-f9f6ef005ffd","informatie_categorieen":[{"uuid":"5f5cca59-6601-49c7-b304-93aaf1d5958b","naam":"Magazine
+      new."}],"publisher":{"uuid":"909a145f-eff7-4503-b75e-620c08c3aedc","naam":"Rich
+      Inc"},"identifier":"document3","officiele_titel":"titel","verkorte_titel":"verkorte
+      titel","omschrijving":"snowflake","creatiedatum":"2025-02-28","registratiedatum":"2025-03-06T01:07:20.913151","laatst_gewijzigd_datum":"2025-02-07T22:29:03.190364"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -96,9 +97,9 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"7eade718-bccb-4876-9f00-a095beebc360","publicatie":"b7af6cd5-3570-489f-890d-7293ce8f7c41","informatie_categorieen":[{"uuid":"40a031a0-dd07-46d2-8edd-056375ab54fc","naam":"Do
-      early."}],"publisher":{"uuid":"bcee5921-9081-4011-95d8-f3def90cec47","naam":"Nixon-Thompson"},"identifier":"document4","officiele_titel":"snowflake","verkorte_titel":"verkorte
-      titel","omschrijving":"omschrijving","creatiedatum":"2025-02-10","registratiedatum":"2025-02-25T15:28:03.885026","laatst_gewijzigd_datum":"2025-02-18T04:06:31.415410"}'
+    body: '{"uuid":"7eade718-bccb-4876-9f00-a095beebc360","publicatie":"15872cd6-f986-46b9-80bc-140772f832ec","informatie_categorieen":[{"uuid":"48057814-a433-40b3-ade7-a42196a786aa","naam":"Role
+      put structure."}],"publisher":{"uuid":"955ada8b-637e-4f10-84fc-d6b9b7ebe15a","naam":"Hardy-Lucas"},"identifier":"document4","officiele_titel":"snowflake","verkorte_titel":"verkorte
+      titel","omschrijving":"omschrijving","creatiedatum":"2025-03-01","registratiedatum":"2025-03-02T03:29:49.215728","laatst_gewijzigd_datum":"2025-03-01T05:44:13.720700"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -128,7 +129,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"query_string":{"query":"snowflake","fields":["identifier^3","officiele_titel^2","verkorte_titel^1.5","omschrijving"],"fuzziness":2}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"query_string":{"query":"snowflake","fields":["identifier^3","officiele_titel^2","verkorte_titel^1.5","omschrijving"],"fuzziness":2}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -144,24 +145,25 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":4,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"d49bc304-01a1-4eda-a914-a8dda5c901e2","_score":10.610572,"_source":{"uuid":"d49bc304-01a1-4eda-a914-a8dda5c901e2","publicatie":"eab10737-b29e-4704-bc50-e4f7aa0c6f65","informatie_categorieen":[{"uuid":"205e2b95-7392-42d9-9c87-5ba362d176e9","naam":"Any
-        defense seek."}],"publisher":{"uuid":"229754f1-41e7-4fa6-b63d-b9f120e8a717","naam":"Burns,
-        Dickson and Hunter"},"identifier":"snowflake","officiele_titel":"titel","verkorte_titel":"verkorte
-        titel","omschrijving":"omschrijving","creatiedatum":"2025-02-17","registratiedatum":"2025-02-21T22:59:54.897722","laatst_gewijzigd_datum":"2025-02-15T11:28:09.932433"},"sort":[10.610572,1739618889932]},{"_index":"document","_id":"7eade718-bccb-4876-9f00-a095beebc360","_score":6.9719877,"_source":{"uuid":"7eade718-bccb-4876-9f00-a095beebc360","publicatie":"b7af6cd5-3570-489f-890d-7293ce8f7c41","informatie_categorieen":[{"uuid":"40a031a0-dd07-46d2-8edd-056375ab54fc","naam":"Do
-        early."}],"publisher":{"uuid":"bcee5921-9081-4011-95d8-f3def90cec47","naam":"Nixon-Thompson"},"identifier":"document4","officiele_titel":"snowflake","verkorte_titel":"verkorte
-        titel","omschrijving":"omschrijving","creatiedatum":"2025-02-10","registratiedatum":"2025-02-25T15:28:03.885026","laatst_gewijzigd_datum":"2025-02-18T04:06:31.415410"},"sort":[6.9719877,1739851591415]},{"_index":"document","_id":"3916925a-4260-4505-bfbb-0942113efd49","_score":5.5523987,"_source":{"uuid":"3916925a-4260-4505-bfbb-0942113efd49","publicatie":"d0562c42-0a98-4975-a5b5-5a6aaba963de","informatie_categorieen":[{"uuid":"9048c8c4-fb64-45ba-8f2e-ee29662caa39","naam":"Wide
-        official phone."}],"publisher":{"uuid":"282adcb0-0400-404a-8e5a-7ba5a07ef414","naam":"Dyer-Moyer"},"identifier":"document1","officiele_titel":"titel","verkorte_titel":"snowflake","omschrijving":"omschrijving","creatiedatum":"2025-02-24","registratiedatum":"2025-02-25T19:01:54.863743","laatst_gewijzigd_datum":"2025-01-28T22:41:19.859488"},"sort":[5.5523987,1738104079859]},{"_index":"document","_id":"bdcc4cea-b186-425e-8dcd-9fecb6818563","_score":4.6008205,"_source":{"uuid":"bdcc4cea-b186-425e-8dcd-9fecb6818563","publicatie":"dceca05e-1d05-442c-a4ae-2d13f96ecfeb","informatie_categorieen":[{"uuid":"08d2aebf-37e3-47d5-b985-c20e766bb49e","naam":"Should
-        too manager."}],"publisher":{"uuid":"634bd44a-c9e2-4f5c-b674-ff963bd6201b","naam":"Thomas-Moss"},"identifier":"document3","officiele_titel":"titel","verkorte_titel":"verkorte
-        titel","omschrijving":"snowflake","creatiedatum":"2025-02-12","registratiedatum":"2025-02-22T17:15:51.249595","laatst_gewijzigd_datum":"2025-02-02T02:47:36.727796"},"sort":[4.6008205,1738464456727]}]},"aggregations":{"InformationCategories":{"doc_count":4,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["08d2aebf-37e3-47d5-b985-c20e766bb49e","Should
-        too manager."],"key_as_string":"08d2aebf-37e3-47d5-b985-c20e766bb49e|Should
-        too manager.","doc_count":1},{"key":["205e2b95-7392-42d9-9c87-5ba362d176e9","Any
-        defense seek."],"key_as_string":"205e2b95-7392-42d9-9c87-5ba362d176e9|Any
-        defense seek.","doc_count":1},{"key":["40a031a0-dd07-46d2-8edd-056375ab54fc","Do
-        early."],"key_as_string":"40a031a0-dd07-46d2-8edd-056375ab54fc|Do early.","doc_count":1},{"key":["9048c8c4-fb64-45ba-8f2e-ee29662caa39","Wide
-        official phone."],"key_as_string":"9048c8c4-fb64-45ba-8f2e-ee29662caa39|Wide
-        official phone.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["229754f1-41e7-4fa6-b63d-b9f120e8a717","Burns,
-        Dickson and Hunter"],"key_as_string":"229754f1-41e7-4fa6-b63d-b9f120e8a717|Burns,
-        Dickson and Hunter","doc_count":1},{"key":["282adcb0-0400-404a-8e5a-7ba5a07ef414","Dyer-Moyer"],"key_as_string":"282adcb0-0400-404a-8e5a-7ba5a07ef414|Dyer-Moyer","doc_count":1},{"key":["634bd44a-c9e2-4f5c-b674-ff963bd6201b","Thomas-Moss"],"key_as_string":"634bd44a-c9e2-4f5c-b674-ff963bd6201b|Thomas-Moss","doc_count":1},{"key":["bcee5921-9081-4011-95d8-f3def90cec47","Nixon-Thompson"],"key_as_string":"bcee5921-9081-4011-95d8-f3def90cec47|Nixon-Thompson","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":4}]}}}'
+      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":4,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"d49bc304-01a1-4eda-a914-a8dda5c901e2","_score":10.610572,"_source":{"uuid":"d49bc304-01a1-4eda-a914-a8dda5c901e2","publicatie":"3c3eb5e4-1ff4-42e8-a39d-02ce4d68303a","informatie_categorieen":[{"uuid":"ff65c845-d532-442a-abfb-6c013f1657eb","naam":"Professional
+        pressure."}],"publisher":{"uuid":"4f68c9dc-0b01-4050-a510-b20b0a7d5fb7","naam":"Lee-Jacobs"},"identifier":"snowflake","officiele_titel":"titel","verkorte_titel":"verkorte
+        titel","omschrijving":"omschrijving","creatiedatum":"2025-02-26","registratiedatum":"2025-03-05T18:43:03.103605","laatst_gewijzigd_datum":"2025-02-26T02:05:43.675701"},"sort":[10.610572,1740535543675]},{"_index":"document","_id":"7eade718-bccb-4876-9f00-a095beebc360","_score":7.0033464,"_source":{"uuid":"7eade718-bccb-4876-9f00-a095beebc360","publicatie":"15872cd6-f986-46b9-80bc-140772f832ec","informatie_categorieen":[{"uuid":"48057814-a433-40b3-ade7-a42196a786aa","naam":"Role
+        put structure."}],"publisher":{"uuid":"955ada8b-637e-4f10-84fc-d6b9b7ebe15a","naam":"Hardy-Lucas"},"identifier":"document4","officiele_titel":"snowflake","verkorte_titel":"verkorte
+        titel","omschrijving":"omschrijving","creatiedatum":"2025-03-01","registratiedatum":"2025-03-02T03:29:49.215728","laatst_gewijzigd_datum":"2025-03-01T05:44:13.720700"},"sort":[7.0033464,1740807853720]},{"_index":"document","_id":"3916925a-4260-4505-bfbb-0942113efd49","_score":5.6862507,"_source":{"uuid":"3916925a-4260-4505-bfbb-0942113efd49","publicatie":"96ada08b-e560-48b8-82a5-29203b9d5724","informatie_categorieen":[{"uuid":"b82a63e5-8c63-4b05-b90c-94bc77df6771","naam":"Sure
+        southern."}],"publisher":{"uuid":"bd54404d-d8b3-4794-adba-d50ff00bf435","naam":"Butler,
+        Castillo and James"},"identifier":"document1","officiele_titel":"titel","verkorte_titel":"snowflake","omschrijving":"omschrijving","creatiedatum":"2025-02-28","registratiedatum":"2025-03-06T10:36:40.081871","laatst_gewijzigd_datum":"2025-02-18T12:17:21.345582"},"sort":[5.6862507,1739881041345]},{"_index":"document","_id":"bdcc4cea-b186-425e-8dcd-9fecb6818563","_score":4.64408,"_source":{"uuid":"bdcc4cea-b186-425e-8dcd-9fecb6818563","publicatie":"5878d120-2bd2-4744-9671-f9f6ef005ffd","informatie_categorieen":[{"uuid":"5f5cca59-6601-49c7-b304-93aaf1d5958b","naam":"Magazine
+        new."}],"publisher":{"uuid":"909a145f-eff7-4503-b75e-620c08c3aedc","naam":"Rich
+        Inc"},"identifier":"document3","officiele_titel":"titel","verkorte_titel":"verkorte
+        titel","omschrijving":"snowflake","creatiedatum":"2025-02-28","registratiedatum":"2025-03-06T01:07:20.913151","laatst_gewijzigd_datum":"2025-02-07T22:29:03.190364"},"sort":[4.64408,1738967343190]}]},"aggregations":{"InformationCategories":{"doc_count":4,"Categories":{"doc_count":4,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["48057814-a433-40b3-ade7-a42196a786aa","Role
+        put structure."],"key_as_string":"48057814-a433-40b3-ade7-a42196a786aa|Role
+        put structure.","doc_count":1},{"key":["5f5cca59-6601-49c7-b304-93aaf1d5958b","Magazine
+        new."],"key_as_string":"5f5cca59-6601-49c7-b304-93aaf1d5958b|Magazine new.","doc_count":1},{"key":["b82a63e5-8c63-4b05-b90c-94bc77df6771","Sure
+        southern."],"key_as_string":"b82a63e5-8c63-4b05-b90c-94bc77df6771|Sure southern.","doc_count":1},{"key":["ff65c845-d532-442a-abfb-6c013f1657eb","Professional
+        pressure."],"key_as_string":"ff65c845-d532-442a-abfb-6c013f1657eb|Professional
+        pressure.","doc_count":1}]}}},"Publisher":{"doc_count":4,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["4f68c9dc-0b01-4050-a510-b20b0a7d5fb7","Lee-Jacobs"],"key_as_string":"4f68c9dc-0b01-4050-a510-b20b0a7d5fb7|Lee-Jacobs","doc_count":1},{"key":["909a145f-eff7-4503-b75e-620c08c3aedc","Rich
+        Inc"],"key_as_string":"909a145f-eff7-4503-b75e-620c08c3aedc|Rich Inc","doc_count":1},{"key":["955ada8b-637e-4f10-84fc-d6b9b7ebe15a","Hardy-Lucas"],"key_as_string":"955ada8b-637e-4f10-84fc-d6b9b7ebe15a|Hardy-Lucas","doc_count":1},{"key":["bd54404d-d8b3-4794-adba-d50ff00bf435","Butler,
+        Castillo and James"],"key_as_string":"bd54404d-d8b3-4794-adba-d50ff00bf435|Butler,
+        Castillo and James","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":4}]}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_result_type.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_result_type.yaml
@@ -1,10 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","publisher":{"uuid":"96aa9414-b38a-4075-adeb-e8495cc5bc8e","naam":"Allen,
-      Reed and Eaton"},"informatie_categorieen":[{"uuid":"839b0310-f77c-4766-b1c9-97fdd3943c31","naam":"Whole
-      one trouble."}],"officiele_titel":"War cultural picture fund human language.","verkorte_titel":"Prevent
-      television.","omschrijving":"Coach lead by mouth none. Responsibility class
-      head whose fly. Mind carry technology perhaps air physical finally room.","registratiedatum":"2025-02-22T21:37:45.434544","laatst_gewijzigd_datum":"2025-02-02T22:14:51.770158"}'
+    body: '{"uuid":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","publisher":{"uuid":"ea038327-2f20-431d-b509-91b35b743fc5","naam":"Davidson-Lambert"},"informatie_categorieen":[{"uuid":"65a7ed3f-c548-4e4a-bbcc-d248f2acce3b","naam":"Interview
+      cell."}],"officiele_titel":"Because yard fall million computer well about.","verkorte_titel":"Dog
+      though person.","omschrijving":"Read day score can foreign. Difficult size want
+      everyone protect lay.","registratiedatum":"2025-03-03T08:42:58.513345","laatst_gewijzigd_datum":"2025-02-04T18:10:32.016883"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -34,11 +33,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"7de0524b-d5f4-4cb5-9ccb-6d653add79b6","informatie_categorieen":[{"uuid":"9437f319-5a9c-4e6f-ac7c-4790099e70c1","naam":"Within
-      husband."}],"publisher":{"uuid":"cdc0486d-8680-40d6-a8ca-a22e28953b91","naam":"Matthews-Johnson"},"identifier":"identifier-27","officiele_titel":"Possible
-      alone suggest pattern source fill draw.","verkorte_titel":"Member process audience.","omschrijving":"See
-      word tonight try mother. Politics action know dog clearly. Leader whose space
-      history today.","creatiedatum":"2025-02-03","registratiedatum":"2025-02-22T17:17:32.185071","laatst_gewijzigd_datum":"2025-02-03T16:47:57.512470"}'
+    body: '{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"8d842cf5-a21d-46d0-8ab8-205b407c2149","informatie_categorieen":[{"uuid":"422f85b9-7e25-4113-ab6e-495c7ee617a7","naam":"Where."}],"publisher":{"uuid":"9d98a651-c1e8-45a1-ad66-98f717ef312f","naam":"Diaz-Thompson"},"identifier":"identifier-28","officiele_titel":"Grow
+      painting lead into everything reduce.","verkorte_titel":"Star happy.","omschrijving":"Tax
+      local strong collection program southern. Sort raise hope production participant
+      issue police. Benefit activity letter cover.","creatiedatum":"2025-02-19","registratiedatum":"2025-03-04T21:11:54.373042","laatst_gewijzigd_datum":"2025-03-01T04:10:56.757145"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -68,7 +66,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -84,12 +82,10 @@ interactions:
     uri: http://localhost:9201/document/_search
   response:
     body:
-      string: '{"took":4,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","_score":1.0,"_source":{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"7de0524b-d5f4-4cb5-9ccb-6d653add79b6","informatie_categorieen":[{"uuid":"9437f319-5a9c-4e6f-ac7c-4790099e70c1","naam":"Within
-        husband."}],"publisher":{"uuid":"cdc0486d-8680-40d6-a8ca-a22e28953b91","naam":"Matthews-Johnson"},"identifier":"identifier-27","officiele_titel":"Possible
-        alone suggest pattern source fill draw.","verkorte_titel":"Member process
-        audience.","omschrijving":"See word tonight try mother. Politics action know
-        dog clearly. Leader whose space history today.","creatiedatum":"2025-02-03","registratiedatum":"2025-02-22T17:17:32.185071","laatst_gewijzigd_datum":"2025-02-03T16:47:57.512470"},"sort":[1.0,1738601277512]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["cdc0486d-8680-40d6-a8ca-a22e28953b91","Matthews-Johnson"],"key_as_string":"cdc0486d-8680-40d6-a8ca-a22e28953b91|Matthews-Johnson","doc_count":1}]},"InformationCategories":{"doc_count":1,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["9437f319-5a9c-4e6f-ac7c-4790099e70c1","Within
-        husband."],"key_as_string":"9437f319-5a9c-4e6f-ac7c-4790099e70c1|Within husband.","doc_count":1}]}}}}'
+      string: '{"took":3,"timed_out":false,"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","_score":1.0,"_source":{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"8d842cf5-a21d-46d0-8ab8-205b407c2149","informatie_categorieen":[{"uuid":"422f85b9-7e25-4113-ab6e-495c7ee617a7","naam":"Where."}],"publisher":{"uuid":"9d98a651-c1e8-45a1-ad66-98f717ef312f","naam":"Diaz-Thompson"},"identifier":"identifier-28","officiele_titel":"Grow
+        painting lead into everything reduce.","verkorte_titel":"Star happy.","omschrijving":"Tax
+        local strong collection program southern. Sort raise hope production participant
+        issue police. Benefit activity letter cover.","creatiedatum":"2025-02-19","registratiedatum":"2025-03-04T21:11:54.373042","laatst_gewijzigd_datum":"2025-03-01T04:10:56.757145"},"sort":[1.0,1740802256757]}]},"aggregations":{"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["9d98a651-c1e8-45a1-ad66-98f717ef312f","Diaz-Thompson"],"key_as_string":"9d98a651-c1e8-45a1-ad66-98f717ef312f|Diaz-Thompson","doc_count":1}]}},"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["422f85b9-7e25-4113-ab6e-495c7ee617a7","Where."],"key_as_string":"422f85b9-7e25-4113-ab6e-495c7ee617a7|Where.","doc_count":1}]}}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_sort_chronological.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_sort_chronological.yaml
@@ -1,9 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","publisher":{"uuid":"8828b6ce-1a96-49be-9083-1eb2176c1c19","naam":"Scott-Ellis"},"informatie_categorieen":[{"uuid":"3e5b7780-5ea3-4d22-ac1b-2d1b62fbe641","naam":"Give."}],"officiele_titel":"List
-      age successful personal goal.","verkorte_titel":"Together issue plant.","omschrijving":"Go
-      discussion in whether. Door today machine exist language student seek. Couple
-      other decade response.","registratiedatum":"2025-02-21T22:54:29.680596","laatst_gewijzigd_datum":"2026-01-02T12:00:00+00:00"}'
+    body: '{"uuid":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","publisher":{"uuid":"ca182436-ed15-4f74-859b-a06622d207f3","naam":"Graham
+      and Sons"},"informatie_categorieen":[{"uuid":"d2aab62a-024b-4c5b-a1cf-a826493f05f5","naam":"Cup
+      relationship hour."}],"officiele_titel":"Ever training senior stock myself lawyer
+      throughout finish.","verkorte_titel":"International plant.","omschrijving":"House
+      member strategy fact. Design act move policy clear friend.","registratiedatum":"2025-03-05T00:06:11.319512","laatst_gewijzigd_datum":"2026-01-02T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,11 +34,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","publicatie":"b3939114-7ac0-489d-8777-bb00ac18983a","informatie_categorieen":[{"uuid":"a5ece552-3a39-4208-95a6-37017143d728","naam":"Better."}],"publisher":{"uuid":"ac1a0693-4e77-4dc8-8a21-d5fc386dcca0","naam":"Davila,
-      Burke and Graham"},"identifier":"identifier-28","officiele_titel":"Spring real
-      mean loss.","verkorte_titel":"Much black pattern.","omschrijving":"Television
-      impact purpose ability produce society. Allow actually about voice research
-      put. Page morning room food.","creatiedatum":"2025-02-07","registratiedatum":"2025-02-26T04:12:17.813581","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","publicatie":"b5e26176-2350-400d-8e01-3dfcdc78b23b","informatie_categorieen":[{"uuid":"8e046a4d-ff8f-440b-a236-670e7bcdf634","naam":"Energy
+      reveal fine."}],"publisher":{"uuid":"6247fc42-5457-4f1a-92e3-7e00552c3b29","naam":"Miller
+      Ltd"},"identifier":"identifier-29","officiele_titel":"Training seven other place
+      trial agreement treat.","verkorte_titel":"Meeting right west.","omschrijving":"Sister
+      company none learn need resource long though. Term subject receive meet sea.
+      Style tree consider hour. Blue still care economic usually current indeed.","creatiedatum":"2025-02-18","registratiedatum":"2025-03-04T09:54:05.092279","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -67,7 +69,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}},"InformationCategories":{"nested":{"path":"informatie_categorieen"},"aggs":{"Categories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}},"sort":[{"laatst_gewijzigd_datum":{"order":"desc"}},"_score"],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"aggs":{"ResultType":{"terms":{"field":"_index"}},"Publisher":{"filter":{"match_all":{}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"match_all":{}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":[{"laatst_gewijzigd_datum":{"order":"desc"}},"_score"],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -83,16 +85,23 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","_score":1.0,"_source":{"uuid":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","publicatie":"b3939114-7ac0-489d-8777-bb00ac18983a","informatie_categorieen":[{"uuid":"a5ece552-3a39-4208-95a6-37017143d728","naam":"Better."}],"publisher":{"uuid":"ac1a0693-4e77-4dc8-8a21-d5fc386dcca0","naam":"Davila,
-        Burke and Graham"},"identifier":"identifier-28","officiele_titel":"Spring
-        real mean loss.","verkorte_titel":"Much black pattern.","omschrijving":"Television
-        impact purpose ability produce society. Allow actually about voice research
-        put. Page morning room food.","creatiedatum":"2025-02-07","registratiedatum":"2025-02-26T04:12:17.813581","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1767614400000,1.0]},{"_index":"publication","_id":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","_score":2.0,"_source":{"uuid":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","publisher":{"uuid":"8828b6ce-1a96-49be-9083-1eb2176c1c19","naam":"Scott-Ellis"},"informatie_categorieen":[{"uuid":"3e5b7780-5ea3-4d22-ac1b-2d1b62fbe641","naam":"Give."}],"officiele_titel":"List
-        age successful personal goal.","verkorte_titel":"Together issue plant.","omschrijving":"Go
-        discussion in whether. Door today machine exist language student seek. Couple
-        other decade response.","registratiedatum":"2025-02-21T22:54:29.680596","laatst_gewijzigd_datum":"2026-01-02T12:00:00+00:00"},"sort":[1767355200000,2.0]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3e5b7780-5ea3-4d22-ac1b-2d1b62fbe641","Give."],"key_as_string":"3e5b7780-5ea3-4d22-ac1b-2d1b62fbe641|Give.","doc_count":1},{"key":["a5ece552-3a39-4208-95a6-37017143d728","Better."],"key_as_string":"a5ece552-3a39-4208-95a6-37017143d728|Better.","doc_count":1}]}},"Publisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["8828b6ce-1a96-49be-9083-1eb2176c1c19","Scott-Ellis"],"key_as_string":"8828b6ce-1a96-49be-9083-1eb2176c1c19|Scott-Ellis","doc_count":1},{"key":["ac1a0693-4e77-4dc8-8a21-d5fc386dcca0","Davila,
-        Burke and Graham"],"key_as_string":"ac1a0693-4e77-4dc8-8a21-d5fc386dcca0|Davila,
-        Burke and Graham","doc_count":1}]},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
+      string: '{"took":13,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","_score":1.0,"_source":{"uuid":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","publicatie":"b5e26176-2350-400d-8e01-3dfcdc78b23b","informatie_categorieen":[{"uuid":"8e046a4d-ff8f-440b-a236-670e7bcdf634","naam":"Energy
+        reveal fine."}],"publisher":{"uuid":"6247fc42-5457-4f1a-92e3-7e00552c3b29","naam":"Miller
+        Ltd"},"identifier":"identifier-29","officiele_titel":"Training seven other
+        place trial agreement treat.","verkorte_titel":"Meeting right west.","omschrijving":"Sister
+        company none learn need resource long though. Term subject receive meet sea.
+        Style tree consider hour. Blue still care economic usually current indeed.","creatiedatum":"2025-02-18","registratiedatum":"2025-03-04T09:54:05.092279","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1767614400000,1.0]},{"_index":"publication","_id":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","_score":2.0,"_source":{"uuid":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","publisher":{"uuid":"ca182436-ed15-4f74-859b-a06622d207f3","naam":"Graham
+        and Sons"},"informatie_categorieen":[{"uuid":"d2aab62a-024b-4c5b-a1cf-a826493f05f5","naam":"Cup
+        relationship hour."}],"officiele_titel":"Ever training senior stock myself
+        lawyer throughout finish.","verkorte_titel":"International plant.","omschrijving":"House
+        member strategy fact. Design act move policy clear friend.","registratiedatum":"2025-03-05T00:06:11.319512","laatst_gewijzigd_datum":"2026-01-02T12:00:00+00:00"},"sort":[1767355200000,2.0]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["8e046a4d-ff8f-440b-a236-670e7bcdf634","Energy
+        reveal fine."],"key_as_string":"8e046a4d-ff8f-440b-a236-670e7bcdf634|Energy
+        reveal fine.","doc_count":1},{"key":["d2aab62a-024b-4c5b-a1cf-a826493f05f5","Cup
+        relationship hour."],"key_as_string":"d2aab62a-024b-4c5b-a1cf-a826493f05f5|Cup
+        relationship hour.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["6247fc42-5457-4f1a-92e3-7e00552c3b29","Miller
+        Ltd"],"key_as_string":"6247fc42-5457-4f1a-92e3-7e00552c3b29|Miller Ltd","doc_count":1},{"key":["ca182436-ed15-4f74-859b-a06622d207f3","Graham
+        and Sons"],"key_as_string":"ca182436-ed15-4f74-859b-a06622d207f3|Graham and
+        Sons","doc_count":1}]}},"ResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}'
     headers:
       Transfer-Encoding:
       - chunked


### PR DESCRIPTION
Part of #10, #11 and #13 - the returned facets now match the expected behaviour.

**Expected UI behaviour**

1. Use empty search terms or enter search terms
2. Facets are returned about the number of each information category and each publisher
3. Click checkbox for a publisher
   1. Results are limited to that publisher
   2. The available information categories are limited to that publisher
   3. Other publishers are still displayed with their hit count
4. Click checkbox for another publisher
    1. Results are limited to publisher 1 and 2 (there should now be more results)
    2. The available information categories are limited to both publishers
    3. Other publishers are still displayed with their hit count

A similar pattern applies to selecting information categories w/r to the available publishers, and there's interaction between them both, which is now handled in this PR.

Meaning, if you select one or more publishers and one or more information categories, the buckets reflect the *other* filters and only results that match the filters are displayed. This allows you to build up a subset of publishers/categories to match.