### PR TITLE
:boom: [#62] Switch resultType field to resultTypes array field

### DIFF
--- a/src/woo_search/api/openapi.yaml
+++ b/src/woo_search/api/openapi.yaml
@@ -318,14 +318,6 @@ components:
       - count
       - naam
       - uuid
-    NaamEnum:
-      enum:
-      - publication
-      - document
-      type: string
-      description: |-
-        * `publication` - Publicatie
-        * `document` - Document
     Publication:
       type: object
       properties:
@@ -412,7 +404,7 @@ components:
       properties:
         naam:
           allOf:
-          - $ref: '#/components/schemas/NaamEnum'
+          - $ref: '#/components/schemas/ResultTypesEnum'
           title: Resultaattype / naam index
           description: |-
             Geeft de type record/index aan die gevonden is.
@@ -427,14 +419,12 @@ components:
       required:
       - count
       - naam
-    ResultTypeEnum:
+    ResultTypesEnum:
       enum:
-      - '*'
       - publication
       - document
       type: string
       description: |-
-        * `*` - Alle
         * `publication` - Publicatie
         * `document` - Document
     Search:
@@ -464,16 +454,12 @@ components:
           allOf:
           - $ref: '#/components/schemas/SortEnum'
           default: relevance
-        resultType:
-          allOf:
-          - $ref: '#/components/schemas/ResultTypeEnum'
-          default: '*'
-          description: |-
-            Welke soort resultaten teruggeven moeten worden.
-
-            * `*` - Alle
-            * `publication` - Publicatie
-            * `document` - Document
+        resultTypes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResultTypesEnum'
+          description: Specify to which document types the results should be limited.
+            If left blank or an empty list is provided, all result types are included.
         registratiedatumVanaf:
           type: string
           format: date-time

--- a/src/woo_search/conf/base.py
+++ b/src/woo_search/conf/base.py
@@ -267,6 +267,9 @@ and you obtain one by contacting the administrator.
         "description": "Functional and technical documentation",
         "url": "https://gpp-zoeken.readthedocs.io/",
     },
+    "ENUM_NAME_OVERRIDES": {
+        "ResultTypesEnum": "woo_search.search_index.constants.ResultTypeChoices",
+    },
 }
 
 #

--- a/src/woo_search/search_index/api/views.py
+++ b/src/woo_search/search_index/api/views.py
@@ -32,7 +32,7 @@ class SearchView(APIView):
             query=params["query"],
             publishers=params["publishers"],
             information_categories=params["informatie_categorieen"],
-            result_type=rt if (rt := params["result_type"]) != "*" else None,
+            result_types=params["result_types"],
             registration_date_from=params["registratiedatum_vanaf"],
             registration_date_to=params["registratiedatum_tot"],
             last_modified_from=params["laatst_gewijzigd_datum_vanaf"],

--- a/src/woo_search/search_index/client.py
+++ b/src/woo_search/search_index/client.py
@@ -125,7 +125,7 @@ def get_search_results(
     # filters
     publishers: Collection[UUID],
     information_categories: Collection[UUID],
-    result_type: IndexName | None = None,
+    result_types: Collection[IndexName] | None = None,
     registration_date_from: datetime | None = None,
     registration_date_to: datetime | None = None,
     last_modified_from: datetime | None = None,
@@ -226,13 +226,13 @@ def get_search_results(
         )
 
     if creatiedatum_from or creatiedatum_to:
-        assert result_type == "document"
+        assert result_types == ["document"]
         search = search.filter(
             "range",
             creatiedatum={"gte": creatiedatum_from, "lte": creatiedatum_to},
         )
 
-    result_type_filter = Q("term", _index=result_type) if result_type else None
+    result_type_filter = Q("terms", _index=result_types) if result_types else None
     if result_type_filter:
         search = search.post_filter(result_type_filter)
 

--- a/src/woo_search/search_index/constants.py
+++ b/src/woo_search/search_index/constants.py
@@ -5,7 +5,6 @@ DOCUMENT_ATTACHMENT_PIPELINE_ID = "document_attachment"
 
 
 class ResultTypeChoices(models.TextChoices):
-    all = "*", _("All")
     publication = "publication", _("Publication")
     document = "document", _("Document")
 

--- a/src/woo_search/search_index/tests/test_search_api.py
+++ b/src/woo_search/search_index/tests/test_search_api.py
@@ -586,7 +586,9 @@ class SearchApiFilterTests(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
             )
         )
 
-        response = self.client.post(self.url, {"resultType": "document"})
+        response = self.client.post(
+            self.url, {"resultTypes": [ResultTypeChoices.document]}
+        )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
@@ -638,7 +640,7 @@ class SearchApiFilterTests(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
             self.url,
             {
                 "publishers": ["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"],
-                "resultType": ResultTypeChoices.document,
+                "resultTypes": [ResultTypeChoices.document],
             },
         )
 
@@ -718,7 +720,7 @@ class SearchApiFilterTests(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
             self.url,
             {
                 "informatieCategorieen": ["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"],
-                "resultType": ResultTypeChoices.publication,
+                "resultTypes": [ResultTypeChoices.publication],
             },
         )
 
@@ -1012,7 +1014,11 @@ class SearchApiFilterTests(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
             creatiedatum_vanaf="2024-02-11", creatiedatum_tot_en_met=None
         ):
             response = self.client.post(
-                self.url, {"resultType": "document", "creatiedatumVanaf": "2024-02-11"}
+                self.url,
+                {
+                    "resultTypes": [ResultTypeChoices.document],
+                    "creatiedatumVanaf": "2024-02-11",
+                },
             )
 
             self.assertEqual(response.status_code, 200)
@@ -1030,7 +1036,10 @@ class SearchApiFilterTests(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
         ):
             response = self.client.post(
                 self.url,
-                {"resultType": "document", "creatiedatumTotEnMet": "2022-12-10"},
+                {
+                    "resultTypes": [ResultTypeChoices.document],
+                    "creatiedatumTotEnMet": "2022-12-10",
+                },
             )
 
             self.assertEqual(response.status_code, 200)
@@ -1046,7 +1055,7 @@ class SearchApiFilterTests(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
             response = self.client.post(
                 self.url,
                 {
-                    "resultType": "document",
+                    "resultTypes": [ResultTypeChoices.document],
                     "creatiedatumVanaf": "2024-01-01",
                     "creatiedatumTotEnMet": "2024-12-31",
                 },
@@ -1423,7 +1432,7 @@ class SearchApiFilterTests(TokenAuthMixin, VCRMixin, ElasticSearchAPITestCase):
             {
                 "publishers": ["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"],
                 "informatieCategorieen": ["c9001845-aef0-4150-bbf0-a5f5c096e603"],
-                "resultType": ResultTypeChoices.document,
+                "resultTypes": [ResultTypeChoices.document],
             },
         )
 

--- a/src/woo_search/search_index/tests/test_search_serializer.py
+++ b/src/woo_search/search_index/tests/test_search_serializer.py
@@ -15,7 +15,7 @@ class SerializerValidationTests(SimpleTestCase):
         with self.subTest("no dates given", result_type="document"):
             serializer1 = SearchSerializer(
                 data={
-                    "result_type": "document",
+                    "result_types": ["document"],
                     "creatiedatum_vanaf": None,
                     "creatiedatum_tot_en_met": None,
                 }
@@ -26,7 +26,7 @@ class SerializerValidationTests(SimpleTestCase):
         with self.subTest("from date given", result_type="document"):
             serializer2 = SearchSerializer(
                 data={
-                    "result_type": "document",
+                    "result_types": ["document"],
                     "creatiedatum_vanaf": "2024-01-01",
                     "creatiedatum_tot_en_met": None,
                 }
@@ -37,7 +37,7 @@ class SerializerValidationTests(SimpleTestCase):
         with self.subTest("to date given", result_type="document"):
             serializer3 = SearchSerializer(
                 data={
-                    "result_type": "document",
+                    "result_types": ["document"],
                     "creatiedatum_vanaf": None,
                     "creatiedatum_tot_en_met": "2024-01-01",
                 }
@@ -52,7 +52,7 @@ class SerializerValidationTests(SimpleTestCase):
             with self.subTest("no dates given", result_type=result_type):
                 serializer1 = SearchSerializer(
                     data={
-                        "result_type": result_type,
+                        "result_types": [result_type],
                         "creatiedatum_vanaf": None,
                         "creatiedatum_tot_en_met": None,
                     }
@@ -63,7 +63,7 @@ class SerializerValidationTests(SimpleTestCase):
             with self.subTest("from date given", result_type=result_type):
                 serializer2 = SearchSerializer(
                     data={
-                        "result_type": result_type,
+                        "result_types": [result_type],
                         "creatiedatum_vanaf": "2024-01-01",
                         "creatiedatum_tot_en_met": None,
                     }
@@ -82,7 +82,7 @@ class SerializerValidationTests(SimpleTestCase):
             with self.subTest("to date given", result_type=result_type):
                 serializer3 = SearchSerializer(
                     data={
-                        "result_type": result_type,
+                        "result_types": [result_type],
                         "creatiedatum_vanaf": None,
                         "creatiedatum_tot_en_met": "2024-01-01",
                     }

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_indexing_api/DocumentApiE2ETest/test_document_creation_happy_flow.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_indexing_api/DocumentApiE2ETest/test_document_creation_happy_flow.yaml
@@ -1,9 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"0c5730c7-17ed-42a7-bc3b-5ee527ef3326","publicatie":"41009391-ae98-48ce-8e2d-1929aa8717b6","informatie_categorieen":[{"uuid":"06a6eb22-8beb-4dcc-9968-92f2a3bd00f6","naam":"Wear
-      free mission."}],"publisher":{"uuid":"b63410eb-5670-4e0b-9853-7ec5414de99e","naam":"Fuentes
-      Ltd"},"identifier":"identifier-0","officiele_titel":"Well ten western local.","verkorte_titel":"End
-      it seek.","omschrijving":"Wait kind war themselves. Trade decide machine.","creatiedatum":"2025-03-17","registratiedatum":"2025-03-19T20:03:44.584484+01:00","laatst_gewijzigd_datum":"2025-03-13T08:30:19.670958+01:00"}'
+    body: '{"uuid":"0c5730c7-17ed-42a7-bc3b-5ee527ef3326","publicatie":"8111d9c2-22a8-4df6-9a58-ff920882c1ee","informatie_categorieen":[{"uuid":"4666bb0f-4019-48a9-a5ca-ce48e62605b1","naam":"Fire
+      job edge."}],"publisher":{"uuid":"998ae358-a38e-45c0-a2ac-c39ad27fbba7","naam":"Nguyen,
+      Barry and Casey"},"identifier":"identifier-0","officiele_titel":"Car woman pretty.","verkorte_titel":"Exactly
+      word.","omschrijving":"Bill money pressure Congress myself might good. Treatment
+      part your this attack thing.","creatiedatum":"2025-03-11","registratiedatum":"2025-03-20T10:02:18.724154+01:00","laatst_gewijzigd_datum":"2025-03-17T05:50:20.817672+01:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -14,7 +15,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/document/_doc/0c5730c7-17ed-42a7-bc3b-5ee527ef3326?pipeline=document_attachment&refresh=wait_for
   response:
@@ -42,21 +43,22 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/document/_doc/0c5730c7-17ed-42a7-bc3b-5ee527ef3326
   response:
     body:
-      string: '{"_index":"document","_id":"0c5730c7-17ed-42a7-bc3b-5ee527ef3326","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"omschrijving":"Wait
-        kind war themselves. Trade decide machine.","identifier":"identifier-0","publicatie":"41009391-ae98-48ce-8e2d-1929aa8717b6","officiele_titel":"Well
-        ten western local.","informatie_categorieen":[{"naam":"Wear free mission.","uuid":"06a6eb22-8beb-4dcc-9968-92f2a3bd00f6"}],"publisher":{"naam":"Fuentes
-        Ltd","uuid":"b63410eb-5670-4e0b-9853-7ec5414de99e"},"creatiedatum":"2025-03-17","registratiedatum":"2025-03-19T20:03:44.584484+01:00","uuid":"0c5730c7-17ed-42a7-bc3b-5ee527ef3326","verkorte_titel":"End
-        it seek.","laatst_gewijzigd_datum":"2025-03-13T08:30:19.670958+01:00"}}'
+      string: '{"_index":"document","_id":"0c5730c7-17ed-42a7-bc3b-5ee527ef3326","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"omschrijving":"Bill
+        money pressure Congress myself might good. Treatment part your this attack
+        thing.","identifier":"identifier-0","publicatie":"8111d9c2-22a8-4df6-9a58-ff920882c1ee","officiele_titel":"Car
+        woman pretty.","informatie_categorieen":[{"naam":"Fire job edge.","uuid":"4666bb0f-4019-48a9-a5ca-ce48e62605b1"}],"publisher":{"naam":"Nguyen,
+        Barry and Casey","uuid":"998ae358-a38e-45c0-a2ac-c39ad27fbba7"},"creatiedatum":"2025-03-11","registratiedatum":"2025-03-20T10:02:18.724154+01:00","uuid":"0c5730c7-17ed-42a7-bc3b-5ee527ef3326","verkorte_titel":"Exactly
+        word.","laatst_gewijzigd_datum":"2025-03-17T05:50:20.817672+01:00"}}'
     headers:
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '727'
+      - '769'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_indexing_api/PublicationApiE2ETest/test_publication_creation_happy_flow.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_indexing_api/PublicationApiE2ETest/test_publication_creation_happy_flow.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"825d61d1-2bdd-4e11-8166-796e96a0bc07","publisher":{"uuid":"6d058855-e472-4384-8269-e6f19302e2a8","naam":"Bryan,
-      Wood and Estrada"},"informatie_categorieen":[{"uuid":"4b2f3f33-1e1d-497a-8a67-c72acf06f61b","naam":"Court
-      skin."}],"officiele_titel":"Protect coach maintain office.","verkorte_titel":"Heavy
-      stage.","omschrijving":"Class group else think.","registratiedatum":"2025-03-19T15:22:42.043612+01:00","laatst_gewijzigd_datum":"2025-03-05T20:01:36.046402+01:00"}'
+    body: '{"uuid":"825d61d1-2bdd-4e11-8166-796e96a0bc07","publisher":{"uuid":"1b48be5f-d570-4b9e-8daf-99ff1e1db964","naam":"Austin-Johnson"},"informatie_categorieen":[{"uuid":"247dcebb-7620-4a2f-99fb-e5c1ac21113f","naam":"Away
+      report today."}],"officiele_titel":"Ready art number condition.","verkorte_titel":"Country
+      mention.","omschrijving":"Information stop receive current later with kitchen.
+      Democrat cell decade exist.","registratiedatum":"2025-03-23T07:37:48.395821+01:00","laatst_gewijzigd_datum":"2025-03-10T04:54:34.969414+01:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -14,7 +14,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/publication/_doc/825d61d1-2bdd-4e11-8166-796e96a0bc07?refresh=wait_for
   response:
@@ -42,20 +42,20 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/publication/_doc/825d61d1-2bdd-4e11-8166-796e96a0bc07
   response:
     body:
-      string: '{"_index":"publication","_id":"825d61d1-2bdd-4e11-8166-796e96a0bc07","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"uuid":"825d61d1-2bdd-4e11-8166-796e96a0bc07","publisher":{"uuid":"6d058855-e472-4384-8269-e6f19302e2a8","naam":"Bryan,
-        Wood and Estrada"},"informatie_categorieen":[{"uuid":"4b2f3f33-1e1d-497a-8a67-c72acf06f61b","naam":"Court
-        skin."}],"officiele_titel":"Protect coach maintain office.","verkorte_titel":"Heavy
-        stage.","omschrijving":"Class group else think.","registratiedatum":"2025-03-19T15:22:42.043612+01:00","laatst_gewijzigd_datum":"2025-03-05T20:01:36.046402+01:00"}}'
+      string: '{"_index":"publication","_id":"825d61d1-2bdd-4e11-8166-796e96a0bc07","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"uuid":"825d61d1-2bdd-4e11-8166-796e96a0bc07","publisher":{"uuid":"1b48be5f-d570-4b9e-8daf-99ff1e1db964","naam":"Austin-Johnson"},"informatie_categorieen":[{"uuid":"247dcebb-7620-4a2f-99fb-e5c1ac21113f","naam":"Away
+        report today."}],"officiele_titel":"Ready art number condition.","verkorte_titel":"Country
+        mention.","omschrijving":"Information stop receive current later with kitchen.
+        Democrat cell decade exist.","registratiedatum":"2025-03-23T07:37:48.395821+01:00","laatst_gewijzigd_datum":"2025-03-10T04:54:34.969414+01:00"}}'
     headers:
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '610'
+      - '666'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_ingest/IngestPipelineTest/test_document_attachment_processor_with_correct_client.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_ingest/IngestPipelineTest/test_document_attachment_processor_with_correct_client.yaml
@@ -9,9 +9,9 @@ interactions:
       content-type:
       - application/vnd.elasticsearch+json; compatible-with=8
       user-agent:
-      - elasticsearch-py/8.17.1 (Python/3.12.6; elastic-transport/8.17.0)
+      - elasticsearch-py/8.17.1 (Python/3.12.9; elastic-transport/8.17.0)
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/_ingest/pipeline/document_attachment
   response:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_by_information_category_uuid.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_by_information_category_uuid.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"bd3831ce-adb5-4f26-aafc-85cc18055382","naam":"Green
-      Ltd"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Myself
-      Democrat feel important.","verkorte_titel":"Hear happen step.","omschrijving":"Type
-      might sport or within open specific. Guess apply both.","registratiedatum":"2025-03-20T20:06:45.336955","laatst_gewijzigd_datum":"2025-02-23T08:06:29.686422"}'
+    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"8964c078-108c-4fed-a40e-7472ad9b6924","naam":"Barber-Allen"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Board
+      dinner sit involve.","verkorte_titel":"East give.","omschrijving":"Safe particular
+      special natural. Property have sea total sit. Throughout boy surface forward
+      pass prove.","registratiedatum":"2025-03-22T11:52:02.431782","laatst_gewijzigd_datum":"2025-03-20T06:55:12.847292"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,11 +33,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"bf13bbfd-dacf-4058-938b-ede7044d56ab","naam":"Moore
-      LLC"},"informatie_categorieen":[{"uuid":"0ca9e806-a4b8-47ca-a42a-aa6f4cde36bf","naam":"Recent
-      know think."}],"officiele_titel":"Enter dark sport machine clearly each of answer.","verkorte_titel":"Five
-      single.","omschrijving":"Story after wrong picture rest service down though.
-      Part method wonder wind. Others much thought off front range huge.","registratiedatum":"2025-03-24T00:41:46.692713","laatst_gewijzigd_datum":"2025-03-05T01:44:13.388707"}'
+    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"02b8afe9-6655-4ee4-8b7e-ad3741b76913","naam":"Brown
+      Inc"},"informatie_categorieen":[{"uuid":"cf680e7c-e293-4a21-b3a0-93c1176752f3","naam":"Attorney
+      main chance door."}],"officiele_titel":"Stand enough condition join low.","verkorte_titel":"Happen
+      change.","omschrijving":"Today bank listen soon remain politics standard. Environmental
+      Congress chance about. Similar produce step have join.","registratiedatum":"2025-03-19T18:04:08.543412","laatst_gewijzigd_datum":"2025-02-27T01:54:50.979493"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -67,11 +67,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"4e05c525-2193-4ebc-a93c-077f957158fb","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"9550b511-6d1b-4e87-bb0c-88c88a5ccdc4","naam":"Smith
-      Ltd"},"identifier":"identifier-1","officiele_titel":"Sometimes thus mind seek
-      or force by similar.","verkorte_titel":"Week help.","omschrijving":"Arm spend
-      majority challenge big plan specific material. Fish well lay toward. Their strong
-      meeting. Public mouth stage line test sense sing.","creatiedatum":"2025-03-10","registratiedatum":"2025-03-21T01:19:30.843769","laatst_gewijzigd_datum":"2025-03-08T00:30:39.436891"}'
+    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"aba37680-6a5d-4582-b163-d5e5f78e6d4c","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"739562eb-4af5-4bac-9ea3-7ccaa1146e24","naam":"Cooper
+      and Sons"},"identifier":"identifier-1","officiele_titel":"Cup represent space
+      machine whatever indicate.","verkorte_titel":"Newspaper particularly eight.","omschrijving":"Room
+      inside hair decision mind. Around fast support become hundred plant. Kid effect
+      same Congress.","creatiedatum":"2025-03-13","registratiedatum":"2025-03-22T07:52:25.944666","laatst_gewijzigd_datum":"2025-03-12T10:39:48.441606"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -101,12 +101,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"c2cb3c33-700e-4c85-8d9a-059f37556606","informatie_categorieen":[{"uuid":"723c84dc-1124-4cd3-9f45-df29af07236b","naam":"Heavy
-      drug."}],"publisher":{"uuid":"43d8d44d-22df-4a28-9be8-beb4745b3478","naam":"Rodriguez,
-      White and Hanson"},"identifier":"identifier-2","officiele_titel":"Act concern
-      matter.","verkorte_titel":"Technology age how believe.","omschrijving":"Soon
-      recognize off suggest common. Describe state two serious class meeting above.
-      Future girl wish surface.","creatiedatum":"2025-03-19","registratiedatum":"2025-03-22T23:45:21.592003","laatst_gewijzigd_datum":"2025-03-14T20:06:59.742774"}'
+    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"b51dc27a-ff9c-4a37-9774-c40a3aabd935","informatie_categorieen":[{"uuid":"b1f42b74-a778-4f10-b447-b7fe4257ee40","naam":"Top
+      international."}],"publisher":{"uuid":"fa20c679-507d-4f35-8509-12ce42068e8b","naam":"Wilson,
+      Garcia and Smith"},"identifier":"identifier-2","officiele_titel":"Example bar
+      social energy.","verkorte_titel":"Western of interview.","omschrijving":"Half
+      heavy as threat large. Quite capital air go set. Outside center executive mouth
+      meeting walk. Need my oil even.","creatiedatum":"2025-02-27","registratiedatum":"2025-03-22T21:26:26.760702","laatst_gewijzigd_datum":"2025-02-24T04:37:28.044969"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -152,10 +152,11 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":4,"Categories":{"doc_count":4,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["0ca9e806-a4b8-47ca-a42a-aa6f4cde36bf","Recent
-        know think."],"key_as_string":"0ca9e806-a4b8-47ca-a42a-aa6f4cde36bf|Recent
-        know think.","doc_count":1},{"key":["723c84dc-1124-4cd3-9f45-df29af07236b","Heavy
-        drug."],"key_as_string":"723c84dc-1124-4cd3-9f45-df29af07236b|Heavy drug.","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}}},"Publisher":{"doc_count":0,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"ResultType":{"doc_count":0,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}}'
+      string: '{"took":3,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":4,"Categories":{"doc_count":4,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["b1f42b74-a778-4f10-b447-b7fe4257ee40","Top
+        international."],"key_as_string":"b1f42b74-a778-4f10-b447-b7fe4257ee40|Top
+        international.","doc_count":1},{"key":["cf680e7c-e293-4a21-b3a0-93c1176752f3","Attorney
+        main chance door."],"key_as_string":"cf680e7c-e293-4a21-b3a0-93c1176752f3|Attorney
+        main chance door.","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}}},"Publisher":{"doc_count":0,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"ResultType":{"doc_count":0,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -183,20 +184,21 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":2.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"bd3831ce-adb5-4f26-aafc-85cc18055382","naam":"Green
-        Ltd"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Myself
-        Democrat feel important.","verkorte_titel":"Hear happen step.","omschrijving":"Type
-        might sport or within open specific. Guess apply both.","registratiedatum":"2025-03-20T20:06:45.336955","laatst_gewijzigd_datum":"2025-02-23T08:06:29.686422"},"sort":[2.0,1740297989686]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":1.0,"_source":{"omschrijving":"Arm
-        spend majority challenge big plan specific material. Fish well lay toward.
-        Their strong meeting. Public mouth stage line test sense sing.","identifier":"identifier-1","publicatie":"4e05c525-2193-4ebc-a93c-077f957158fb","officiele_titel":"Sometimes
-        thus mind seek or force by similar.","informatie_categorieen":[{"naam":"Inspanningsverplichting","uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7"}],"publisher":{"naam":"Smith
-        Ltd","uuid":"9550b511-6d1b-4e87-bb0c-88c88a5ccdc4"},"creatiedatum":"2025-03-10","registratiedatum":"2025-03-21T01:19:30.843769","uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","verkorte_titel":"Week
-        help.","laatst_gewijzigd_datum":"2025-03-08T00:30:39.436891"},"sort":[1.0,1741393839436]}]},"aggregations":{"InformationCategories":{"doc_count":4,"Categories":{"doc_count":4,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["0ca9e806-a4b8-47ca-a42a-aa6f4cde36bf","Recent
-        know think."],"key_as_string":"0ca9e806-a4b8-47ca-a42a-aa6f4cde36bf|Recent
-        know think.","doc_count":1},{"key":["723c84dc-1124-4cd3-9f45-df29af07236b","Heavy
-        drug."],"key_as_string":"723c84dc-1124-4cd3-9f45-df29af07236b|Heavy drug.","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["9550b511-6d1b-4e87-bb0c-88c88a5ccdc4","Smith
-        Ltd"],"key_as_string":"9550b511-6d1b-4e87-bb0c-88c88a5ccdc4|Smith Ltd","doc_count":1},{"key":["bd3831ce-adb5-4f26-aafc-85cc18055382","Green
-        Ltd"],"key_as_string":"bd3831ce-adb5-4f26-aafc-85cc18055382|Green Ltd","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
+      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":2.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"8964c078-108c-4fed-a40e-7472ad9b6924","naam":"Barber-Allen"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Board
+        dinner sit involve.","verkorte_titel":"East give.","omschrijving":"Safe particular
+        special natural. Property have sea total sit. Throughout boy surface forward
+        pass prove.","registratiedatum":"2025-03-22T11:52:02.431782","laatst_gewijzigd_datum":"2025-03-20T06:55:12.847292"},"sort":[2.0,1742453712847]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":1.0,"_source":{"omschrijving":"Room
+        inside hair decision mind. Around fast support become hundred plant. Kid effect
+        same Congress.","identifier":"identifier-1","publicatie":"aba37680-6a5d-4582-b163-d5e5f78e6d4c","officiele_titel":"Cup
+        represent space machine whatever indicate.","informatie_categorieen":[{"naam":"Inspanningsverplichting","uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7"}],"publisher":{"naam":"Cooper
+        and Sons","uuid":"739562eb-4af5-4bac-9ea3-7ccaa1146e24"},"creatiedatum":"2025-03-13","registratiedatum":"2025-03-22T07:52:25.944666","uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","verkorte_titel":"Newspaper
+        particularly eight.","laatst_gewijzigd_datum":"2025-03-12T10:39:48.441606"},"sort":[1.0,1741775988441]}]},"aggregations":{"InformationCategories":{"doc_count":4,"Categories":{"doc_count":4,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["b1f42b74-a778-4f10-b447-b7fe4257ee40","Top
+        international."],"key_as_string":"b1f42b74-a778-4f10-b447-b7fe4257ee40|Top
+        international.","doc_count":1},{"key":["cf680e7c-e293-4a21-b3a0-93c1176752f3","Attorney
+        main chance door."],"key_as_string":"cf680e7c-e293-4a21-b3a0-93c1176752f3|Attorney
+        main chance door.","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["739562eb-4af5-4bac-9ea3-7ccaa1146e24","Cooper
+        and Sons"],"key_as_string":"739562eb-4af5-4bac-9ea3-7ccaa1146e24|Cooper and
+        Sons","doc_count":1},{"key":["8964c078-108c-4fed-a40e-7472ad9b6924","Barber-Allen"],"key_as_string":"8964c078-108c-4fed-a40e-7472ad9b6924|Barber-Allen","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -224,16 +226,18 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":14,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":1.0,"_source":{"omschrijving":"Arm
-        spend majority challenge big plan specific material. Fish well lay toward.
-        Their strong meeting. Public mouth stage line test sense sing.","identifier":"identifier-1","publicatie":"4e05c525-2193-4ebc-a93c-077f957158fb","officiele_titel":"Sometimes
-        thus mind seek or force by similar.","informatie_categorieen":[{"naam":"Inspanningsverplichting","uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7"}],"publisher":{"naam":"Smith
-        Ltd","uuid":"9550b511-6d1b-4e87-bb0c-88c88a5ccdc4"},"creatiedatum":"2025-03-10","registratiedatum":"2025-03-21T01:19:30.843769","uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","verkorte_titel":"Week
-        help.","laatst_gewijzigd_datum":"2025-03-08T00:30:39.436891"},"sort":[1.0,1741393839436]}]},"aggregations":{"InformationCategories":{"doc_count":4,"Categories":{"doc_count":4,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["0ca9e806-a4b8-47ca-a42a-aa6f4cde36bf","Recent
-        know think."],"key_as_string":"0ca9e806-a4b8-47ca-a42a-aa6f4cde36bf|Recent
-        know think.","doc_count":1},{"key":["723c84dc-1124-4cd3-9f45-df29af07236b","Heavy
-        drug."],"key_as_string":"723c84dc-1124-4cd3-9f45-df29af07236b|Heavy drug.","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["9550b511-6d1b-4e87-bb0c-88c88a5ccdc4","Smith
-        Ltd"],"key_as_string":"9550b511-6d1b-4e87-bb0c-88c88a5ccdc4|Smith Ltd","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
+      string: '{"took":4,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":1.0,"_source":{"omschrijving":"Room
+        inside hair decision mind. Around fast support become hundred plant. Kid effect
+        same Congress.","identifier":"identifier-1","publicatie":"aba37680-6a5d-4582-b163-d5e5f78e6d4c","officiele_titel":"Cup
+        represent space machine whatever indicate.","informatie_categorieen":[{"naam":"Inspanningsverplichting","uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7"}],"publisher":{"naam":"Cooper
+        and Sons","uuid":"739562eb-4af5-4bac-9ea3-7ccaa1146e24"},"creatiedatum":"2025-03-13","registratiedatum":"2025-03-22T07:52:25.944666","uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","verkorte_titel":"Newspaper
+        particularly eight.","laatst_gewijzigd_datum":"2025-03-12T10:39:48.441606"},"sort":[1.0,1741775988441]}]},"aggregations":{"InformationCategories":{"doc_count":4,"Categories":{"doc_count":4,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["b1f42b74-a778-4f10-b447-b7fe4257ee40","Top
+        international."],"key_as_string":"b1f42b74-a778-4f10-b447-b7fe4257ee40|Top
+        international.","doc_count":1},{"key":["cf680e7c-e293-4a21-b3a0-93c1176752f3","Attorney
+        main chance door."],"key_as_string":"cf680e7c-e293-4a21-b3a0-93c1176752f3|Attorney
+        main chance door.","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["739562eb-4af5-4bac-9ea3-7ccaa1146e24","Cooper
+        and Sons"],"key_as_string":"739562eb-4af5-4bac-9ea3-7ccaa1146e24|Cooper and
+        Sons","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_by_publisher_and_information_category.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_by_publisher_and_information_category.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"16b924da-a3ae-4040-9b73-98f13a0b5070","informatie_categorieen":[{"uuid":"c9001845-aef0-4150-bbf0-a5f5c096e603","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-3","officiele_titel":"Figure
-      star people none me.","verkorte_titel":"Similar country radio.","omschrijving":"How
-      office among big. Rise training create eat become quite suddenly opportunity.
-      Yard center letter door.","creatiedatum":"2025-03-06","registratiedatum":"2025-03-20T12:05:40.109176","laatst_gewijzigd_datum":"2025-03-19T08:45:59.870483"}'
+    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"4a21adeb-2324-4c03-a68d-e8040e3d9b44","informatie_categorieen":[{"uuid":"c9001845-aef0-4150-bbf0-a5f5c096e603","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-3","officiele_titel":"Item
+      him southern compare daughter.","verkorte_titel":"Risk movie.","omschrijving":"Health
+      against theory decision understand. Thing home event management of place. Physical
+      bag there help until form.","creatiedatum":"2025-03-03","registratiedatum":"2025-03-20T03:04:50.817055","laatst_gewijzigd_datum":"2025-03-24T01:20:26.673268"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,10 +33,9 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"ef80ae15-358b-41c3-ace8-8bd62c113716","informatie_categorieen":[{"uuid":"70aa62cf-f404-47c6-92a5-78cb40cedc41","naam":"WOO"}],"publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"identifier":"identifier-4","officiele_titel":"Mean
-      able type represent cover.","verkorte_titel":"Ok challenge art.","omschrijving":"Full
-      sense share letter employee above. Trouble card particularly reduce space heart
-      glass professional.","creatiedatum":"2025-03-01","registratiedatum":"2025-03-20T09:26:08.535136","laatst_gewijzigd_datum":"2025-03-07T04:15:13.064718"}'
+    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"465b55bf-ffbb-4da6-bde1-846bcd9f8e21","informatie_categorieen":[{"uuid":"70aa62cf-f404-47c6-92a5-78cb40cedc41","naam":"WOO"}],"publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"identifier":"identifier-4","officiele_titel":"Cut
+      around financial myself back good.","verkorte_titel":"Least measure.","omschrijving":"Test
+      choice hand animal six court. Heart newspaper south radio street media.","creatiedatum":"2025-03-05","registratiedatum":"2025-03-21T10:01:57.767351","laatst_gewijzigd_datum":"2025-03-08T16:45:36.312841"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -82,7 +81,7 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":14,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c9001845-aef0-4150-bbf0-a5f5c096e603","Inspanningsverplichting"],"key_as_string":"c9001845-aef0-4150-bbf0-a5f5c096e603|Inspanningsverplichting","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1}]}},"ResultType":{"doc_count":0,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}}'
+      string: '{"took":4,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c9001845-aef0-4150-bbf0-a5f5c096e603","Inspanningsverplichting"],"key_as_string":"c9001845-aef0-4150-bbf0-a5f5c096e603|Inspanningsverplichting","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1}]}},"ResultType":{"doc_count":0,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_by_publisher_and_information_category_and_result_type.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_by_publisher_and_information_category_and_result_type.yaml
@@ -1,9 +1,8 @@
 interactions:
 - request:
-    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"informatie_categorieen":[{"uuid":"c9001845-aef0-4150-bbf0-a5f5c096e603","naam":"Inspanningsverplichting"}],"officiele_titel":"Produce
-      small their Democrat box concern better.","verkorte_titel":"Mother church.","omschrijving":"Walk
-      consider part movement level southern hospital remember. Reduce wall authority
-      goal. Worry performance happy bill any possible heavy.","registratiedatum":"2025-03-23T09:17:47.293710","laatst_gewijzigd_datum":"2025-03-23T23:46:46.567393"}'
+    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"informatie_categorieen":[{"uuid":"c9001845-aef0-4150-bbf0-a5f5c096e603","naam":"Inspanningsverplichting"}],"officiele_titel":"Start
+      behind hit.","verkorte_titel":"Bank capital.","omschrijving":"Least body simple
+      reveal third their court without. Security entire knowledge determine staff.","registratiedatum":"2025-03-23T07:07:56.015269","laatst_gewijzigd_datum":"2025-03-18T22:50:21.261338"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,10 +32,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"7246ea5d-72c7-4ab5-ae71-cc52cad67c62","publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"informatie_categorieen":[{"uuid":"70aa62cf-f404-47c6-92a5-78cb40cedc41","naam":"WOO"}],"officiele_titel":"Do
-      place market that blue the sit.","verkorte_titel":"Real seven avoid.","omschrijving":"Administration
-      second director hair whether. Place answer serious fine when stand help. Value
-      former scene dinner important.","registratiedatum":"2025-03-20T04:09:47.671834","laatst_gewijzigd_datum":"2025-03-23T15:21:54.154458"}'
+    body: '{"uuid":"7246ea5d-72c7-4ab5-ae71-cc52cad67c62","publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"informatie_categorieen":[{"uuid":"70aa62cf-f404-47c6-92a5-78cb40cedc41","naam":"WOO"}],"officiele_titel":"Space
+      commercial determine civil.","verkorte_titel":"Activity teach.","omschrijving":"Boy
+      rule number turn media south great. Network phone indeed learn top floor. Game
+      require American party.","registratiedatum":"2025-03-21T23:35:08.028392","laatst_gewijzigd_datum":"2025-03-20T03:21:09.508736"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -66,10 +65,9 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"a73d00a0-2d01-4fcf-8b9e-e8cb9e2c81b2","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"c9001845-aef0-4150-bbf0-a5f5c096e603","naam":"Inspanningsverplichting"}],"officiele_titel":"Computer
-      think ability organization garden.","verkorte_titel":"Across him address.","omschrijving":"Soon
-      despite throw. Through on everyone whole employee spend floor when. Education
-      off suggest role. Boy military impact out series huge our parent.","registratiedatum":"2025-03-19T14:35:21.545424","laatst_gewijzigd_datum":"2025-03-10T11:34:46.080673"}'
+    body: '{"uuid":"a73d00a0-2d01-4fcf-8b9e-e8cb9e2c81b2","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"c9001845-aef0-4150-bbf0-a5f5c096e603","naam":"Inspanningsverplichting"}],"officiele_titel":"Choice
+      election cup.","verkorte_titel":"Born whole.","omschrijving":"Quickly all pass
+      group finish choose may. Quickly girl street stay network understand.","registratiedatum":"2025-03-22T11:16:53.420168","laatst_gewijzigd_datum":"2025-03-16T09:25:49.963217"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -99,9 +97,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"fd779365-250f-4f1c-9de6-0c308a1f9093","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"70aa62cf-f404-47c6-92a5-78cb40cedc41","naam":"WOO"}],"officiele_titel":"Road
-      difference window room indeed career dinner.","verkorte_titel":"Last cost lot.","omschrijving":"Hand
-      fish education. Start particularly religious place fear.","registratiedatum":"2025-03-19T19:27:23.091108","laatst_gewijzigd_datum":"2025-03-20T12:55:08.323906"}'
+    body: '{"uuid":"fd779365-250f-4f1c-9de6-0c308a1f9093","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"70aa62cf-f404-47c6-92a5-78cb40cedc41","naam":"WOO"}],"officiele_titel":"Minute
+      clear sense which.","verkorte_titel":"Activity as.","omschrijving":"Point ball
+      look always foot billion another deep. Set line help we nearly large improve.
+      Little meeting road.","registratiedatum":"2025-03-21T02:18:58.671717","laatst_gewijzigd_datum":"2025-03-11T18:23:23.514486"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -131,10 +130,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"e6c8c179-d118-4d0e-96ec-75d168e2300d","informatie_categorieen":[{"uuid":"c9001845-aef0-4150-bbf0-a5f5c096e603","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-5","officiele_titel":"Quality
-      day money edge fish.","verkorte_titel":"West agency.","omschrijving":"In produce
-      adult left. Half fill base look themselves stock draw behind. Become happen
-      ground care civil.","creatiedatum":"2025-03-01","registratiedatum":"2025-03-20T17:21:14.616292","laatst_gewijzigd_datum":"2025-02-27T22:19:20.775771"}'
+    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"03a80d83-6744-4c56-b8ee-5eb7031a81ab","informatie_categorieen":[{"uuid":"c9001845-aef0-4150-bbf0-a5f5c096e603","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-5","officiele_titel":"Possible
+      attention floor true although possible president.","verkorte_titel":"Cell son.","omschrijving":"Night
+      response notice late join. Federal bag argue floor ten paper hotel various.
+      Way fight health want herself.","creatiedatum":"2025-03-02","registratiedatum":"2025-03-19T23:20:56.759426","laatst_gewijzigd_datum":"2025-03-15T14:10:30.318887"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -164,10 +163,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"c46347e1-e10e-47f4-b47d-0667cfe4e009","informatie_categorieen":[{"uuid":"70aa62cf-f404-47c6-92a5-78cb40cedc41","naam":"WOO"}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-6","officiele_titel":"Three
-      employee director charge garden.","verkorte_titel":"Member police start.","omschrijving":"Look
-      paper type everybody wait relationship decision food. Quality computer case
-      tough enjoy.","creatiedatum":"2025-02-23","registratiedatum":"2025-03-19T19:19:31.923598","laatst_gewijzigd_datum":"2025-03-12T04:48:06.173788"}'
+    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"06e0fd95-c737-4b2a-9759-ae8c2abb177f","informatie_categorieen":[{"uuid":"70aa62cf-f404-47c6-92a5-78cb40cedc41","naam":"WOO"}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-6","officiele_titel":"Wife
+      night recognize involve federal fine traditional newspaper.","verkorte_titel":"Right
+      analysis.","omschrijving":"Brother whatever hard. Brother miss either fight
+      quality exactly create.","creatiedatum":"2025-03-04","registratiedatum":"2025-03-24T07:25:55.337380","laatst_gewijzigd_datum":"2025-03-05T02:56:21.624300"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -197,9 +196,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"23a6663d-3dfd-4ffd-9179-855eb7d5f26d","publicatie":"0a315ed2-86b4-4984-9e78-861ad79d92d1","informatie_categorieen":[{"uuid":"c9001845-aef0-4150-bbf0-a5f5c096e603","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"identifier":"identifier-7","officiele_titel":"Compare
-      east type again research scene out pick.","verkorte_titel":"Very.","omschrijving":"Task
-      wear machine share gas.","creatiedatum":"2025-03-05","registratiedatum":"2025-03-21T09:11:48.583395","laatst_gewijzigd_datum":"2025-03-18T03:10:41.462650"}'
+    body: '{"uuid":"23a6663d-3dfd-4ffd-9179-855eb7d5f26d","publicatie":"f75f351b-240a-4eec-b6b0-354bc8fa4315","informatie_categorieen":[{"uuid":"c9001845-aef0-4150-bbf0-a5f5c096e603","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"identifier":"identifier-7","officiele_titel":"Real
+      power sign off dinner term.","verkorte_titel":"Onto speak center.","omschrijving":"Explain
+      many camera let. Education yeah none positive dark artist peace. Side nature
+      player.","creatiedatum":"2025-03-11","registratiedatum":"2025-03-23T14:56:15.588957","laatst_gewijzigd_datum":"2025-02-22T20:02:54.923056"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -229,10 +229,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"56a2576a-519a-4c53-8507-966a971a6e51","publicatie":"6c244f74-82c0-4d8e-90fc-6d6c45b3f2dd","informatie_categorieen":[{"uuid":"70aa62cf-f404-47c6-92a5-78cb40cedc41","naam":"WOO"}],"publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"identifier":"identifier-8","officiele_titel":"Social
-      chance north maybe beat.","verkorte_titel":"Result current.","omschrijving":"Sport
-      collection piece present himself. House information central specific TV. Us
-      accept usually field sit.","creatiedatum":"2025-03-07","registratiedatum":"2025-03-19T15:03:19.812434","laatst_gewijzigd_datum":"2025-03-08T22:58:02.939822"}'
+    body: '{"uuid":"56a2576a-519a-4c53-8507-966a971a6e51","publicatie":"d588d067-c92a-4b98-875c-3def0f644744","informatie_categorieen":[{"uuid":"70aa62cf-f404-47c6-92a5-78cb40cedc41","naam":"WOO"}],"publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"identifier":"identifier-8","officiele_titel":"Then
+      determine whom owner program.","verkorte_titel":"Effort sign fine able.","omschrijving":"Rise
+      be story kind common quality program. Film example tax letter pass. Meeting
+      section enter lot control role.","creatiedatum":"2025-03-02","registratiedatum":"2025-03-24T14:51:27.882251","laatst_gewijzigd_datum":"2025-02-28T14:24:57.663680"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -262,7 +262,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"post_filter":{"bool":{"must":[{"term":{"_index":"document"}},{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}},{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["c9001845-aef0-4150-bbf0-a5f5c096e603"]}}}}]}},"aggs":{"ResultType":{"filter":{"bool":{"must":[{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["c9001845-aef0-4150-bbf0-a5f5c096e603"]}}}},{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}}]}},"aggs":{"FilteredResultType":{"terms":{"field":"_index"}}}},"Publisher":{"filter":{"bool":{"must":[{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["c9001845-aef0-4150-bbf0-a5f5c096e603"]}}}},{"term":{"_index":"document"}}]}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"bool":{"must":[{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}},{"term":{"_index":"document"}}]}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"post_filter":{"bool":{"must":[{"terms":{"_index":["document"]}},{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}},{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["c9001845-aef0-4150-bbf0-a5f5c096e603"]}}}}]}},"aggs":{"ResultType":{"filter":{"bool":{"must":[{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["c9001845-aef0-4150-bbf0-a5f5c096e603"]}}}},{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}}]}},"aggs":{"FilteredResultType":{"terms":{"field":"_index"}}}},"Publisher":{"filter":{"bool":{"must":[{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["c9001845-aef0-4150-bbf0-a5f5c096e603"]}}}},{"terms":{"_index":["document"]}}]}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"bool":{"must":[{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}},{"terms":{"_index":["document"]}}]}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -278,11 +278,11 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":21,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":1.0,"_source":{"omschrijving":"In
-        produce adult left. Half fill base look themselves stock draw behind. Become
-        happen ground care civil.","identifier":"identifier-5","publicatie":"e6c8c179-d118-4d0e-96ec-75d168e2300d","officiele_titel":"Quality
-        day money edge fish.","informatie_categorieen":[{"naam":"Inspanningsverplichting","uuid":"c9001845-aef0-4150-bbf0-a5f5c096e603"}],"publisher":{"naam":"Dimpact","uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7"},"creatiedatum":"2025-03-01","registratiedatum":"2025-03-20T17:21:14.616292","uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","verkorte_titel":"West
-        agency.","laatst_gewijzigd_datum":"2025-02-27T22:19:20.775771"},"sort":[1.0,1740694760775]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["70aa62cf-f404-47c6-92a5-78cb40cedc41","WOO"],"key_as_string":"70aa62cf-f404-47c6-92a5-78cb40cedc41|WOO","doc_count":1},{"key":["c9001845-aef0-4150-bbf0-a5f5c096e603","Inspanningsverplichting"],"key_as_string":"c9001845-aef0-4150-bbf0-a5f5c096e603|Inspanningsverplichting","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
+      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":1.0,"_source":{"omschrijving":"Night
+        response notice late join. Federal bag argue floor ten paper hotel various.
+        Way fight health want herself.","identifier":"identifier-5","publicatie":"03a80d83-6744-4c56-b8ee-5eb7031a81ab","officiele_titel":"Possible
+        attention floor true although possible president.","informatie_categorieen":[{"naam":"Inspanningsverplichting","uuid":"c9001845-aef0-4150-bbf0-a5f5c096e603"}],"publisher":{"naam":"Dimpact","uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7"},"creatiedatum":"2025-03-02","registratiedatum":"2025-03-19T23:20:56.759426","uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","verkorte_titel":"Cell
+        son.","laatst_gewijzigd_datum":"2025-03-15T14:10:30.318887"},"sort":[1.0,1742047830318]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["70aa62cf-f404-47c6-92a5-78cb40cedc41","WOO"],"key_as_string":"70aa62cf-f404-47c6-92a5-78cb40cedc41|WOO","doc_count":1},{"key":["c9001845-aef0-4150-bbf0-a5f5c096e603","Inspanningsverplichting"],"key_as_string":"c9001845-aef0-4150-bbf0-a5f5c096e603|Inspanningsverplichting","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_by_publisher_uuid.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_by_publisher_uuid.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"25d72db2-58cf-4a12-a0fd-2cafd9a781d2","naam":"Part
-      author."}],"officiele_titel":"Note generation yes others bad company support.","verkorte_titel":"Natural
-      wrong.","omschrijving":"Improve nothing air article in travel. Couple occur
-      treat article finish.","registratiedatum":"2025-03-22T07:05:03.083054","laatst_gewijzigd_datum":"2025-03-15T13:47:14.539069"}'
+    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"07415f89-c238-4dd7-8e10-27e25095e8ad","naam":"Network
+      gas race human."}],"officiele_titel":"Area hundred news while.","verkorte_titel":"Country
+      catch.","omschrijving":"Need trip hand treatment interview character who. Down
+      leader father newspaper. Try anything last in safe.","registratiedatum":"2025-03-19T16:38:47.090813","laatst_gewijzigd_datum":"2025-03-08T08:04:48.485506"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,11 +33,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"d84a5257-9ed4-4b25-9b20-1b508d8f80d3","naam":"Barber,
-      Gomez and Santiago"},"informatie_categorieen":[{"uuid":"5725c7ef-8d54-4255-9a67-ff05de992900","naam":"Although."}],"officiele_titel":"Less
-      air star area leg quickly little.","verkorte_titel":"Imagine identify.","omschrijving":"Party
-      who particularly poor maintain. Article little soldier lose third smile. Couple
-      Mrs perform easy.","registratiedatum":"2025-03-23T03:48:23.854787","laatst_gewijzigd_datum":"2025-02-22T14:21:13.909976"}'
+    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"fe5e5e11-b7db-46e1-998d-6538d9190801","naam":"Williams-Boone"},"informatie_categorieen":[{"uuid":"ff7e5d53-c36c-4031-be27-2c32f4af063a","naam":"Professor
+      land."}],"officiele_titel":"Experience threat rule record their.","verkorte_titel":"Level
+      political.","omschrijving":"Measure only church second fish short within. Us
+      marriage budget system reduce beyond. Debate statement Mrs room child participant
+      their.","registratiedatum":"2025-03-23T22:41:30.232907","laatst_gewijzigd_datum":"2025-03-17T21:43:16.527519"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -67,11 +67,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"3c6c92de-b09c-458e-a44b-5d05893922ed","informatie_categorieen":[{"uuid":"d8eb4df7-8fec-4446-9344-e9dd0952832a","naam":"House
-      size."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-9","officiele_titel":"Policy
-      attention feel world painting.","verkorte_titel":"Loss task believe.","omschrijving":"Of
-      certainly reflect over think evening course same. Still knowledge later produce
-      positive build.","creatiedatum":"2025-03-21","registratiedatum":"2025-03-22T08:00:18.061349","laatst_gewijzigd_datum":"2025-03-05T19:28:21.365880"}'
+    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"8a95809d-0fd5-41fa-b273-b8cc4657f52a","informatie_categorieen":[{"uuid":"e578c7a3-3952-41c1-9c3f-656041529c8a","naam":"Then."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-9","officiele_titel":"Right
+      on could possible.","verkorte_titel":"Bit kid.","omschrijving":"Check what really
+      finally movement cultural into. List carry book heavy buy oil. Affect person
+      interest which risk. Senior cause lead sport decision player.","creatiedatum":"2025-03-05","registratiedatum":"2025-03-20T06:02:06.403870","laatst_gewijzigd_datum":"2025-03-03T23:14:09.228070"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -101,12 +100,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"8cec91dc-40d2-4cba-8223-84d36896c82e","informatie_categorieen":[{"uuid":"717441f3-bd87-4b0e-8c61-68b088447f3b","naam":"Gas
-      wrong wear."}],"publisher":{"uuid":"b9f4f784-a20c-4cf3-8a1a-e9a044c8a86d","naam":"Bennett
-      and Sons"},"identifier":"identifier-10","officiele_titel":"Stand about protect
-      major design Republican artist.","verkorte_titel":"Opportunity step care.","omschrijving":"Pass
-      ask dog industry authority situation president. Open maintain drug over. Serious
-      student tell.","creatiedatum":"2025-03-12","registratiedatum":"2025-03-23T19:41:53.847641","laatst_gewijzigd_datum":"2025-03-18T23:02:11.814472"}'
+    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"2be6232b-281e-4861-87de-a032d09cb553","informatie_categorieen":[{"uuid":"d828842f-516a-4c5b-bce2-8ccf829c500f","naam":"Ability
+      me force kitchen."}],"publisher":{"uuid":"444f37d9-0ba1-460f-b049-07530ebb01b8","naam":"Barry-Morales"},"identifier":"identifier-10","officiele_titel":"Front
+      culture cold tend mean lawyer.","verkorte_titel":"Good market at since.","omschrijving":"Right
+      what item from director memory natural. Out population public create sign. Respond
+      talk thank next.","creatiedatum":"2025-03-07","registratiedatum":"2025-03-22T15:53:39.767177","laatst_gewijzigd_datum":"2025-02-28T00:03:45.472235"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -152,11 +150,7 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":13,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count":0,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}},"Publisher":{"doc_count":4,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["b9f4f784-a20c-4cf3-8a1a-e9a044c8a86d","Bennett
-        and Sons"],"key_as_string":"b9f4f784-a20c-4cf3-8a1a-e9a044c8a86d|Bennett and
-        Sons","doc_count":1},{"key":["d84a5257-9ed4-4b25-9b20-1b508d8f80d3","Barber,
-        Gomez and Santiago"],"key_as_string":"d84a5257-9ed4-4b25-9b20-1b508d8f80d3|Barber,
-        Gomez and Santiago","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]}},"ResultType":{"doc_count":0,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}}'
+      string: '{"took":4,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count":0,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}},"Publisher":{"doc_count":4,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["444f37d9-0ba1-460f-b049-07530ebb01b8","Barry-Morales"],"key_as_string":"444f37d9-0ba1-460f-b049-07530ebb01b8|Barry-Morales","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1},{"key":["fe5e5e11-b7db-46e1-998d-6538d9190801","Williams-Boone"],"key_as_string":"fe5e5e11-b7db-46e1-998d-6538d9190801|Williams-Boone","doc_count":1}]}},"ResultType":{"doc_count":0,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -184,20 +178,16 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":19,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":2.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"25d72db2-58cf-4a12-a0fd-2cafd9a781d2","naam":"Part
-        author."}],"officiele_titel":"Note generation yes others bad company support.","verkorte_titel":"Natural
-        wrong.","omschrijving":"Improve nothing air article in travel. Couple occur
-        treat article finish.","registratiedatum":"2025-03-22T07:05:03.083054","laatst_gewijzigd_datum":"2025-03-15T13:47:14.539069"},"sort":[2.0,1742046434539]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":1.0,"_source":{"omschrijving":"Of
-        certainly reflect over think evening course same. Still knowledge later produce
-        positive build.","identifier":"identifier-9","publicatie":"3c6c92de-b09c-458e-a44b-5d05893922ed","officiele_titel":"Policy
-        attention feel world painting.","informatie_categorieen":[{"naam":"House size.","uuid":"d8eb4df7-8fec-4446-9344-e9dd0952832a"}],"publisher":{"naam":"Dimpact","uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7"},"creatiedatum":"2025-03-21","registratiedatum":"2025-03-22T08:00:18.061349","uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","verkorte_titel":"Loss
-        task believe.","laatst_gewijzigd_datum":"2025-03-05T19:28:21.365880"},"sort":[1.0,1741202901365]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["25d72db2-58cf-4a12-a0fd-2cafd9a781d2","Part
-        author."],"key_as_string":"25d72db2-58cf-4a12-a0fd-2cafd9a781d2|Part author.","doc_count":1},{"key":["d8eb4df7-8fec-4446-9344-e9dd0952832a","House
-        size."],"key_as_string":"d8eb4df7-8fec-4446-9344-e9dd0952832a|House size.","doc_count":1}]}}},"Publisher":{"doc_count":4,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["b9f4f784-a20c-4cf3-8a1a-e9a044c8a86d","Bennett
-        and Sons"],"key_as_string":"b9f4f784-a20c-4cf3-8a1a-e9a044c8a86d|Bennett and
-        Sons","doc_count":1},{"key":["d84a5257-9ed4-4b25-9b20-1b508d8f80d3","Barber,
-        Gomez and Santiago"],"key_as_string":"d84a5257-9ed4-4b25-9b20-1b508d8f80d3|Barber,
-        Gomez and Santiago","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
+      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":2.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"informatie_categorieen":[{"uuid":"07415f89-c238-4dd7-8e10-27e25095e8ad","naam":"Network
+        gas race human."}],"officiele_titel":"Area hundred news while.","verkorte_titel":"Country
+        catch.","omschrijving":"Need trip hand treatment interview character who.
+        Down leader father newspaper. Try anything last in safe.","registratiedatum":"2025-03-19T16:38:47.090813","laatst_gewijzigd_datum":"2025-03-08T08:04:48.485506"},"sort":[2.0,1741421088485]},{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":1.0,"_source":{"omschrijving":"Check
+        what really finally movement cultural into. List carry book heavy buy oil.
+        Affect person interest which risk. Senior cause lead sport decision player.","identifier":"identifier-9","publicatie":"8a95809d-0fd5-41fa-b273-b8cc4657f52a","officiele_titel":"Right
+        on could possible.","informatie_categorieen":[{"naam":"Then.","uuid":"e578c7a3-3952-41c1-9c3f-656041529c8a"}],"publisher":{"naam":"Dimpact","uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7"},"creatiedatum":"2025-03-05","registratiedatum":"2025-03-20T06:02:06.403870","uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","verkorte_titel":"Bit
+        kid.","laatst_gewijzigd_datum":"2025-03-03T23:14:09.228070"},"sort":[1.0,1741043649228]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["07415f89-c238-4dd7-8e10-27e25095e8ad","Network
+        gas race human."],"key_as_string":"07415f89-c238-4dd7-8e10-27e25095e8ad|Network
+        gas race human.","doc_count":1},{"key":["e578c7a3-3952-41c1-9c3f-656041529c8a","Then."],"key_as_string":"e578c7a3-3952-41c1-9c3f-656041529c8a|Then.","doc_count":1}]}}},"Publisher":{"doc_count":4,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["444f37d9-0ba1-460f-b049-07530ebb01b8","Barry-Morales"],"key_as_string":"444f37d9-0ba1-460f-b049-07530ebb01b8|Barry-Morales","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1},{"key":["fe5e5e11-b7db-46e1-998d-6538d9190801","Williams-Boone"],"key_as_string":"fe5e5e11-b7db-46e1-998d-6538d9190801|Williams-Boone","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -225,16 +215,11 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":1.0,"_source":{"omschrijving":"Of
-        certainly reflect over think evening course same. Still knowledge later produce
-        positive build.","identifier":"identifier-9","publicatie":"3c6c92de-b09c-458e-a44b-5d05893922ed","officiele_titel":"Policy
-        attention feel world painting.","informatie_categorieen":[{"naam":"House size.","uuid":"d8eb4df7-8fec-4446-9344-e9dd0952832a"}],"publisher":{"naam":"Dimpact","uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7"},"creatiedatum":"2025-03-21","registratiedatum":"2025-03-22T08:00:18.061349","uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","verkorte_titel":"Loss
-        task believe.","laatst_gewijzigd_datum":"2025-03-05T19:28:21.365880"},"sort":[1.0,1741202901365]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["d8eb4df7-8fec-4446-9344-e9dd0952832a","House
-        size."],"key_as_string":"d8eb4df7-8fec-4446-9344-e9dd0952832a|House size.","doc_count":1}]}}},"Publisher":{"doc_count":4,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["b9f4f784-a20c-4cf3-8a1a-e9a044c8a86d","Bennett
-        and Sons"],"key_as_string":"b9f4f784-a20c-4cf3-8a1a-e9a044c8a86d|Bennett and
-        Sons","doc_count":1},{"key":["d84a5257-9ed4-4b25-9b20-1b508d8f80d3","Barber,
-        Gomez and Santiago"],"key_as_string":"d84a5257-9ed4-4b25-9b20-1b508d8f80d3|Barber,
-        Gomez and Santiago","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
+      string: '{"took":4,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":1.0,"_source":{"omschrijving":"Check
+        what really finally movement cultural into. List carry book heavy buy oil.
+        Affect person interest which risk. Senior cause lead sport decision player.","identifier":"identifier-9","publicatie":"8a95809d-0fd5-41fa-b273-b8cc4657f52a","officiele_titel":"Right
+        on could possible.","informatie_categorieen":[{"naam":"Then.","uuid":"e578c7a3-3952-41c1-9c3f-656041529c8a"}],"publisher":{"naam":"Dimpact","uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7"},"creatiedatum":"2025-03-05","registratiedatum":"2025-03-20T06:02:06.403870","uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","verkorte_titel":"Bit
+        kid.","laatst_gewijzigd_datum":"2025-03-03T23:14:09.228070"},"sort":[1.0,1741043649228]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e578c7a3-3952-41c1-9c3f-656041529c8a","Then."],"key_as_string":"e578c7a3-3952-41c1-9c3f-656041529c8a|Then.","doc_count":1}]}}},"Publisher":{"doc_count":4,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["444f37d9-0ba1-460f-b049-07530ebb01b8","Barry-Morales"],"key_as_string":"444f37d9-0ba1-460f-b049-07530ebb01b8|Barry-Morales","doc_count":1},{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1},{"key":["fe5e5e11-b7db-46e1-998d-6538d9190801","Williams-Boone"],"key_as_string":"fe5e5e11-b7db-46e1-998d-6538d9190801|Williams-Boone","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_on_creatiedatum.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_on_creatiedatum.yaml
@@ -1,10 +1,11 @@
 interactions:
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"42486cc1-7dab-433e-be64-681f7572d455","informatie_categorieen":[{"uuid":"537efa21-9f71-48d4-be49-1139d473ee2f","naam":"Soldier
-      officer condition."}],"publisher":{"uuid":"9352724c-b9d1-4d69-9f06-73f8f20eb084","naam":"Padilla
-      and Sons"},"identifier":"identifier-11","officiele_titel":"Cell specific business
-      future.","verkorte_titel":"Degree media.","omschrijving":"Happen no owner individual
-      stock. Recent threat option trial sometimes. Mrs letter rather.","creatiedatum":"2024-02-11","registratiedatum":"2025-03-22T02:11:54.276910","laatst_gewijzigd_datum":"2025-03-03T00:36:18.233743"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"72824d35-bd6d-4381-9997-d567cb07e1bb","informatie_categorieen":[{"uuid":"92dcb295-bfe4-466c-8b04-694d821a442b","naam":"Carry
+      at."}],"publisher":{"uuid":"f2edaf3d-c0d1-443c-a2fa-7dd5332e64ad","naam":"Chang
+      LLC"},"identifier":"identifier-11","officiele_titel":"Few social speech serve
+      shoulder able.","verkorte_titel":"Card military.","omschrijving":"Toward consumer
+      anything drive training. Situation large she hour song. Everyone improve once
+      sign number his.","creatiedatum":"2024-02-11","registratiedatum":"2025-03-21T16:26:49.503872","laatst_gewijzigd_datum":"2025-03-15T02:07:21.696591"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -34,12 +35,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"e88ea87a-73a4-4b0f-a74a-35610ac89122","informatie_categorieen":[{"uuid":"d6053d82-d677-4693-a00b-80571d60f15d","naam":"Feeling
-      example."}],"publisher":{"uuid":"8c8ee6e7-99e8-46f1-8002-0d5b5d7141d0","naam":"Cantu
-      LLC"},"identifier":"identifier-12","officiele_titel":"Rate stuff husband maybe
-      medical.","verkorte_titel":"Sport three field.","omschrijving":"Consider major
-      give huge center executive or. Public feeling child foreign writer health. Station
-      suffer television drop officer station treatment.","creatiedatum":"2022-12-10","registratiedatum":"2025-03-23T22:01:58.361334","laatst_gewijzigd_datum":"2025-02-23T01:35:09.294125"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"54b56683-c890-458e-b0ed-b6bd67b505cd","informatie_categorieen":[{"uuid":"1e6ff9fa-9888-4943-a0a3-1bab50a52e71","naam":"Tough
+      most top."}],"publisher":{"uuid":"d0732e0f-ccf7-4c7e-8630-b38ac156d888","naam":"Medina-Moody"},"identifier":"identifier-12","officiele_titel":"May
+      yeah member trial game energy.","verkorte_titel":"Grow exactly reveal.","omschrijving":"Charge
+      indicate probably us place hard could. Way very role help decision my.","creatiedatum":"2022-12-10","registratiedatum":"2025-03-22T01:30:14.576360","laatst_gewijzigd_datum":"2025-03-08T07:20:50.386212"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -69,12 +68,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"8d25bfb4-c8cc-47c4-9591-468675f85e20","informatie_categorieen":[{"uuid":"ceabcb1b-28b7-4db7-a760-b76a5a516460","naam":"Attack
-      tell rate."}],"publisher":{"uuid":"586e5fb7-71a8-479b-a9a6-d506f64543ff","naam":"Manning
-      Inc"},"identifier":"identifier-13","officiele_titel":"Traditional myself case
-      increase dog billion new.","verkorte_titel":"Understand consumer.","omschrijving":"Front
-      nice husband trial. Bit only think though. Water enough rich too. Value adult
-      spring community among network side tax.","creatiedatum":"2025-01-14","registratiedatum":"2025-03-20T21:14:37.671662","laatst_gewijzigd_datum":"2025-02-23T06:25:01.534113"}'
+    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"3da8f6ca-04f0-4368-b74f-ca343b9a3928","informatie_categorieen":[{"uuid":"8972f2ef-1519-4a0d-970f-1f45e6fa14bd","naam":"Alone
+      election degree."}],"publisher":{"uuid":"46c1c24d-933f-437b-b4f3-72bec526c514","naam":"Mcgee-Gonzalez"},"identifier":"identifier-13","officiele_titel":"Big
+      economic carry she suddenly.","verkorte_titel":"Wind.","omschrijving":"Still
+      important material no Mrs.","creatiedatum":"2025-01-14","registratiedatum":"2025-03-24T15:00:35.458155","laatst_gewijzigd_datum":"2025-02-23T18:32:56.702258"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -104,7 +101,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":"2024-02-11","lte":null}}}]}},"score_mode":"multiply"}},"post_filter":{"term":{"_index":"document"}},"aggs":{"ResultType":{"filter":{"match_all":{}},"aggs":{"FilteredResultType":{"terms":{"field":"_index"}}}},"Publisher":{"filter":{"term":{"_index":"document"}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"term":{"_index":"document"}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":"2024-02-11","lte":null}}}]}},"score_mode":"multiply"}},"post_filter":{"terms":{"_index":["document"]}},"aggs":{"ResultType":{"filter":{"match_all":{}},"aggs":{"FilteredResultType":{"terms":{"field":"_index"}}}},"Publisher":{"filter":{"terms":{"_index":["document"]}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"terms":{"_index":["document"]}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -120,26 +117,20 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":23,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"omschrijving":"Happen
-        no owner individual stock. Recent threat option trial sometimes. Mrs letter
-        rather.","identifier":"identifier-11","publicatie":"42486cc1-7dab-433e-be64-681f7572d455","officiele_titel":"Cell
-        specific business future.","informatie_categorieen":[{"naam":"Soldier officer
-        condition.","uuid":"537efa21-9f71-48d4-be49-1139d473ee2f"}],"publisher":{"naam":"Padilla
-        and Sons","uuid":"9352724c-b9d1-4d69-9f06-73f8f20eb084"},"creatiedatum":"2024-02-11","registratiedatum":"2025-03-22T02:11:54.276910","uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","verkorte_titel":"Degree
-        media.","laatst_gewijzigd_datum":"2025-03-03T00:36:18.233743"},"sort":[0.0,1740962178233]},{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"omschrijving":"Front
-        nice husband trial. Bit only think though. Water enough rich too. Value adult
-        spring community among network side tax.","identifier":"identifier-13","publicatie":"8d25bfb4-c8cc-47c4-9591-468675f85e20","officiele_titel":"Traditional
-        myself case increase dog billion new.","informatie_categorieen":[{"naam":"Attack
-        tell rate.","uuid":"ceabcb1b-28b7-4db7-a760-b76a5a516460"}],"publisher":{"naam":"Manning
-        Inc","uuid":"586e5fb7-71a8-479b-a9a6-d506f64543ff"},"creatiedatum":"2025-01-14","registratiedatum":"2025-03-20T21:14:37.671662","uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","verkorte_titel":"Understand
-        consumer.","laatst_gewijzigd_datum":"2025-02-23T06:25:01.534113"},"sort":[0.0,1740291901534]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["537efa21-9f71-48d4-be49-1139d473ee2f","Soldier
-        officer condition."],"key_as_string":"537efa21-9f71-48d4-be49-1139d473ee2f|Soldier
-        officer condition.","doc_count":1},{"key":["ceabcb1b-28b7-4db7-a760-b76a5a516460","Attack
-        tell rate."],"key_as_string":"ceabcb1b-28b7-4db7-a760-b76a5a516460|Attack
-        tell rate.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["586e5fb7-71a8-479b-a9a6-d506f64543ff","Manning
-        Inc"],"key_as_string":"586e5fb7-71a8-479b-a9a6-d506f64543ff|Manning Inc","doc_count":1},{"key":["9352724c-b9d1-4d69-9f06-73f8f20eb084","Padilla
-        and Sons"],"key_as_string":"9352724c-b9d1-4d69-9f06-73f8f20eb084|Padilla and
-        Sons","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}}'
+      string: '{"took":4,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"omschrijving":"Toward
+        consumer anything drive training. Situation large she hour song. Everyone
+        improve once sign number his.","identifier":"identifier-11","publicatie":"72824d35-bd6d-4381-9997-d567cb07e1bb","officiele_titel":"Few
+        social speech serve shoulder able.","informatie_categorieen":[{"naam":"Carry
+        at.","uuid":"92dcb295-bfe4-466c-8b04-694d821a442b"}],"publisher":{"naam":"Chang
+        LLC","uuid":"f2edaf3d-c0d1-443c-a2fa-7dd5332e64ad"},"creatiedatum":"2024-02-11","registratiedatum":"2025-03-21T16:26:49.503872","uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","verkorte_titel":"Card
+        military.","laatst_gewijzigd_datum":"2025-03-15T02:07:21.696591"},"sort":[0.0,1742004441696]},{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"omschrijving":"Still
+        important material no Mrs.","identifier":"identifier-13","publicatie":"3da8f6ca-04f0-4368-b74f-ca343b9a3928","officiele_titel":"Big
+        economic carry she suddenly.","informatie_categorieen":[{"naam":"Alone election
+        degree.","uuid":"8972f2ef-1519-4a0d-970f-1f45e6fa14bd"}],"publisher":{"naam":"Mcgee-Gonzalez","uuid":"46c1c24d-933f-437b-b4f3-72bec526c514"},"creatiedatum":"2025-01-14","registratiedatum":"2025-03-24T15:00:35.458155","uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","verkorte_titel":"Wind.","laatst_gewijzigd_datum":"2025-02-23T18:32:56.702258"},"sort":[0.0,1740335576702]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["8972f2ef-1519-4a0d-970f-1f45e6fa14bd","Alone
+        election degree."],"key_as_string":"8972f2ef-1519-4a0d-970f-1f45e6fa14bd|Alone
+        election degree.","doc_count":1},{"key":["92dcb295-bfe4-466c-8b04-694d821a442b","Carry
+        at."],"key_as_string":"92dcb295-bfe4-466c-8b04-694d821a442b|Carry at.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["46c1c24d-933f-437b-b4f3-72bec526c514","Mcgee-Gonzalez"],"key_as_string":"46c1c24d-933f-437b-b4f3-72bec526c514|Mcgee-Gonzalez","doc_count":1},{"key":["f2edaf3d-c0d1-443c-a2fa-7dd5332e64ad","Chang
+        LLC"],"key_as_string":"f2edaf3d-c0d1-443c-a2fa-7dd5332e64ad|Chang LLC","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -151,7 +142,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":null,"lte":"2022-12-10"}}}]}},"score_mode":"multiply"}},"post_filter":{"term":{"_index":"document"}},"aggs":{"ResultType":{"filter":{"match_all":{}},"aggs":{"FilteredResultType":{"terms":{"field":"_index"}}}},"Publisher":{"filter":{"term":{"_index":"document"}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"term":{"_index":"document"}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":null,"lte":"2022-12-10"}}}]}},"score_mode":"multiply"}},"post_filter":{"terms":{"_index":["document"]}},"aggs":{"ResultType":{"filter":{"match_all":{}},"aggs":{"FilteredResultType":{"terms":{"field":"_index"}}}},"Publisher":{"filter":{"terms":{"_index":["document"]}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"terms":{"_index":["document"]}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -167,14 +158,13 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"omschrijving":"Consider
-        major give huge center executive or. Public feeling child foreign writer health.
-        Station suffer television drop officer station treatment.","identifier":"identifier-12","publicatie":"e88ea87a-73a4-4b0f-a74a-35610ac89122","officiele_titel":"Rate
-        stuff husband maybe medical.","informatie_categorieen":[{"naam":"Feeling example.","uuid":"d6053d82-d677-4693-a00b-80571d60f15d"}],"publisher":{"naam":"Cantu
-        LLC","uuid":"8c8ee6e7-99e8-46f1-8002-0d5b5d7141d0"},"creatiedatum":"2022-12-10","registratiedatum":"2025-03-23T22:01:58.361334","uuid":"62fceb92-98bd-475c-b184-49ee8a274787","verkorte_titel":"Sport
-        three field.","laatst_gewijzigd_datum":"2025-02-23T01:35:09.294125"},"sort":[0.0,1740274509294]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["d6053d82-d677-4693-a00b-80571d60f15d","Feeling
-        example."],"key_as_string":"d6053d82-d677-4693-a00b-80571d60f15d|Feeling example.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["8c8ee6e7-99e8-46f1-8002-0d5b5d7141d0","Cantu
-        LLC"],"key_as_string":"8c8ee6e7-99e8-46f1-8002-0d5b5d7141d0|Cantu LLC","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
+      string: '{"took":4,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"omschrijving":"Charge
+        indicate probably us place hard could. Way very role help decision my.","identifier":"identifier-12","publicatie":"54b56683-c890-458e-b0ed-b6bd67b505cd","officiele_titel":"May
+        yeah member trial game energy.","informatie_categorieen":[{"naam":"Tough most
+        top.","uuid":"1e6ff9fa-9888-4943-a0a3-1bab50a52e71"}],"publisher":{"naam":"Medina-Moody","uuid":"d0732e0f-ccf7-4c7e-8630-b38ac156d888"},"creatiedatum":"2022-12-10","registratiedatum":"2025-03-22T01:30:14.576360","uuid":"62fceb92-98bd-475c-b184-49ee8a274787","verkorte_titel":"Grow
+        exactly reveal.","laatst_gewijzigd_datum":"2025-03-08T07:20:50.386212"},"sort":[0.0,1741418450386]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["1e6ff9fa-9888-4943-a0a3-1bab50a52e71","Tough
+        most top."],"key_as_string":"1e6ff9fa-9888-4943-a0a3-1bab50a52e71|Tough most
+        top.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["d0732e0f-ccf7-4c7e-8630-b38ac156d888","Medina-Moody"],"key_as_string":"d0732e0f-ccf7-4c7e-8630-b38ac156d888|Medina-Moody","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -186,7 +176,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":"2024-01-01","lte":"2024-12-31"}}}]}},"score_mode":"multiply"}},"post_filter":{"term":{"_index":"document"}},"aggs":{"ResultType":{"filter":{"match_all":{}},"aggs":{"FilteredResultType":{"terms":{"field":"_index"}}}},"Publisher":{"filter":{"term":{"_index":"document"}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"term":{"_index":"document"}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"bool":{"filter":[{"range":{"creatiedatum":{"gte":"2024-01-01","lte":"2024-12-31"}}}]}},"score_mode":"multiply"}},"post_filter":{"terms":{"_index":["document"]}},"aggs":{"ResultType":{"filter":{"match_all":{}},"aggs":{"FilteredResultType":{"terms":{"field":"_index"}}}},"Publisher":{"filter":{"terms":{"_index":["document"]}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"terms":{"_index":["document"]}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -202,17 +192,15 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"omschrijving":"Happen
-        no owner individual stock. Recent threat option trial sometimes. Mrs letter
-        rather.","identifier":"identifier-11","publicatie":"42486cc1-7dab-433e-be64-681f7572d455","officiele_titel":"Cell
-        specific business future.","informatie_categorieen":[{"naam":"Soldier officer
-        condition.","uuid":"537efa21-9f71-48d4-be49-1139d473ee2f"}],"publisher":{"naam":"Padilla
-        and Sons","uuid":"9352724c-b9d1-4d69-9f06-73f8f20eb084"},"creatiedatum":"2024-02-11","registratiedatum":"2025-03-22T02:11:54.276910","uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","verkorte_titel":"Degree
-        media.","laatst_gewijzigd_datum":"2025-03-03T00:36:18.233743"},"sort":[0.0,1740962178233]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["537efa21-9f71-48d4-be49-1139d473ee2f","Soldier
-        officer condition."],"key_as_string":"537efa21-9f71-48d4-be49-1139d473ee2f|Soldier
-        officer condition.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["9352724c-b9d1-4d69-9f06-73f8f20eb084","Padilla
-        and Sons"],"key_as_string":"9352724c-b9d1-4d69-9f06-73f8f20eb084|Padilla and
-        Sons","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
+      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"omschrijving":"Toward
+        consumer anything drive training. Situation large she hour song. Everyone
+        improve once sign number his.","identifier":"identifier-11","publicatie":"72824d35-bd6d-4381-9997-d567cb07e1bb","officiele_titel":"Few
+        social speech serve shoulder able.","informatie_categorieen":[{"naam":"Carry
+        at.","uuid":"92dcb295-bfe4-466c-8b04-694d821a442b"}],"publisher":{"naam":"Chang
+        LLC","uuid":"f2edaf3d-c0d1-443c-a2fa-7dd5332e64ad"},"creatiedatum":"2024-02-11","registratiedatum":"2025-03-21T16:26:49.503872","uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","verkorte_titel":"Card
+        military.","laatst_gewijzigd_datum":"2025-03-15T02:07:21.696591"},"sort":[0.0,1742004441696]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["92dcb295-bfe4-466c-8b04-694d821a442b","Carry
+        at."],"key_as_string":"92dcb295-bfe4-466c-8b04-694d821a442b|Carry at.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["f2edaf3d-c0d1-443c-a2fa-7dd5332e64ad","Chang
+        LLC"],"key_as_string":"f2edaf3d-c0d1-443c-a2fa-7dd5332e64ad|Chang LLC","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_on_last_modified_date.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_on_last_modified_date.yaml
@@ -1,11 +1,11 @@
 interactions:
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"3a617815-9254-4a3d-8f97-014bb88dcd9c","informatie_categorieen":[{"uuid":"4d520658-e7b6-4e44-8a5c-10caa452ecc6","naam":"Dark
-      difficult."}],"publisher":{"uuid":"b86d37da-fdbf-428a-80f4-70df42c91dc1","naam":"Smith,
-      Rogers and Glover"},"identifier":"identifier-14","officiele_titel":"Care night
-      subject surface young.","verkorte_titel":"Memory list.","omschrijving":"Learn
-      shake difficult actually. Once adult toward glass through almost. Them book
-      prove kind since. Could stage allow apply hour still.","creatiedatum":"2025-03-12","registratiedatum":"2025-03-22T22:59:33.911657","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"63642b0b-cc07-420c-9040-eb67608b6003","informatie_categorieen":[{"uuid":"58595551-04f2-4539-817f-a782df07b0ad","naam":"Work
+      these discussion."}],"publisher":{"uuid":"3a32b8e4-0b99-410a-9f56-5ac06d160d24","naam":"Duarte
+      LLC"},"identifier":"identifier-14","officiele_titel":"Attack main operation
+      here.","verkorte_titel":"Property officer.","omschrijving":"Goal quality chair
+      be free. Site nothing foreign ago common time professional. Majority media agency
+      treat message rock head.","creatiedatum":"2025-03-02","registratiedatum":"2025-03-21T22:07:43.669425","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -35,10 +35,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"cdbb5c3d-2486-490b-8df2-429cbe2c7f2e","informatie_categorieen":[{"uuid":"3314dec9-d3f2-40cc-80bd-0493edc74710","naam":"Down
-      play deal."}],"publisher":{"uuid":"d9dcc89a-ff8b-43df-aeae-ea50e5e41c54","naam":"Davis-Smith"},"identifier":"identifier-15","officiele_titel":"First
-      interest present chair.","verkorte_titel":"Unit home.","omschrijving":"Score
-      main scene structure certainly. Chair himself leg represent.","creatiedatum":"2025-03-17","registratiedatum":"2025-03-22T11:42:35.705140","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"b430b5a1-2c0c-435a-9b9f-3d39eedbb066","informatie_categorieen":[{"uuid":"5077ed82-4f39-4401-81c3-7488f95d3e77","naam":"Piece
+      more billion writer."}],"publisher":{"uuid":"092f17e2-7836-4570-919b-74538d271694","naam":"Delgado
+      Ltd"},"identifier":"identifier-15","officiele_titel":"Father like vote.","verkorte_titel":"Wish
+      send.","omschrijving":"Office set fill interview well quite police.","creatiedatum":"2025-03-09","registratiedatum":"2025-03-23T00:41:32.488371","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -68,11 +68,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"55bdc43d-ed01-4e06-b0c9-b8bfe87c215a","informatie_categorieen":[{"uuid":"875d0fa5-690c-4973-a414-587a33c8c7f9","naam":"Level
-      magazine word."}],"publisher":{"uuid":"b72be629-94e7-4c3d-aae7-ff7ed2fda1e7","naam":"Hamilton
-      and Sons"},"identifier":"identifier-16","officiele_titel":"Set give manage.","verkorte_titel":"Have
-      detail.","omschrijving":"Expect just soldier prove wife. Security network expect
-      beyond lot decade. Market action agent say if audience six back.","creatiedatum":"2025-03-10","registratiedatum":"2025-03-19T15:18:47.326357","laatst_gewijzigd_datum":"2025-01-14T21:12:00+00:00"}'
+    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"b6e2597a-74a1-4c45-98e4-d3269acdfe8c","informatie_categorieen":[{"uuid":"99751370-0448-4076-8545-646f0167f650","naam":"Beyond
+      against."}],"publisher":{"uuid":"799442af-12a3-4755-b9c1-dd580b6f569d","naam":"Garza,
+      Rodriguez and Long"},"identifier":"identifier-16","officiele_titel":"Social
+      entire surface best data maintain all contain.","verkorte_titel":"Camera.","omschrijving":"Doctor
+      nothing front ball. Same yet feeling analysis agree deal. It with ask.","creatiedatum":"2025-03-02","registratiedatum":"2025-03-22T09:24:41.160029","laatst_gewijzigd_datum":"2025-01-14T21:12:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -118,24 +118,22 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"omschrijving":"Expect
-        just soldier prove wife. Security network expect beyond lot decade. Market
-        action agent say if audience six back.","identifier":"identifier-16","publicatie":"55bdc43d-ed01-4e06-b0c9-b8bfe87c215a","officiele_titel":"Set
-        give manage.","informatie_categorieen":[{"naam":"Level magazine word.","uuid":"875d0fa5-690c-4973-a414-587a33c8c7f9"}],"publisher":{"naam":"Hamilton
-        and Sons","uuid":"b72be629-94e7-4c3d-aae7-ff7ed2fda1e7"},"creatiedatum":"2025-03-10","registratiedatum":"2025-03-19T15:18:47.326357","uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","verkorte_titel":"Have
-        detail.","laatst_gewijzigd_datum":"2025-01-14T21:12:00+00:00"},"sort":[0.0,1736889120000]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"omschrijving":"Learn
-        shake difficult actually. Once adult toward glass through almost. Them book
-        prove kind since. Could stage allow apply hour still.","identifier":"identifier-14","publicatie":"3a617815-9254-4a3d-8f97-014bb88dcd9c","officiele_titel":"Care
-        night subject surface young.","informatie_categorieen":[{"naam":"Dark difficult.","uuid":"4d520658-e7b6-4e44-8a5c-10caa452ecc6"}],"publisher":{"naam":"Smith,
-        Rogers and Glover","uuid":"b86d37da-fdbf-428a-80f4-70df42c91dc1"},"creatiedatum":"2025-03-12","registratiedatum":"2025-03-22T22:59:33.911657","uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","verkorte_titel":"Memory
-        list.","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["4d520658-e7b6-4e44-8a5c-10caa452ecc6","Dark
-        difficult."],"key_as_string":"4d520658-e7b6-4e44-8a5c-10caa452ecc6|Dark difficult.","doc_count":1},{"key":["875d0fa5-690c-4973-a414-587a33c8c7f9","Level
-        magazine word."],"key_as_string":"875d0fa5-690c-4973-a414-587a33c8c7f9|Level
-        magazine word.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["b72be629-94e7-4c3d-aae7-ff7ed2fda1e7","Hamilton
-        and Sons"],"key_as_string":"b72be629-94e7-4c3d-aae7-ff7ed2fda1e7|Hamilton
-        and Sons","doc_count":1},{"key":["b86d37da-fdbf-428a-80f4-70df42c91dc1","Smith,
-        Rogers and Glover"],"key_as_string":"b86d37da-fdbf-428a-80f4-70df42c91dc1|Smith,
-        Rogers and Glover","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}}'
+      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"omschrijving":"Doctor
+        nothing front ball. Same yet feeling analysis agree deal. It with ask.","identifier":"identifier-16","publicatie":"b6e2597a-74a1-4c45-98e4-d3269acdfe8c","officiele_titel":"Social
+        entire surface best data maintain all contain.","informatie_categorieen":[{"naam":"Beyond
+        against.","uuid":"99751370-0448-4076-8545-646f0167f650"}],"publisher":{"naam":"Garza,
+        Rodriguez and Long","uuid":"799442af-12a3-4755-b9c1-dd580b6f569d"},"creatiedatum":"2025-03-02","registratiedatum":"2025-03-22T09:24:41.160029","uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","verkorte_titel":"Camera.","laatst_gewijzigd_datum":"2025-01-14T21:12:00+00:00"},"sort":[0.0,1736889120000]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"omschrijving":"Goal
+        quality chair be free. Site nothing foreign ago common time professional.
+        Majority media agency treat message rock head.","identifier":"identifier-14","publicatie":"63642b0b-cc07-420c-9040-eb67608b6003","officiele_titel":"Attack
+        main operation here.","informatie_categorieen":[{"naam":"Work these discussion.","uuid":"58595551-04f2-4539-817f-a782df07b0ad"}],"publisher":{"naam":"Duarte
+        LLC","uuid":"3a32b8e4-0b99-410a-9f56-5ac06d160d24"},"creatiedatum":"2025-03-02","registratiedatum":"2025-03-21T22:07:43.669425","uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","verkorte_titel":"Property
+        officer.","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["58595551-04f2-4539-817f-a782df07b0ad","Work
+        these discussion."],"key_as_string":"58595551-04f2-4539-817f-a782df07b0ad|Work
+        these discussion.","doc_count":1},{"key":["99751370-0448-4076-8545-646f0167f650","Beyond
+        against."],"key_as_string":"99751370-0448-4076-8545-646f0167f650|Beyond against.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3a32b8e4-0b99-410a-9f56-5ac06d160d24","Duarte
+        LLC"],"key_as_string":"3a32b8e4-0b99-410a-9f56-5ac06d160d24|Duarte LLC","doc_count":1},{"key":["799442af-12a3-4755-b9c1-dd580b6f569d","Garza,
+        Rodriguez and Long"],"key_as_string":"799442af-12a3-4755-b9c1-dd580b6f569d|Garza,
+        Rodriguez and Long","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -163,12 +161,14 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"omschrijving":"Score
-        main scene structure certainly. Chair himself leg represent.","identifier":"identifier-15","publicatie":"cdbb5c3d-2486-490b-8df2-429cbe2c7f2e","officiele_titel":"First
-        interest present chair.","informatie_categorieen":[{"naam":"Down play deal.","uuid":"3314dec9-d3f2-40cc-80bd-0493edc74710"}],"publisher":{"naam":"Davis-Smith","uuid":"d9dcc89a-ff8b-43df-aeae-ea50e5e41c54"},"creatiedatum":"2025-03-17","registratiedatum":"2025-03-22T11:42:35.705140","uuid":"62fceb92-98bd-475c-b184-49ee8a274787","verkorte_titel":"Unit
-        home.","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"},"sort":[0.0,1670695200000]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3314dec9-d3f2-40cc-80bd-0493edc74710","Down
-        play deal."],"key_as_string":"3314dec9-d3f2-40cc-80bd-0493edc74710|Down play
-        deal.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["d9dcc89a-ff8b-43df-aeae-ea50e5e41c54","Davis-Smith"],"key_as_string":"d9dcc89a-ff8b-43df-aeae-ea50e5e41c54|Davis-Smith","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
+      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"omschrijving":"Office
+        set fill interview well quite police.","identifier":"identifier-15","publicatie":"b430b5a1-2c0c-435a-9b9f-3d39eedbb066","officiele_titel":"Father
+        like vote.","informatie_categorieen":[{"naam":"Piece more billion writer.","uuid":"5077ed82-4f39-4401-81c3-7488f95d3e77"}],"publisher":{"naam":"Delgado
+        Ltd","uuid":"092f17e2-7836-4570-919b-74538d271694"},"creatiedatum":"2025-03-09","registratiedatum":"2025-03-23T00:41:32.488371","uuid":"62fceb92-98bd-475c-b184-49ee8a274787","verkorte_titel":"Wish
+        send.","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"},"sort":[0.0,1670695200000]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["5077ed82-4f39-4401-81c3-7488f95d3e77","Piece
+        more billion writer."],"key_as_string":"5077ed82-4f39-4401-81c3-7488f95d3e77|Piece
+        more billion writer.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["092f17e2-7836-4570-919b-74538d271694","Delgado
+        Ltd"],"key_as_string":"092f17e2-7836-4570-919b-74538d271694|Delgado Ltd","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -196,15 +196,15 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"omschrijving":"Learn
-        shake difficult actually. Once adult toward glass through almost. Them book
-        prove kind since. Could stage allow apply hour still.","identifier":"identifier-14","publicatie":"3a617815-9254-4a3d-8f97-014bb88dcd9c","officiele_titel":"Care
-        night subject surface young.","informatie_categorieen":[{"naam":"Dark difficult.","uuid":"4d520658-e7b6-4e44-8a5c-10caa452ecc6"}],"publisher":{"naam":"Smith,
-        Rogers and Glover","uuid":"b86d37da-fdbf-428a-80f4-70df42c91dc1"},"creatiedatum":"2025-03-12","registratiedatum":"2025-03-22T22:59:33.911657","uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","verkorte_titel":"Memory
-        list.","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["4d520658-e7b6-4e44-8a5c-10caa452ecc6","Dark
-        difficult."],"key_as_string":"4d520658-e7b6-4e44-8a5c-10caa452ecc6|Dark difficult.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["b86d37da-fdbf-428a-80f4-70df42c91dc1","Smith,
-        Rogers and Glover"],"key_as_string":"b86d37da-fdbf-428a-80f4-70df42c91dc1|Smith,
-        Rogers and Glover","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
+      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"omschrijving":"Goal
+        quality chair be free. Site nothing foreign ago common time professional.
+        Majority media agency treat message rock head.","identifier":"identifier-14","publicatie":"63642b0b-cc07-420c-9040-eb67608b6003","officiele_titel":"Attack
+        main operation here.","informatie_categorieen":[{"naam":"Work these discussion.","uuid":"58595551-04f2-4539-817f-a782df07b0ad"}],"publisher":{"naam":"Duarte
+        LLC","uuid":"3a32b8e4-0b99-410a-9f56-5ac06d160d24"},"creatiedatum":"2025-03-02","registratiedatum":"2025-03-21T22:07:43.669425","uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","verkorte_titel":"Property
+        officer.","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["58595551-04f2-4539-817f-a782df07b0ad","Work
+        these discussion."],"key_as_string":"58595551-04f2-4539-817f-a782df07b0ad|Work
+        these discussion.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3a32b8e4-0b99-410a-9f56-5ac06d160d24","Duarte
+        LLC"],"key_as_string":"3a32b8e4-0b99-410a-9f56-5ac06d160d24|Duarte LLC","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_on_last_modified_date_both_indexes.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_on_last_modified_date_both_indexes.yaml
@@ -1,10 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"1999c252-997c-4384-9b10-f0d6cfcd2995","naam":"Chambers,
-      Sims and Barnett"},"informatie_categorieen":[{"uuid":"40225aed-bb79-4400-9680-59c24528e4cd","naam":"Road
-      old far."}],"officiele_titel":"Western who begin source your become serious.","verkorte_titel":"Kitchen
-      certain.","omschrijving":"Officer buy full bed western. There what southern.
-      Continue find cup.","registratiedatum":"2025-03-24T04:26:05.875855","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
+    body: '{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"7530ab12-7776-43bf-82d8-f8ef11e20ed2","naam":"Robertson,
+      Haney and Sherman"},"informatie_categorieen":[{"uuid":"3011b26a-b2ed-4024-b0d9-8f166c3bac2a","naam":"Test."}],"officiele_titel":"Industry
+      age fall try clearly full rest.","verkorte_titel":"Until pretty stock.","omschrijving":"Fish
+      necessary officer any score know item ahead.","registratiedatum":"2025-03-20T10:18:27.741899","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -34,11 +33,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"de225c2e-2700-4fee-a6ea-efa276db42d4","publisher":{"uuid":"d2915f8c-6414-484c-aff3-982ce9589fbc","naam":"Henderson,
-      Warren and Spence"},"informatie_categorieen":[{"uuid":"a6a2432e-8e89-49c5-b04a-faf68bd39c40","naam":"Truth
-      human."}],"officiele_titel":"Agency arm their pattern hair.","verkorte_titel":"Middle
-      natural.","omschrijving":"Have step could own none seat. Information ever blood
-      any behavior receive.","registratiedatum":"2025-03-19T14:49:59.494766","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
+    body: '{"uuid":"de225c2e-2700-4fee-a6ea-efa276db42d4","publisher":{"uuid":"ba8b6fe6-2878-41ca-a7a0-f361a6ed02eb","naam":"Ramirez,
+      Bridges and Harris"},"informatie_categorieen":[{"uuid":"5c7bf9d3-5432-4ac6-bc92-d16c15c4b74d","naam":"Forget
+      notice likely."}],"officiele_titel":"Middle shake room policy effect keep.","verkorte_titel":"Reflect
+      over feeling.","omschrijving":"Type question model state company. Worker relate
+      Republican within only pass structure teach. Mr computer side few arrive crime
+      white.","registratiedatum":"2025-03-24T06:30:24.656644","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -68,11 +68,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"9027226d-1bcd-4c2f-8cc0-a3559c708e62","informatie_categorieen":[{"uuid":"f140d768-2c63-4c54-93e9-dc35b615e814","naam":"It
-      walk sure."}],"publisher":{"uuid":"7568fc61-3713-44a2-91c0-55d382c41804","naam":"Bass,
-      Rangel and Hurley"},"identifier":"identifier-17","officiele_titel":"Not mind
-      stock bring.","verkorte_titel":"Price so positive while.","omschrijving":"Fly
-      appear between probably father. Smile do build hard worry leave care.","creatiedatum":"2025-03-09","registratiedatum":"2025-03-24T02:09:07.799011","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"40fba565-0747-4073-beb5-ff0be134a97e","informatie_categorieen":[{"uuid":"7bb1b686-b6f0-4db3-97dd-b984c99b805a","naam":"Religious
+      fish he."}],"publisher":{"uuid":"53127403-b8fc-4f8c-bc9f-f0f74661c25c","naam":"Cardenas
+      PLC"},"identifier":"identifier-17","officiele_titel":"Human ball interesting
+      represent away guess later.","verkorte_titel":"Respond author.","omschrijving":"Set
+      take between agency issue receive garden.","creatiedatum":"2025-03-04","registratiedatum":"2025-03-24T08:00:18.621286","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -102,10 +102,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"a1d9e763-a407-4ace-a061-3aaa85839f1f","informatie_categorieen":[{"uuid":"56a8763d-606d-49bb-b43a-833f364b1f98","naam":"Truth
-      she."}],"publisher":{"uuid":"2d788c1b-6c62-4388-95b1-edff50258906","naam":"Ross-Hawkins"},"identifier":"identifier-18","officiele_titel":"Soldier
-      sing feeling speech chair data.","verkorte_titel":"Explain color require read.","omschrijving":"Southern
-      wide throw more from fund.","creatiedatum":"2025-03-18","registratiedatum":"2025-03-24T06:46:11.224862","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"c9a28bc9-a787-4c7c-8a42-568492b2bb6b","informatie_categorieen":[{"uuid":"06837ff5-2fc3-4a9c-9152-bf84703d33f6","naam":"Degree
+      western."}],"publisher":{"uuid":"19b3e784-46ad-4d9b-8c0b-46b4cc15d791","naam":"Gutierrez,
+      Cabrera and Watson"},"identifier":"identifier-18","officiele_titel":"They listen
+      responsibility about offer since live.","verkorte_titel":"Nor sign reduce.","omschrijving":"Space
+      spring could be star information act. Action commercial movement themselves
+      city station benefit.","creatiedatum":"2025-03-06","registratiedatum":"2025-03-23T06:05:19.259839","laatst_gewijzigd_datum":"2022-12-10T18:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -151,22 +153,20 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"omschrijving":"Fly
-        appear between probably father. Smile do build hard worry leave care.","identifier":"identifier-17","publicatie":"9027226d-1bcd-4c2f-8cc0-a3559c708e62","officiele_titel":"Not
-        mind stock bring.","informatie_categorieen":[{"naam":"It walk sure.","uuid":"f140d768-2c63-4c54-93e9-dc35b615e814"}],"publisher":{"naam":"Bass,
-        Rangel and Hurley","uuid":"7568fc61-3713-44a2-91c0-55d382c41804"},"creatiedatum":"2025-03-09","registratiedatum":"2025-03-24T02:09:07.799011","uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","verkorte_titel":"Price
-        so positive while.","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]},{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_score":0.0,"_source":{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"1999c252-997c-4384-9b10-f0d6cfcd2995","naam":"Chambers,
-        Sims and Barnett"},"informatie_categorieen":[{"uuid":"40225aed-bb79-4400-9680-59c24528e4cd","naam":"Road
-        old far."}],"officiele_titel":"Western who begin source your become serious.","verkorte_titel":"Kitchen
-        certain.","omschrijving":"Officer buy full bed western. There what southern.
-        Continue find cup.","registratiedatum":"2025-03-24T04:26:05.875855","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["40225aed-bb79-4400-9680-59c24528e4cd","Road
-        old far."],"key_as_string":"40225aed-bb79-4400-9680-59c24528e4cd|Road old
-        far.","doc_count":1},{"key":["f140d768-2c63-4c54-93e9-dc35b615e814","It walk
-        sure."],"key_as_string":"f140d768-2c63-4c54-93e9-dc35b615e814|It walk sure.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["1999c252-997c-4384-9b10-f0d6cfcd2995","Chambers,
-        Sims and Barnett"],"key_as_string":"1999c252-997c-4384-9b10-f0d6cfcd2995|Chambers,
-        Sims and Barnett","doc_count":1},{"key":["7568fc61-3713-44a2-91c0-55d382c41804","Bass,
-        Rangel and Hurley"],"key_as_string":"7568fc61-3713-44a2-91c0-55d382c41804|Bass,
-        Rangel and Hurley","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
+      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"omschrijving":"Set
+        take between agency issue receive garden.","identifier":"identifier-17","publicatie":"40fba565-0747-4073-beb5-ff0be134a97e","officiele_titel":"Human
+        ball interesting represent away guess later.","informatie_categorieen":[{"naam":"Religious
+        fish he.","uuid":"7bb1b686-b6f0-4db3-97dd-b984c99b805a"}],"publisher":{"naam":"Cardenas
+        PLC","uuid":"53127403-b8fc-4f8c-bc9f-f0f74661c25c"},"creatiedatum":"2025-03-04","registratiedatum":"2025-03-24T08:00:18.621286","uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","verkorte_titel":"Respond
+        author.","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]},{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_score":0.0,"_source":{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"7530ab12-7776-43bf-82d8-f8ef11e20ed2","naam":"Robertson,
+        Haney and Sherman"},"informatie_categorieen":[{"uuid":"3011b26a-b2ed-4024-b0d9-8f166c3bac2a","naam":"Test."}],"officiele_titel":"Industry
+        age fall try clearly full rest.","verkorte_titel":"Until pretty stock.","omschrijving":"Fish
+        necessary officer any score know item ahead.","registratiedatum":"2025-03-20T10:18:27.741899","laatst_gewijzigd_datum":"2024-02-11T10:00:00+00:00"},"sort":[0.0,1707645600000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3011b26a-b2ed-4024-b0d9-8f166c3bac2a","Test."],"key_as_string":"3011b26a-b2ed-4024-b0d9-8f166c3bac2a|Test.","doc_count":1},{"key":["7bb1b686-b6f0-4db3-97dd-b984c99b805a","Religious
+        fish he."],"key_as_string":"7bb1b686-b6f0-4db3-97dd-b984c99b805a|Religious
+        fish he.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["53127403-b8fc-4f8c-bc9f-f0f74661c25c","Cardenas
+        PLC"],"key_as_string":"53127403-b8fc-4f8c-bc9f-f0f74661c25c|Cardenas PLC","doc_count":1},{"key":["7530ab12-7776-43bf-82d8-f8ef11e20ed2","Robertson,
+        Haney and Sherman"],"key_as_string":"7530ab12-7776-43bf-82d8-f8ef11e20ed2|Robertson,
+        Haney and Sherman","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_on_registration_date.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_on_registration_date.yaml
@@ -1,10 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"65c3b16a-fcea-42f6-89ef-9e902636baf3","informatie_categorieen":[{"uuid":"6808a08f-9e7a-4fab-961e-9cbcf0de18ca","naam":"Wall
-      tax coach."}],"publisher":{"uuid":"2a1548d8-ce95-4a56-8a05-704d4cfaa3a0","naam":"Rollins,
-      Hicks and Sanchez"},"identifier":"identifier-19","officiele_titel":"Position
-      this fast whom.","verkorte_titel":"Part industry.","omschrijving":"Career message
-      all loss major care audience. Thought who miss buy pass small other.","creatiedatum":"2025-02-27","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-03-24T00:58:33.304606"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"ce6dea35-d8dd-4649-8e41-61177bf75aaa","informatie_categorieen":[{"uuid":"108eb240-08be-419f-a080-4a4be8e0c936","naam":"Rather
+      ten common."}],"publisher":{"uuid":"b505b74d-5973-4f0a-89fd-daccb1aa9938","naam":"Mann-Carrillo"},"identifier":"identifier-19","officiele_titel":"Those
+      old manager toward.","verkorte_titel":"He security population.","omschrijving":"Hear
+      oil similar citizen message financial.","creatiedatum":"2025-02-27","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-03-03T06:20:59.467648"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -34,11 +33,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"2a00deef-891d-4844-a3af-03809cabb898","informatie_categorieen":[{"uuid":"339ba520-52ce-44ab-8184-bf0334e7df5e","naam":"Walk
-      area item common."}],"publisher":{"uuid":"6607f2db-e7eb-46a1-98db-91b64621f33b","naam":"Best,
-      Gonzales and Olson"},"identifier":"identifier-20","officiele_titel":"Lose nor
-      record card speak believe research.","verkorte_titel":"Concern history media.","omschrijving":"Bag
-      tend similar. Teach why begin on game.","creatiedatum":"2025-03-16","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-03-07T21:40:17.880875"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"9ae32cbb-7ba3-401c-a3b8-7b06649447f1","informatie_categorieen":[{"uuid":"99de6084-8e6e-4de7-9e10-9b81b3f9ce79","naam":"Toward
+      street win either."}],"publisher":{"uuid":"7b54ed83-5016-4400-8a20-23d7ca5f4db4","naam":"Johnson-Meyer"},"identifier":"identifier-20","officiele_titel":"Room
+      lose tend pick new whether.","verkorte_titel":"Job training look.","omschrijving":"Off
+      attorney arm hope. Value message street support sit scene treat. Stop reality
+      allow international news measure sometimes.","creatiedatum":"2025-03-03","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-03-01T00:28:53.846786"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -68,11 +67,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"d45612f0-8d59-4af4-b67d-5cbc70f165f9","informatie_categorieen":[{"uuid":"32cdcbfd-d104-42d1-b528-293d7a50aa46","naam":"Summer
-      fly."}],"publisher":{"uuid":"42366dec-236f-498c-a174-6b658d643e56","naam":"Wright-Spencer"},"identifier":"identifier-21","officiele_titel":"Mr
-      decade represent year wall threat.","verkorte_titel":"Use painting mouth.","omschrijving":"See
-      customer foreign and. Argue list fill without attack. View song usually ability
-      nation.","creatiedatum":"2025-03-01","registratiedatum":"2025-01-14T21:12:00+00:00","laatst_gewijzigd_datum":"2025-03-17T12:21:28.008795"}'
+    body: '{"uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","publicatie":"a8208039-68d2-4259-8f3e-cc6af9a57dbf","informatie_categorieen":[{"uuid":"a07e928b-000b-4864-ae65-fc496b4407d6","naam":"Half
+      appear."}],"publisher":{"uuid":"ae7ac29c-1e25-43ab-a001-a68b1d33912c","naam":"Brooks,
+      Sullivan and Mcdonald"},"identifier":"identifier-21","officiele_titel":"Stand
+      sort might east from.","verkorte_titel":"Listen himself television.","omschrijving":"Choose
+      leg its. Decision ground minute appear best find put. Never building more.","creatiedatum":"2025-02-26","registratiedatum":"2025-01-14T21:12:00+00:00","laatst_gewijzigd_datum":"2025-03-02T22:24:06.856326"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -118,21 +117,19 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"omschrijving":"Career
-        message all loss major care audience. Thought who miss buy pass small other.","identifier":"identifier-19","publicatie":"65c3b16a-fcea-42f6-89ef-9e902636baf3","officiele_titel":"Position
-        this fast whom.","informatie_categorieen":[{"naam":"Wall tax coach.","uuid":"6808a08f-9e7a-4fab-961e-9cbcf0de18ca"}],"publisher":{"naam":"Rollins,
-        Hicks and Sanchez","uuid":"2a1548d8-ce95-4a56-8a05-704d4cfaa3a0"},"creatiedatum":"2025-02-27","registratiedatum":"2024-02-11T10:00:00+00:00","uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","verkorte_titel":"Part
-        industry.","laatst_gewijzigd_datum":"2025-03-24T00:58:33.304606"},"sort":[0.0,1742777913304]},{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"omschrijving":"See
-        customer foreign and. Argue list fill without attack. View song usually ability
-        nation.","identifier":"identifier-21","publicatie":"d45612f0-8d59-4af4-b67d-5cbc70f165f9","officiele_titel":"Mr
-        decade represent year wall threat.","informatie_categorieen":[{"naam":"Summer
-        fly.","uuid":"32cdcbfd-d104-42d1-b528-293d7a50aa46"}],"publisher":{"naam":"Wright-Spencer","uuid":"42366dec-236f-498c-a174-6b658d643e56"},"creatiedatum":"2025-03-01","registratiedatum":"2025-01-14T21:12:00+00:00","uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","verkorte_titel":"Use
-        painting mouth.","laatst_gewijzigd_datum":"2025-03-17T12:21:28.008795"},"sort":[0.0,1742214088008]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["32cdcbfd-d104-42d1-b528-293d7a50aa46","Summer
-        fly."],"key_as_string":"32cdcbfd-d104-42d1-b528-293d7a50aa46|Summer fly.","doc_count":1},{"key":["6808a08f-9e7a-4fab-961e-9cbcf0de18ca","Wall
-        tax coach."],"key_as_string":"6808a08f-9e7a-4fab-961e-9cbcf0de18ca|Wall tax
-        coach.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2a1548d8-ce95-4a56-8a05-704d4cfaa3a0","Rollins,
-        Hicks and Sanchez"],"key_as_string":"2a1548d8-ce95-4a56-8a05-704d4cfaa3a0|Rollins,
-        Hicks and Sanchez","doc_count":1},{"key":["42366dec-236f-498c-a174-6b658d643e56","Wright-Spencer"],"key_as_string":"42366dec-236f-498c-a174-6b658d643e56|Wright-Spencer","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}}'
+      string: '{"took":4,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"omschrijving":"Hear
+        oil similar citizen message financial.","identifier":"identifier-19","publicatie":"ce6dea35-d8dd-4649-8e41-61177bf75aaa","officiele_titel":"Those
+        old manager toward.","informatie_categorieen":[{"naam":"Rather ten common.","uuid":"108eb240-08be-419f-a080-4a4be8e0c936"}],"publisher":{"naam":"Mann-Carrillo","uuid":"b505b74d-5973-4f0a-89fd-daccb1aa9938"},"creatiedatum":"2025-02-27","registratiedatum":"2024-02-11T10:00:00+00:00","uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","verkorte_titel":"He
+        security population.","laatst_gewijzigd_datum":"2025-03-03T06:20:59.467648"},"sort":[0.0,1740982859467]},{"_index":"document","_id":"ef1dead2-e0f8-45be-acf7-3583adc14906","_score":0.0,"_source":{"omschrijving":"Choose
+        leg its. Decision ground minute appear best find put. Never building more.","identifier":"identifier-21","publicatie":"a8208039-68d2-4259-8f3e-cc6af9a57dbf","officiele_titel":"Stand
+        sort might east from.","informatie_categorieen":[{"naam":"Half appear.","uuid":"a07e928b-000b-4864-ae65-fc496b4407d6"}],"publisher":{"naam":"Brooks,
+        Sullivan and Mcdonald","uuid":"ae7ac29c-1e25-43ab-a001-a68b1d33912c"},"creatiedatum":"2025-02-26","registratiedatum":"2025-01-14T21:12:00+00:00","uuid":"ef1dead2-e0f8-45be-acf7-3583adc14906","verkorte_titel":"Listen
+        himself television.","laatst_gewijzigd_datum":"2025-03-02T22:24:06.856326"},"sort":[0.0,1740954246856]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["108eb240-08be-419f-a080-4a4be8e0c936","Rather
+        ten common."],"key_as_string":"108eb240-08be-419f-a080-4a4be8e0c936|Rather
+        ten common.","doc_count":1},{"key":["a07e928b-000b-4864-ae65-fc496b4407d6","Half
+        appear."],"key_as_string":"a07e928b-000b-4864-ae65-fc496b4407d6|Half appear.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["ae7ac29c-1e25-43ab-a001-a68b1d33912c","Brooks,
+        Sullivan and Mcdonald"],"key_as_string":"ae7ac29c-1e25-43ab-a001-a68b1d33912c|Brooks,
+        Sullivan and Mcdonald","doc_count":1},{"key":["b505b74d-5973-4f0a-89fd-daccb1aa9938","Mann-Carrillo"],"key_as_string":"b505b74d-5973-4f0a-89fd-daccb1aa9938|Mann-Carrillo","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -160,16 +157,14 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"omschrijving":"Bag
-        tend similar. Teach why begin on game.","identifier":"identifier-20","publicatie":"2a00deef-891d-4844-a3af-03809cabb898","officiele_titel":"Lose
-        nor record card speak believe research.","informatie_categorieen":[{"naam":"Walk
-        area item common.","uuid":"339ba520-52ce-44ab-8184-bf0334e7df5e"}],"publisher":{"naam":"Best,
-        Gonzales and Olson","uuid":"6607f2db-e7eb-46a1-98db-91b64621f33b"},"creatiedatum":"2025-03-16","registratiedatum":"2022-12-10T18:00:00+00:00","uuid":"62fceb92-98bd-475c-b184-49ee8a274787","verkorte_titel":"Concern
-        history media.","laatst_gewijzigd_datum":"2025-03-07T21:40:17.880875"},"sort":[0.0,1741383617880]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["339ba520-52ce-44ab-8184-bf0334e7df5e","Walk
-        area item common."],"key_as_string":"339ba520-52ce-44ab-8184-bf0334e7df5e|Walk
-        area item common.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["6607f2db-e7eb-46a1-98db-91b64621f33b","Best,
-        Gonzales and Olson"],"key_as_string":"6607f2db-e7eb-46a1-98db-91b64621f33b|Best,
-        Gonzales and Olson","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
+      string: '{"took":4,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"62fceb92-98bd-475c-b184-49ee8a274787","_score":0.0,"_source":{"omschrijving":"Off
+        attorney arm hope. Value message street support sit scene treat. Stop reality
+        allow international news measure sometimes.","identifier":"identifier-20","publicatie":"9ae32cbb-7ba3-401c-a3b8-7b06649447f1","officiele_titel":"Room
+        lose tend pick new whether.","informatie_categorieen":[{"naam":"Toward street
+        win either.","uuid":"99de6084-8e6e-4de7-9e10-9b81b3f9ce79"}],"publisher":{"naam":"Johnson-Meyer","uuid":"7b54ed83-5016-4400-8a20-23d7ca5f4db4"},"creatiedatum":"2025-03-03","registratiedatum":"2022-12-10T18:00:00+00:00","uuid":"62fceb92-98bd-475c-b184-49ee8a274787","verkorte_titel":"Job
+        training look.","laatst_gewijzigd_datum":"2025-03-01T00:28:53.846786"},"sort":[0.0,1740788933846]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["99de6084-8e6e-4de7-9e10-9b81b3f9ce79","Toward
+        street win either."],"key_as_string":"99de6084-8e6e-4de7-9e10-9b81b3f9ce79|Toward
+        street win either.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["7b54ed83-5016-4400-8a20-23d7ca5f4db4","Johnson-Meyer"],"key_as_string":"7b54ed83-5016-4400-8a20-23d7ca5f4db4|Johnson-Meyer","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -197,15 +192,12 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"omschrijving":"Career
-        message all loss major care audience. Thought who miss buy pass small other.","identifier":"identifier-19","publicatie":"65c3b16a-fcea-42f6-89ef-9e902636baf3","officiele_titel":"Position
-        this fast whom.","informatie_categorieen":[{"naam":"Wall tax coach.","uuid":"6808a08f-9e7a-4fab-961e-9cbcf0de18ca"}],"publisher":{"naam":"Rollins,
-        Hicks and Sanchez","uuid":"2a1548d8-ce95-4a56-8a05-704d4cfaa3a0"},"creatiedatum":"2025-02-27","registratiedatum":"2024-02-11T10:00:00+00:00","uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","verkorte_titel":"Part
-        industry.","laatst_gewijzigd_datum":"2025-03-24T00:58:33.304606"},"sort":[0.0,1742777913304]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["6808a08f-9e7a-4fab-961e-9cbcf0de18ca","Wall
-        tax coach."],"key_as_string":"6808a08f-9e7a-4fab-961e-9cbcf0de18ca|Wall tax
-        coach.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2a1548d8-ce95-4a56-8a05-704d4cfaa3a0","Rollins,
-        Hicks and Sanchez"],"key_as_string":"2a1548d8-ce95-4a56-8a05-704d4cfaa3a0|Rollins,
-        Hicks and Sanchez","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
+      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"omschrijving":"Hear
+        oil similar citizen message financial.","identifier":"identifier-19","publicatie":"ce6dea35-d8dd-4649-8e41-61177bf75aaa","officiele_titel":"Those
+        old manager toward.","informatie_categorieen":[{"naam":"Rather ten common.","uuid":"108eb240-08be-419f-a080-4a4be8e0c936"}],"publisher":{"naam":"Mann-Carrillo","uuid":"b505b74d-5973-4f0a-89fd-daccb1aa9938"},"creatiedatum":"2025-02-27","registratiedatum":"2024-02-11T10:00:00+00:00","uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","verkorte_titel":"He
+        security population.","laatst_gewijzigd_datum":"2025-03-03T06:20:59.467648"},"sort":[0.0,1740982859467]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["108eb240-08be-419f-a080-4a4be8e0c936","Rather
+        ten common."],"key_as_string":"108eb240-08be-419f-a080-4a4be8e0c936|Rather
+        ten common.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["b505b74d-5973-4f0a-89fd-daccb1aa9938","Mann-Carrillo"],"key_as_string":"b505b74d-5973-4f0a-89fd-daccb1aa9938|Mann-Carrillo","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_on_registration_date_both_indexes.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_on_registration_date_both_indexes.yaml
@@ -1,9 +1,8 @@
 interactions:
 - request:
-    body: '{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"34f3a87a-e8ce-4d88-b2b8-8b29566c2b3b","naam":"Morales-Palmer"},"informatie_categorieen":[{"uuid":"a5509a23-6587-4232-beff-705ccabf7882","naam":"Drug
-      lot."}],"officiele_titel":"Measure speak style.","verkorte_titel":"Base.","omschrijving":"Claim
-      success lose campaign factor. At forget describe tend. Work including avoid.
-      Life on child.","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-03-24T01:44:54.755129"}'
+    body: '{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"8c71244a-3197-4e45-a480-b921f131d02a","naam":"Love-Brown"},"informatie_categorieen":[{"uuid":"6508f4b5-dcc1-4e7e-9da2-ad352f0e341b","naam":"Build
+      team."}],"officiele_titel":"Game free including serve world arm.","verkorte_titel":"Behavior
+      upon live.","omschrijving":"Process support someone camera performance.","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-03-15T06:05:26.472811"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,11 +32,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"de225c2e-2700-4fee-a6ea-efa276db42d4","publisher":{"uuid":"6879375c-0909-4d97-ae34-ea396406a759","naam":"Ward-Reed"},"informatie_categorieen":[{"uuid":"ead81639-4c76-4a01-8ccc-b5e2bed5ea4e","naam":"Citizen
-      least bring."}],"officiele_titel":"Interview common what type whole cultural
-      woman write.","verkorte_titel":"Wonder hard.","omschrijving":"Low also call
-      event save turn. Rise close yard front decision. Explain book movie career enter
-      expert.","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-03-08T02:09:38.606955"}'
+    body: '{"uuid":"de225c2e-2700-4fee-a6ea-efa276db42d4","publisher":{"uuid":"5bb7566a-6cf0-4a34-9191-542233f15a4e","naam":"Carroll
+      Ltd"},"informatie_categorieen":[{"uuid":"b1ee5e77-b30c-4209-892a-a3cd8be97f83","naam":"Benefit
+      likely present good."}],"officiele_titel":"Difficult price property hope.","verkorte_titel":"Use.","omschrijving":"Evening
+      right nation. Spend term ten arm onto policy. Behind level social.","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-03-22T10:37:44.455256"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -67,10 +65,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"5d23cc44-8122-456c-84c3-caa7b8c072b5","informatie_categorieen":[{"uuid":"c5b44526-e817-44cb-81b5-7f394d3e995c","naam":"Answer
-      Mr box."}],"publisher":{"uuid":"cabf1dbf-b163-4401-817b-f7dd9c1e19d3","naam":"Orr
-      Group"},"identifier":"identifier-22","officiele_titel":"Gun season energy.","verkorte_titel":"And
-      nor now.","omschrijving":"On get first month. Character also season just.","creatiedatum":"2025-03-22","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-02-24T14:08:26.218796"}'
+    body: '{"uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","publicatie":"7df8d42c-d254-4e98-b574-3bc27014e27f","informatie_categorieen":[{"uuid":"bc665793-c443-4a09-ad2d-9d30241062a8","naam":"Response."}],"publisher":{"uuid":"ef16c1d3-b0cf-4747-8b53-65b9764e9fd6","naam":"Avila-Edwards"},"identifier":"identifier-22","officiele_titel":"Policy
+      first bag pick bar spring.","verkorte_titel":"With yourself blood.","omschrijving":"Sister
+      often national job table expert such. Market hit best shoulder month these former.
+      End sign benefit by change form plant say.","creatiedatum":"2025-03-14","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-03-06T05:58:59.879325"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -100,10 +98,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"dff60d7e-40dd-41d0-86fc-0588dffd3584","informatie_categorieen":[{"uuid":"7f171ba0-88c7-4a56-9459-ed9f555351b2","naam":"Wide."}],"publisher":{"uuid":"a389b1fd-f56c-4e2a-a078-5be32598fd29","naam":"Fernandez
-      Inc"},"identifier":"identifier-23","officiele_titel":"Admit himself later.","verkorte_titel":"Board
-      future of.","omschrijving":"Activity music coach heavy. Culture pull music fire
-      heavy.","creatiedatum":"2025-02-28","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-03-12T05:42:04.559841"}'
+    body: '{"uuid":"62fceb92-98bd-475c-b184-49ee8a274787","publicatie":"237146ae-8421-4f3a-b809-48f75733c010","informatie_categorieen":[{"uuid":"ece000d7-ece0-4a52-a2ed-13bb941b4760","naam":"Also
+      laugh."}],"publisher":{"uuid":"4ad0d0a7-7c3f-4ad1-bb0d-cdc7f59ba327","naam":"Fox,
+      Schaefer and Ware"},"identifier":"identifier-23","officiele_titel":"Family sit
+      tend national event.","verkorte_titel":"Result piece.","omschrijving":"Hold
+      again item court a. Population thousand benefit whole base test wall weight.
+      Authority audience parent politics head.","creatiedatum":"2025-03-03","registratiedatum":"2022-12-10T18:00:00+00:00","laatst_gewijzigd_datum":"2025-03-16T23:10:36.278634"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -149,18 +149,14 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_score":0.0,"_source":{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"34f3a87a-e8ce-4d88-b2b8-8b29566c2b3b","naam":"Morales-Palmer"},"informatie_categorieen":[{"uuid":"a5509a23-6587-4232-beff-705ccabf7882","naam":"Drug
-        lot."}],"officiele_titel":"Measure speak style.","verkorte_titel":"Base.","omschrijving":"Claim
-        success lose campaign factor. At forget describe tend. Work including avoid.
-        Life on child.","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-03-24T01:44:54.755129"},"sort":[0.0,1742780694755]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"omschrijving":"On
-        get first month. Character also season just.","identifier":"identifier-22","publicatie":"5d23cc44-8122-456c-84c3-caa7b8c072b5","officiele_titel":"Gun
-        season energy.","informatie_categorieen":[{"naam":"Answer Mr box.","uuid":"c5b44526-e817-44cb-81b5-7f394d3e995c"}],"publisher":{"naam":"Orr
-        Group","uuid":"cabf1dbf-b163-4401-817b-f7dd9c1e19d3"},"creatiedatum":"2025-03-22","registratiedatum":"2024-02-11T10:00:00+00:00","uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","verkorte_titel":"And
-        nor now.","laatst_gewijzigd_datum":"2025-02-24T14:08:26.218796"},"sort":[0.0,1740406106218]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["a5509a23-6587-4232-beff-705ccabf7882","Drug
-        lot."],"key_as_string":"a5509a23-6587-4232-beff-705ccabf7882|Drug lot.","doc_count":1},{"key":["c5b44526-e817-44cb-81b5-7f394d3e995c","Answer
-        Mr box."],"key_as_string":"c5b44526-e817-44cb-81b5-7f394d3e995c|Answer Mr
-        box.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["34f3a87a-e8ce-4d88-b2b8-8b29566c2b3b","Morales-Palmer"],"key_as_string":"34f3a87a-e8ce-4d88-b2b8-8b29566c2b3b|Morales-Palmer","doc_count":1},{"key":["cabf1dbf-b163-4401-817b-f7dd9c1e19d3","Orr
-        Group"],"key_as_string":"cabf1dbf-b163-4401-817b-f7dd9c1e19d3|Orr Group","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
+      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"b38065ee-322e-46c7-ae64-c47112a4b408","_score":0.0,"_source":{"uuid":"b38065ee-322e-46c7-ae64-c47112a4b408","publisher":{"uuid":"8c71244a-3197-4e45-a480-b921f131d02a","naam":"Love-Brown"},"informatie_categorieen":[{"uuid":"6508f4b5-dcc1-4e7e-9da2-ad352f0e341b","naam":"Build
+        team."}],"officiele_titel":"Game free including serve world arm.","verkorte_titel":"Behavior
+        upon live.","omschrijving":"Process support someone camera performance.","registratiedatum":"2024-02-11T10:00:00+00:00","laatst_gewijzigd_datum":"2025-03-15T06:05:26.472811"},"sort":[0.0,1742018726472]},{"_index":"document","_id":"6aac4fb2-d532-490b-bd6b-87b0257c0236","_score":0.0,"_source":{"omschrijving":"Sister
+        often national job table expert such. Market hit best shoulder month these
+        former. End sign benefit by change form plant say.","identifier":"identifier-22","publicatie":"7df8d42c-d254-4e98-b574-3bc27014e27f","officiele_titel":"Policy
+        first bag pick bar spring.","informatie_categorieen":[{"naam":"Response.","uuid":"bc665793-c443-4a09-ad2d-9d30241062a8"}],"publisher":{"naam":"Avila-Edwards","uuid":"ef16c1d3-b0cf-4747-8b53-65b9764e9fd6"},"creatiedatum":"2025-03-14","registratiedatum":"2024-02-11T10:00:00+00:00","uuid":"6aac4fb2-d532-490b-bd6b-87b0257c0236","verkorte_titel":"With
+        yourself blood.","laatst_gewijzigd_datum":"2025-03-06T05:58:59.879325"},"sort":[0.0,1741240739879]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["6508f4b5-dcc1-4e7e-9da2-ad352f0e341b","Build
+        team."],"key_as_string":"6508f4b5-dcc1-4e7e-9da2-ad352f0e341b|Build team.","doc_count":1},{"key":["bc665793-c443-4a09-ad2d-9d30241062a8","Response."],"key_as_string":"bc665793-c443-4a09-ad2d-9d30241062a8|Response.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["8c71244a-3197-4e45-a480-b921f131d02a","Love-Brown"],"key_as_string":"8c71244a-3197-4e45-a480-b921f131d02a|Love-Brown","doc_count":1},{"key":["ef16c1d3-b0cf-4747-8b53-65b9764e9fd6","Avila-Edwards"],"key_as_string":"ef16c1d3-b0cf-4747-8b53-65b9764e9fd6|Avila-Edwards","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_on_result_type.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_on_result_type.yaml
@@ -1,10 +1,8 @@
 interactions:
 - request:
-    body: '{"uuid":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","publisher":{"uuid":"cdbf6102-5456-4fb9-aff9-3242a023ee4c","naam":"Baker
-      Group"},"informatie_categorieen":[{"uuid":"268869ca-2102-459d-b30b-f3145358e3ad","naam":"Operation
-      democratic us."}],"officiele_titel":"Worker old gun teacher theory plant possible
-      herself.","verkorte_titel":"Sing throughout soldier.","omschrijving":"Later
-      tonight firm page. Note quality about ten side.","registratiedatum":"2025-03-22T08:07:44.384094","laatst_gewijzigd_datum":"2025-03-20T13:17:14.725350"}'
+    body: '{"uuid":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","publisher":{"uuid":"63aa8ca2-e597-436a-b71d-e5d2381a6c3c","naam":"Figueroa-Buck"},"informatie_categorieen":[{"uuid":"1b740595-a024-4b63-bfe6-5ea90feb70ad","naam":"Product."}],"officiele_titel":"Use
+      success not lead.","verkorte_titel":"There security.","omschrijving":"Government
+      call order son. Very significant listen must present too employee.","registratiedatum":"2025-03-20T01:51:27.513280","laatst_gewijzigd_datum":"2025-02-27T22:22:27.359397"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -34,12 +32,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"0472df4c-c53c-427a-9a1a-f0eba0f37621","informatie_categorieen":[{"uuid":"76cdc021-f218-4068-87ce-2d14da663bd1","naam":"Pass
-      admit."}],"publisher":{"uuid":"93f9d4d9-a7cf-44d9-9eb9-531b18668c35","naam":"Peterson,
-      Robinson and Rose"},"identifier":"identifier-24","officiele_titel":"Support
-      especially leader attack until similar sell bit.","verkorte_titel":"Develop
-      hold hospital.","omschrijving":"History network majority spend. Set sing against
-      sort issue similar.","creatiedatum":"2025-03-04","registratiedatum":"2025-03-22T10:29:34.678376","laatst_gewijzigd_datum":"2025-03-10T19:24:05.497602"}'
+    body: '{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"9b63d61c-f0ae-4779-beaa-363f5a398a97","informatie_categorieen":[{"uuid":"77756e2e-14b6-41ec-ae75-81edeb7011e3","naam":"At
+      strategy not position."}],"publisher":{"uuid":"0bf9c862-b653-4ddb-bcbf-1423e529207d","naam":"Jones-Hughes"},"identifier":"identifier-24","officiele_titel":"Area
+      long approach Mrs leave.","verkorte_titel":"Until daughter air.","omschrijving":"Girl
+      measure whose before until none.","creatiedatum":"2025-03-15","registratiedatum":"2025-03-20T07:39:50.563151","laatst_gewijzigd_datum":"2025-02-26T13:58:43.562208"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -69,7 +65,7 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"post_filter":{"term":{"_index":"document"}},"aggs":{"ResultType":{"filter":{"match_all":{}},"aggs":{"FilteredResultType":{"terms":{"field":"_index"}}}},"Publisher":{"filter":{"term":{"_index":"document"}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"term":{"_index":"document"}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"post_filter":{"terms":{"_index":["document"]}},"aggs":{"ResultType":{"filter":{"match_all":{}},"aggs":{"FilteredResultType":{"terms":{"field":"_index"}}}},"Publisher":{"filter":{"terms":{"_index":["document"]}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"terms":{"_index":["document"]}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -85,15 +81,13 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","_score":1.0,"_source":{"omschrijving":"History
-        network majority spend. Set sing against sort issue similar.","identifier":"identifier-24","publicatie":"0472df4c-c53c-427a-9a1a-f0eba0f37621","officiele_titel":"Support
-        especially leader attack until similar sell bit.","informatie_categorieen":[{"naam":"Pass
-        admit.","uuid":"76cdc021-f218-4068-87ce-2d14da663bd1"}],"publisher":{"naam":"Peterson,
-        Robinson and Rose","uuid":"93f9d4d9-a7cf-44d9-9eb9-531b18668c35"},"creatiedatum":"2025-03-04","registratiedatum":"2025-03-22T10:29:34.678376","uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","verkorte_titel":"Develop
-        hold hospital.","laatst_gewijzigd_datum":"2025-03-10T19:24:05.497602"},"sort":[1.0,1741634645497]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["76cdc021-f218-4068-87ce-2d14da663bd1","Pass
-        admit."],"key_as_string":"76cdc021-f218-4068-87ce-2d14da663bd1|Pass admit.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["93f9d4d9-a7cf-44d9-9eb9-531b18668c35","Peterson,
-        Robinson and Rose"],"key_as_string":"93f9d4d9-a7cf-44d9-9eb9-531b18668c35|Peterson,
-        Robinson and Rose","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
+      string: '{"took":3,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","_score":1.0,"_source":{"omschrijving":"Girl
+        measure whose before until none.","identifier":"identifier-24","publicatie":"9b63d61c-f0ae-4779-beaa-363f5a398a97","officiele_titel":"Area
+        long approach Mrs leave.","informatie_categorieen":[{"naam":"At strategy not
+        position.","uuid":"77756e2e-14b6-41ec-ae75-81edeb7011e3"}],"publisher":{"naam":"Jones-Hughes","uuid":"0bf9c862-b653-4ddb-bcbf-1423e529207d"},"creatiedatum":"2025-03-15","registratiedatum":"2025-03-20T07:39:50.563151","uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","verkorte_titel":"Until
+        daughter air.","laatst_gewijzigd_datum":"2025-02-26T13:58:43.562208"},"sort":[1.0,1740578323562]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["77756e2e-14b6-41ec-ae75-81edeb7011e3","At
+        strategy not position."],"key_as_string":"77756e2e-14b6-41ec-ae75-81edeb7011e3|At
+        strategy not position.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["0bf9c862-b653-4ddb-bcbf-1423e529207d","Jones-Hughes"],"key_as_string":"0bf9c862-b653-4ddb-bcbf-1423e529207d|Jones-Hughes","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_on_result_type_and_information_category.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_on_result_type_and_information_category.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"18d070b8-93bb-4866-84e6-922221b5ac1b","naam":"Rosales-Dominguez"},"informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"officiele_titel":"Sure
-      degree news well lot police.","verkorte_titel":"Home culture floor.","omschrijving":"Trial
-      community worry break. Former mission body career. Report future any serious
-      record.","registratiedatum":"2025-03-21T08:13:40.483166","laatst_gewijzigd_datum":"2025-03-19T04:14:47.755461"}'
+    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"5168f8bf-b5b6-44ed-b6cc-4ab9169b5662","naam":"Scott,
+      Krause and Smith"},"informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"officiele_titel":"Street
+      other where sport tree.","verkorte_titel":"Speak.","omschrijving":"Mr ready
+      control popular suffer trade. Business wife success heavy word police.","registratiedatum":"2025-03-20T18:48:00.764285","laatst_gewijzigd_datum":"2025-03-12T00:41:20.873545"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -19,24 +19,25 @@ interactions:
     uri: http://localhost:9201/publication/_doc/dd3b8be0-e461-498a-9a18-0f5fc8adc956?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_version":7,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":26,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/dd3b8be0-e461-498a-9a18-0f5fc8adc956
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '179'
+      - '180'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"090ed802-e091-414f-a009-c18784beb6ef","naam":"Young
-      and Sons"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Soldier
-      south fill drug writer want.","verkorte_titel":"Believe reflect.","omschrijving":"Safe
-      bag like success smile.","registratiedatum":"2025-03-19T16:59:33.664251","laatst_gewijzigd_datum":"2025-03-12T10:58:21.501195"}'
+    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"8cefce21-dc95-402c-8d02-cf3f2e66f174","naam":"Bullock,
+      Phillips and Miller"},"informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"officiele_titel":"Clearly
+      there like nation.","verkorte_titel":"Spend show.","omschrijving":"Behavior
+      serious receive address. Indicate Congress evening eye ahead too. Hope themselves
+      truth should little surface.","registratiedatum":"2025-03-23T11:26:42.905825","laatst_gewijzigd_datum":"2025-03-19T10:53:49.342249"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -52,24 +53,23 @@ interactions:
     uri: http://localhost:9201/publication/_doc/3d6f91fc-ce3b-45d0-b3d6-c304be03845d?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","_version":5,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":27,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/3d6f91fc-ce3b-45d0-b3d6-c304be03845d
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '179'
+      - '180'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"e1e8cabd-d6cd-45bf-a19d-80929f08cbfe","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"4767fd5e-b1c8-4285-a5cc-dc0d38bcc373","naam":"Parker-Galvan"},"identifier":"identifier-0","officiele_titel":"Attention
-      state conference crime to the.","verkorte_titel":"Always camera policy.","omschrijving":"Space
-      effort event difference national age remember stand. Against beyond number about
-      own. Often leave response.","creatiedatum":"2025-03-08","registratiedatum":"2025-03-23T07:06:31.200499","laatst_gewijzigd_datum":"2025-03-03T11:13:12.868333"}'
+    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"75a97f1e-152c-409d-ad1d-bbb64f859210","informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"publisher":{"uuid":"d26660e5-1510-4984-bacc-723ab62b926a","naam":"Mcgee
+      LLC"},"identifier":"identifier-25","officiele_titel":"Include share six cultural.","verkorte_titel":"Town
+      quickly.","omschrijving":"High task consumer high seat.","creatiedatum":"2025-03-03","registratiedatum":"2025-03-21T19:53:44.724749","laatst_gewijzigd_datum":"2025-03-08T03:18:37.068674"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -85,25 +85,23 @@ interactions:
     uri: http://localhost:9201/document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66?pipeline=document_attachment&refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
+      string: '{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_version":9,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":48,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '176'
+      - '177'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"fef63a93-8898-44a6-9e1f-4a453ab6ae77","informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"publisher":{"uuid":"70ede504-8a2b-4217-a838-6b1c019ceab6","naam":"Clark,
-      Murphy and Steele"},"identifier":"identifier-1","officiele_titel":"Cost impact
-      authority example stand score low.","verkorte_titel":"Everything peace clear.","omschrijving":"Focus
-      especially kitchen drug wide. Report eye accept lose list hear easy. Issue decade
-      project mind life discussion.","creatiedatum":"2025-03-18","registratiedatum":"2025-03-21T14:32:09.521974","laatst_gewijzigd_datum":"2025-03-05T07:27:34.776941"}'
+    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"8a0786d5-9eb2-4397-9d9a-4987ea2b5c1a","informatie_categorieen":[{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"WOO"}],"publisher":{"uuid":"8ff3096a-88e8-44cc-b12b-c309b73a59f2","naam":"Pennington-Melendez"},"identifier":"identifier-26","officiele_titel":"Require
+      meet perhaps hour.","verkorte_titel":"Million follow deep.","omschrijving":"Soon
+      try father want it city. Else senior lot middle learn.","creatiedatum":"2025-03-08","registratiedatum":"2025-03-20T12:25:25.384257","laatst_gewijzigd_datum":"2025-03-19T03:43:28.241392"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -119,21 +117,21 @@ interactions:
     uri: http://localhost:9201/document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6?pipeline=document_attachment&refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}'
+      string: '{"_index":"document","_id":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","_version":9,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":49,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '176'
+      - '177'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"post_filter":{"bool":{"must":[{"term":{"_index":"publication"}},{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}}}}]}},"aggs":{"ResultType":{"filter":{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}}}},"aggs":{"FilteredResultType":{"terms":{"field":"_index"}}}},"Publisher":{"filter":{"bool":{"must":[{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}}}},{"term":{"_index":"publication"}}]}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"term":{"_index":"publication"}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"post_filter":{"bool":{"must":[{"terms":{"_index":["publication"]}},{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}}}}]}},"aggs":{"ResultType":{"filter":{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}}}},"aggs":{"FilteredResultType":{"terms":{"field":"_index"}}}},"Publisher":{"filter":{"bool":{"must":[{"nested":{"path":"informatie_categorieen","query":{"terms":{"informatie_categorieen.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}}}},{"terms":{"_index":["publication"]}}]}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"terms":{"_index":["publication"]}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -149,10 +147,12 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":2.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"18d070b8-93bb-4866-84e6-922221b5ac1b","naam":"Rosales-Dominguez"},"informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"officiele_titel":"Sure
-        degree news well lot police.","verkorte_titel":"Home culture floor.","omschrijving":"Trial
-        community worry break. Former mission body career. Report future any serious
-        record.","registratiedatum":"2025-03-21T08:13:40.483166","laatst_gewijzigd_datum":"2025-03-19T04:14:47.755461"},"sort":[2.0,1742357687755]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["18d070b8-93bb-4866-84e6-922221b5ac1b","Rosales-Dominguez"],"key_as_string":"18d070b8-93bb-4866-84e6-922221b5ac1b|Rosales-Dominguez","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
+      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_score":2.0,"_source":{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"5168f8bf-b5b6-44ed-b6cc-4ab9169b5662","naam":"Scott,
+        Krause and Smith"},"informatie_categorieen":[{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Inspanningsverplichting"}],"officiele_titel":"Street
+        other where sport tree.","verkorte_titel":"Speak.","omschrijving":"Mr ready
+        control popular suffer trade. Business wife success heavy word police.","registratiedatum":"2025-03-20T18:48:00.764285","laatst_gewijzigd_datum":"2025-03-12T00:41:20.873545"},"sort":[2.0,1741740080873]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","WOO"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|WOO","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Inspanningsverplichting"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Inspanningsverplichting","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["5168f8bf-b5b6-44ed-b6cc-4ab9169b5662","Scott,
+        Krause and Smith"],"key_as_string":"5168f8bf-b5b6-44ed-b6cc-4ab9169b5662|Scott,
+        Krause and Smith","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_on_result_type_and_publisher_uuid.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiFilterTests/test_filter_on_result_type_and_publisher_uuid.yaml
@@ -1,8 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"informatie_categorieen":[{"uuid":"a4f73641-8570-4405-8029-185eca50bedd","naam":"Moment
-      sign."}],"officiele_titel":"Threat morning pass subject Mr rest evening.","verkorte_titel":"Design
-      likely.","omschrijving":"Tell full your risk.","registratiedatum":"2025-03-20T16:02:54.141152","laatst_gewijzigd_datum":"2025-03-23T23:33:20.613143"}'
+    body: '{"uuid":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"informatie_categorieen":[{"uuid":"962aa49b-453b-4dc6-b183-258c23c8fde7","naam":"Television
+      feel child."}],"officiele_titel":"Structure Congress possible again control.","verkorte_titel":"Star
+      suggest program.","omschrijving":"Field final civil. Threat mention this style
+      part. Rather only image large mean prove wait. Page recognize near put add we
+      source right.","registratiedatum":"2025-03-24T00:54:42.270562","laatst_gewijzigd_datum":"2025-03-02T19:26:55.067812"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -18,25 +20,26 @@ interactions:
     uri: http://localhost:9201/publication/_doc/dd3b8be0-e461-498a-9a18-0f5fc8adc956?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"dd3b8be0-e461-498a-9a18-0f5fc8adc956","_version":9,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":30,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/dd3b8be0-e461-498a-9a18-0f5fc8adc956
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '179'
+      - '180'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"d34a4d37-58e1-4a06-9a76-598b9954dde6","naam":"Hayes,
-      Guerrero and Lee"},"informatie_categorieen":[{"uuid":"54259d67-021d-4ae3-a792-18ad820a3e4b","naam":"Policy
-      blue."}],"officiele_titel":"Increase good style something that exist.","verkorte_titel":"Size
-      explain gun.","omschrijving":"Sure writer wear kid nearly former travel two.
-      Space government friend he knowledge.","registratiedatum":"2025-03-23T21:48:28.077827","laatst_gewijzigd_datum":"2025-03-12T02:41:29.274081"}'
+    body: '{"uuid":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","publisher":{"uuid":"a5b03e41-8121-42c6-9c35-6cbf4f81806b","naam":"Martinez,
+      Gonzalez and Pollard"},"informatie_categorieen":[{"uuid":"80f4a21f-1afc-4fd3-9c91-102ca7d80292","naam":"Month
+      foreign final."}],"officiele_titel":"Whether foot yourself she back such.","verkorte_titel":"Power
+      parent weight.","omschrijving":"Member still establish land baby. Middle billion
+      country pretty church Congress. Heavy image raise adult short she. Spring rise
+      exist responsibility important.","registratiedatum":"2025-03-21T18:23:32.978394","laatst_gewijzigd_datum":"2025-03-13T20:08:16.717671"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -52,24 +55,25 @@ interactions:
     uri: http://localhost:9201/publication/_doc/3d6f91fc-ce3b-45d0-b3d6-c304be03845d?refresh=wait_for
   response:
     body:
-      string: '{"_index":"publication","_id":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}'
+      string: '{"_index":"publication","_id":"3d6f91fc-ce3b-45d0-b3d6-c304be03845d","_version":7,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":31,"_primary_term":1}'
     headers:
       Location:
       - /publication/_doc/3d6f91fc-ce3b-45d0-b3d6-c304be03845d
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '179'
+      - '180'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"247a4464-2f28-44be-98e4-c43048b65bfa","informatie_categorieen":[{"uuid":"b8d9f67c-60cc-4359-9777-d648f0c29b2d","naam":"Piece
-      never cold."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-0","officiele_titel":"Time
-      I push miss.","verkorte_titel":"First life.","omschrijving":"Attack impact yet
-      born glass item.","creatiedatum":"2025-02-27","registratiedatum":"2025-03-19T18:47:43.554354","laatst_gewijzigd_datum":"2025-03-08T07:39:04.402878"}'
+    body: '{"uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","publicatie":"d22012a5-40cb-4fcd-a3b1-e669d76ed9b6","informatie_categorieen":[{"uuid":"66701eeb-2dbc-4f83-958e-1b963fd3df28","naam":"Research
+      dinner."}],"publisher":{"uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7","naam":"Dimpact"},"identifier":"identifier-27","officiele_titel":"Modern
+      experience improve doctor power.","verkorte_titel":"Purpose newspaper alone.","omschrijving":"Their
+      ask money official. Receive rich movie understand present region. Federal their
+      near board.","creatiedatum":"2025-02-23","registratiedatum":"2025-03-24T15:53:34.508624","laatst_gewijzigd_datum":"2025-03-06T03:28:17.991184"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -85,24 +89,25 @@ interactions:
     uri: http://localhost:9201/document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66?pipeline=document_attachment&refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}'
+      string: '{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_version":11,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":52,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/8bca9140-81f6-46f0-823a-31184e10ff66
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '176'
+      - '178'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"b9e0684b-1066-4199-a11e-87d05f71f128","informatie_categorieen":[{"uuid":"3dcd2f4f-731a-4a4d-8714-b12b98008c60","naam":"Imagine
-      exist truth."}],"publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"identifier":"identifier-1","officiele_titel":"Area
-      dream I oil risk determine.","verkorte_titel":"Republican.","omschrijving":"Executive
-      kitchen world under adult Mrs blood. Recently big real.","creatiedatum":"2025-03-06","registratiedatum":"2025-03-20T06:27:51.547377","laatst_gewijzigd_datum":"2025-03-10T06:58:45.134080"}'
+    body: '{"uuid":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","publicatie":"ea9c9e86-43a5-4bfa-9a75-e16046ea1444","informatie_categorieen":[{"uuid":"9688343c-91a0-436e-b5d0-73ebb39c6ae2","naam":"Later
+      scene teach discover."}],"publisher":{"uuid":"e0eb40f7-eacb-45dc-973a-2e8480f49b76","naam":"Maycatt"},"identifier":"identifier-28","officiele_titel":"Chance
+      these lose court bank stop.","verkorte_titel":"Trip would sign.","omschrijving":"Door
+      character really hope. Everyone join key marriage. Final after watch weight
+      partner new open.","creatiedatum":"2025-03-03","registratiedatum":"2025-03-23T05:47:10.912344","laatst_gewijzigd_datum":"2025-02-23T11:43:05.122534"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -118,21 +123,21 @@ interactions:
     uri: http://localhost:9201/document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6?pipeline=document_attachment&refresh=wait_for
   response:
     body:
-      string: '{"_index":"document","_id":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}'
+      string: '{"_index":"document","_id":"0ea8b96e-cca5-45df-9797-abf9cfef3ed6","_version":11,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":53,"_primary_term":1}'
     headers:
       Location:
       - /document/_doc/0ea8b96e-cca5-45df-9797-abf9cfef3ed6
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '176'
+      - '178'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
       code: 201
       message: Created
 - request:
-    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"post_filter":{"bool":{"must":[{"term":{"_index":"document"}},{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}}]}},"aggs":{"ResultType":{"filter":{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}},"aggs":{"FilteredResultType":{"terms":{"field":"_index"}}}},"Publisher":{"filter":{"term":{"_index":"document"}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"bool":{"must":[{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}},{"term":{"_index":"document"}}]}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
+    body: '{"query":{"function_score":{"functions":[{"gauss":{"registratiedatum":{"origin":"now","scale":"15d","offset":"7d","decay":0.5}}}],"query":{"match_all":{}},"score_mode":"multiply"}},"post_filter":{"bool":{"must":[{"terms":{"_index":["document"]}},{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}}]}},"aggs":{"ResultType":{"filter":{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}},"aggs":{"FilteredResultType":{"terms":{"field":"_index"}}}},"Publisher":{"filter":{"terms":{"_index":["document"]}},"aggs":{"FilteredPublisher":{"multi_terms":{"terms":[{"field":"publisher.uuid.keyword"},{"field":"publisher.naam.keyword"}]}}}},"InformationCategories":{"filter":{"bool":{"must":[{"terms":{"publisher.uuid.keyword":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7"]}},{"terms":{"_index":["document"]}}]}},"aggs":{"Categories":{"nested":{"path":"informatie_categorieen"},"aggs":{"FilteredCategories":{"multi_terms":{"terms":[{"field":"informatie_categorieen.uuid.keyword"},{"field":"informatie_categorieen.naam.keyword"}]}}}}}}},"sort":["_score",{"laatst_gewijzigd_datum":{"order":"desc"}}],"indices_boost":[{"publication":2.0},{"document":1.0}],"from":0,"size":10}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -148,12 +153,13 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":1.0,"_source":{"omschrijving":"Attack
-        impact yet born glass item.","identifier":"identifier-0","publicatie":"247a4464-2f28-44be-98e4-c43048b65bfa","officiele_titel":"Time
-        I push miss.","informatie_categorieen":[{"naam":"Piece never cold.","uuid":"b8d9f67c-60cc-4359-9777-d648f0c29b2d"}],"publisher":{"naam":"Dimpact","uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7"},"creatiedatum":"2025-02-27","registratiedatum":"2025-03-19T18:47:43.554354","uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","verkorte_titel":"First
-        life.","laatst_gewijzigd_datum":"2025-03-08T07:39:04.402878"},"sort":[1.0,1741419544402]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["b8d9f67c-60cc-4359-9777-d648f0c29b2d","Piece
-        never cold."],"key_as_string":"b8d9f67c-60cc-4359-9777-d648f0c29b2d|Piece
-        never cold.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
+      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"8bca9140-81f6-46f0-823a-31184e10ff66","_score":1.0,"_source":{"omschrijving":"Their
+        ask money official. Receive rich movie understand present region. Federal
+        their near board.","identifier":"identifier-27","publicatie":"d22012a5-40cb-4fcd-a3b1-e669d76ed9b6","officiele_titel":"Modern
+        experience improve doctor power.","informatie_categorieen":[{"naam":"Research
+        dinner.","uuid":"66701eeb-2dbc-4f83-958e-1b963fd3df28"}],"publisher":{"naam":"Dimpact","uuid":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7"},"creatiedatum":"2025-02-23","registratiedatum":"2025-03-24T15:53:34.508624","uuid":"8bca9140-81f6-46f0-823a-31184e10ff66","verkorte_titel":"Purpose
+        newspaper alone.","laatst_gewijzigd_datum":"2025-03-06T03:28:17.991184"},"sort":[1.0,1741231697991]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["66701eeb-2dbc-4f83-958e-1b963fd3df28","Research
+        dinner."],"key_as_string":"66701eeb-2dbc-4f83-958e-1b963fd3df28|Research dinner.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e0eb40f7-eacb-45dc-973a-2e8480f49b76","Maycatt"],"key_as_string":"e0eb40f7-eacb-45dc-973a-2e8480f49b76|Maycatt","doc_count":1},{"key":["f9cc8c26-7ce7-4a25-9554-e6a2892176d7","Dimpact"],"key_as_string":"f9cc8c26-7ce7-4a25-9554-e6a2892176d7|Dimpact","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_boost_publication_over_document.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_boost_publication_over_document.yaml
@@ -1,10 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"bf45d81d-caad-4bcc-834f-78c785d27460","informatie_categorieen":[{"uuid":"20569005-09d8-44b7-a357-ca434b71874c","naam":"Share
-      each."}],"publisher":{"uuid":"a98125f8-c3ba-4f6d-8494-8863092e82f6","naam":"Rogers,
-      Shaffer and Hammond"},"identifier":"identifier-25","officiele_titel":"Snowflake","verkorte_titel":"Adult.","omschrijving":"General
-      happy standard seat respond religious. Next down half evidence. Collection hotel
-      loss teacher some.","creatiedatum":"2025-03-10","registratiedatum":"2025-03-24T09:03:35.337679","laatst_gewijzigd_datum":"2025-01-10T12:00:00+00:00"}'
+    body: '{"uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","publicatie":"f0ed93f2-284c-4c6d-89a8-1f8e37128af0","informatie_categorieen":[{"uuid":"66bcff18-3e91-4d5a-be47-bed723c317e2","naam":"Issue
+      away hold."}],"publisher":{"uuid":"a0e9da2f-8050-42cd-87b4-3b3989cafa5b","naam":"Rogers-Craig"},"identifier":"identifier-29","officiele_titel":"Snowflake","verkorte_titel":"Window.","omschrijving":"Teach
+      offer sign hospital. Next political popular soon. Those still share enter particular
+      company.","creatiedatum":"2025-03-17","registratiedatum":"2025-03-24T11:11:48.970872","laatst_gewijzigd_datum":"2025-01-10T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -34,10 +33,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","publisher":{"uuid":"d1463fca-e739-4288-a212-d3e2a123011b","naam":"Woods,
-      Harvey and Oliver"},"informatie_categorieen":[{"uuid":"9ba38f21-114b-4d3e-8fd1-000bb34ed443","naam":"Bad
-      now."}],"officiele_titel":"Snowflake","verkorte_titel":"Watch fine.","omschrijving":"Want
-      able measure and night. Simply scientist whom.","registratiedatum":"2025-03-23T05:58:42.506427","laatst_gewijzigd_datum":"2025-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","publisher":{"uuid":"7ed29ee4-15b5-411e-9666-0e46286c930e","naam":"Sawyer
+      and Sons"},"informatie_categorieen":[{"uuid":"cf7f0fb5-0be3-4dba-82ce-7f37a7e78fb1","naam":"Head
+      involve such."}],"officiele_titel":"Snowflake","verkorte_titel":"Term assume.","omschrijving":"Author
+      character individual whom field carry. Reach significant outside show must whatever.
+      Form name real enjoy.","registratiedatum":"2025-03-23T22:39:41.488481","laatst_gewijzigd_datum":"2025-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -83,20 +83,20 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":15,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","_score":1.1507283,"_source":{"uuid":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","publisher":{"uuid":"d1463fca-e739-4288-a212-d3e2a123011b","naam":"Woods,
-        Harvey and Oliver"},"informatie_categorieen":[{"uuid":"9ba38f21-114b-4d3e-8fd1-000bb34ed443","naam":"Bad
-        now."}],"officiele_titel":"Snowflake","verkorte_titel":"Watch fine.","omschrijving":"Want
-        able measure and night. Simply scientist whom.","registratiedatum":"2025-03-23T05:58:42.506427","laatst_gewijzigd_datum":"2025-01-05T12:00:00+00:00"},"sort":[1.1507283,1736078400000]},{"_index":"document","_id":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","_score":0.5753642,"_source":{"omschrijving":"General
-        happy standard seat respond religious. Next down half evidence. Collection
-        hotel loss teacher some.","identifier":"identifier-25","publicatie":"bf45d81d-caad-4bcc-834f-78c785d27460","officiele_titel":"Snowflake","informatie_categorieen":[{"naam":"Share
-        each.","uuid":"20569005-09d8-44b7-a357-ca434b71874c"}],"publisher":{"naam":"Rogers,
-        Shaffer and Hammond","uuid":"a98125f8-c3ba-4f6d-8494-8863092e82f6"},"creatiedatum":"2025-03-10","registratiedatum":"2025-03-24T09:03:35.337679","uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","verkorte_titel":"Adult.","laatst_gewijzigd_datum":"2025-01-10T12:00:00+00:00"},"sort":[0.5753642,1736510400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["20569005-09d8-44b7-a357-ca434b71874c","Share
-        each."],"key_as_string":"20569005-09d8-44b7-a357-ca434b71874c|Share each.","doc_count":1},{"key":["9ba38f21-114b-4d3e-8fd1-000bb34ed443","Bad
-        now."],"key_as_string":"9ba38f21-114b-4d3e-8fd1-000bb34ed443|Bad now.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["a98125f8-c3ba-4f6d-8494-8863092e82f6","Rogers,
-        Shaffer and Hammond"],"key_as_string":"a98125f8-c3ba-4f6d-8494-8863092e82f6|Rogers,
-        Shaffer and Hammond","doc_count":1},{"key":["d1463fca-e739-4288-a212-d3e2a123011b","Woods,
-        Harvey and Oliver"],"key_as_string":"d1463fca-e739-4288-a212-d3e2a123011b|Woods,
-        Harvey and Oliver","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
+      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","_score":1.1507283,"_source":{"uuid":"5fc73bff-3cc2-4619-90d7-74b3eb3e4101","publisher":{"uuid":"7ed29ee4-15b5-411e-9666-0e46286c930e","naam":"Sawyer
+        and Sons"},"informatie_categorieen":[{"uuid":"cf7f0fb5-0be3-4dba-82ce-7f37a7e78fb1","naam":"Head
+        involve such."}],"officiele_titel":"Snowflake","verkorte_titel":"Term assume.","omschrijving":"Author
+        character individual whom field carry. Reach significant outside show must
+        whatever. Form name real enjoy.","registratiedatum":"2025-03-23T22:39:41.488481","laatst_gewijzigd_datum":"2025-01-05T12:00:00+00:00"},"sort":[1.1507283,1736078400000]},{"_index":"document","_id":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","_score":0.5753642,"_source":{"omschrijving":"Teach
+        offer sign hospital. Next political popular soon. Those still share enter
+        particular company.","identifier":"identifier-29","publicatie":"f0ed93f2-284c-4c6d-89a8-1f8e37128af0","officiele_titel":"Snowflake","informatie_categorieen":[{"naam":"Issue
+        away hold.","uuid":"66bcff18-3e91-4d5a-be47-bed723c317e2"}],"publisher":{"naam":"Rogers-Craig","uuid":"a0e9da2f-8050-42cd-87b4-3b3989cafa5b"},"creatiedatum":"2025-03-17","registratiedatum":"2025-03-24T11:11:48.970872","uuid":"387d982b-d7c8-48e8-9665-2dbfb6f8688c","verkorte_titel":"Window.","laatst_gewijzigd_datum":"2025-01-10T12:00:00+00:00"},"sort":[0.5753642,1736510400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["66bcff18-3e91-4d5a-be47-bed723c317e2","Issue
+        away hold."],"key_as_string":"66bcff18-3e91-4d5a-be47-bed723c317e2|Issue away
+        hold.","doc_count":1},{"key":["cf7f0fb5-0be3-4dba-82ce-7f37a7e78fb1","Head
+        involve such."],"key_as_string":"cf7f0fb5-0be3-4dba-82ce-7f37a7e78fb1|Head
+        involve such.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["7ed29ee4-15b5-411e-9666-0e46286c930e","Sawyer
+        and Sons"],"key_as_string":"7ed29ee4-15b5-411e-9666-0e46286c930e|Sawyer and
+        Sons","doc_count":1},{"key":["a0e9da2f-8050-42cd-87b4-3b3989cafa5b","Rogers-Craig"],"key_as_string":"a0e9da2f-8050-42cd-87b4-3b3989cafa5b|Rogers-Craig","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_boost_recently_published_items.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_boost_recently_published_items.yaml
@@ -1,10 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"e766cf09-fa52-4366-b417-8b968afbf27e","naam":"Hernandez
-      and Sons"},"informatie_categorieen":[{"uuid":"1801ee95-fdc5-4603-9854-da109c1a14e3","naam":"Catch."}],"officiele_titel":"Threat
-      travel old family produce probably financial.","verkorte_titel":"Along focus.","omschrijving":"Statement
-      they usually into five worker management daughter. Center rather forward. President
-      many city.","registratiedatum":"2024-01-01T12:00:00+00:00","laatst_gewijzigd_datum":"2025-01-26T12:00:00+00:00"}'
+    body: '{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"223a526e-2371-4719-8742-c622ba4f4501","naam":"Davis-Thompson"},"informatie_categorieen":[{"uuid":"46247ab4-a537-4de2-a3da-91330206f5a3","naam":"Face
+      wife."}],"officiele_titel":"Property leader threat would help drive follow.","verkorte_titel":"Edge
+      budget personal.","omschrijving":"Certain interview low head walk too song.
+      Suddenly civil manager.","registratiedatum":"2024-01-01T12:00:00+00:00","laatst_gewijzigd_datum":"2025-01-26T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -34,10 +33,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publisher":{"uuid":"e2c343ff-770c-41e8-87eb-4204dea0bcc9","naam":"Singh-Lewis"},"informatie_categorieen":[{"uuid":"0041a885-a7a5-485a-8440-6e139b77b36e","naam":"Property
-      blue officer."}],"officiele_titel":"Anything outside despite send federal.","verkorte_titel":"Necessary
-      record dream.","omschrijving":"Community apply try summer. Age culture field
-      general improve. Letter think at around.","registratiedatum":"2025-01-15T12:00:00+00:00","laatst_gewijzigd_datum":"2025-01-15T12:00:00+00:00"}'
+    body: '{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publisher":{"uuid":"73f54752-07b9-4b66-9157-5ab269865656","naam":"Malone
+      Ltd"},"informatie_categorieen":[{"uuid":"5d0b0a6a-2c1b-47a4-996f-d8b89dc6d1f6","naam":"National
+      task."}],"officiele_titel":"Across physical avoid simply husband current local.","verkorte_titel":"Hold
+      care explain.","omschrijving":"Or hand million answer rate character my. Choice
+      manager give size magazine safe.","registratiedatum":"2025-01-15T12:00:00+00:00","laatst_gewijzigd_datum":"2025-01-15T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -83,18 +83,17 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"525747fd-7e58-4005-8efa-59bcf4403385","_score":2.1145677E-5,"_source":{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publisher":{"uuid":"e2c343ff-770c-41e8-87eb-4204dea0bcc9","naam":"Singh-Lewis"},"informatie_categorieen":[{"uuid":"0041a885-a7a5-485a-8440-6e139b77b36e","naam":"Property
-        blue officer."}],"officiele_titel":"Anything outside despite send federal.","verkorte_titel":"Necessary
-        record dream.","omschrijving":"Community apply try summer. Age culture field
-        general improve. Letter think at around.","registratiedatum":"2025-01-15T12:00:00+00:00","laatst_gewijzigd_datum":"2025-01-15T12:00:00+00:00"},"sort":[2.1145677E-5,1736942400000]},{"_index":"publication","_id":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","_score":0.0,"_source":{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"e766cf09-fa52-4366-b417-8b968afbf27e","naam":"Hernandez
-        and Sons"},"informatie_categorieen":[{"uuid":"1801ee95-fdc5-4603-9854-da109c1a14e3","naam":"Catch."}],"officiele_titel":"Threat
-        travel old family produce probably financial.","verkorte_titel":"Along focus.","omschrijving":"Statement
-        they usually into five worker management daughter. Center rather forward.
-        President many city.","registratiedatum":"2024-01-01T12:00:00+00:00","laatst_gewijzigd_datum":"2025-01-26T12:00:00+00:00"},"sort":[0.0,1737892800000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["0041a885-a7a5-485a-8440-6e139b77b36e","Property
-        blue officer."],"key_as_string":"0041a885-a7a5-485a-8440-6e139b77b36e|Property
-        blue officer.","doc_count":1},{"key":["1801ee95-fdc5-4603-9854-da109c1a14e3","Catch."],"key_as_string":"1801ee95-fdc5-4603-9854-da109c1a14e3|Catch.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e2c343ff-770c-41e8-87eb-4204dea0bcc9","Singh-Lewis"],"key_as_string":"e2c343ff-770c-41e8-87eb-4204dea0bcc9|Singh-Lewis","doc_count":1},{"key":["e766cf09-fa52-4366-b417-8b968afbf27e","Hernandez
-        and Sons"],"key_as_string":"e766cf09-fa52-4366-b417-8b968afbf27e|Hernandez
-        and Sons","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"publication","doc_count":2}]}}}}'
+      string: '{"took":4,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"525747fd-7e58-4005-8efa-59bcf4403385","_score":2.0047682E-5,"_source":{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publisher":{"uuid":"73f54752-07b9-4b66-9157-5ab269865656","naam":"Malone
+        Ltd"},"informatie_categorieen":[{"uuid":"5d0b0a6a-2c1b-47a4-996f-d8b89dc6d1f6","naam":"National
+        task."}],"officiele_titel":"Across physical avoid simply husband current local.","verkorte_titel":"Hold
+        care explain.","omschrijving":"Or hand million answer rate character my. Choice
+        manager give size magazine safe.","registratiedatum":"2025-01-15T12:00:00+00:00","laatst_gewijzigd_datum":"2025-01-15T12:00:00+00:00"},"sort":[2.0047682E-5,1736942400000]},{"_index":"publication","_id":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","_score":0.0,"_source":{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"223a526e-2371-4719-8742-c622ba4f4501","naam":"Davis-Thompson"},"informatie_categorieen":[{"uuid":"46247ab4-a537-4de2-a3da-91330206f5a3","naam":"Face
+        wife."}],"officiele_titel":"Property leader threat would help drive follow.","verkorte_titel":"Edge
+        budget personal.","omschrijving":"Certain interview low head walk too song.
+        Suddenly civil manager.","registratiedatum":"2024-01-01T12:00:00+00:00","laatst_gewijzigd_datum":"2025-01-26T12:00:00+00:00"},"sort":[0.0,1737892800000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["46247ab4-a537-4de2-a3da-91330206f5a3","Face
+        wife."],"key_as_string":"46247ab4-a537-4de2-a3da-91330206f5a3|Face wife.","doc_count":1},{"key":["5d0b0a6a-2c1b-47a4-996f-d8b89dc6d1f6","National
+        task."],"key_as_string":"5d0b0a6a-2c1b-47a4-996f-d8b89dc6d1f6|National task.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["223a526e-2371-4719-8742-c622ba4f4501","Davis-Thompson"],"key_as_string":"223a526e-2371-4719-8742-c622ba4f4501|Davis-Thompson","doc_count":1},{"key":["73f54752-07b9-4b66-9157-5ab269865656","Malone
+        Ltd"],"key_as_string":"73f54752-07b9-4b66-9157-5ab269865656|Malone Ltd","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"publication","doc_count":2}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_broken_query_string_syntax.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_broken_query_string_syntax.yaml
@@ -17,7 +17,7 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count":0,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}},"Publisher":{"doc_count":0,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"ResultType":{"doc_count":0,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}}'
+      string: '{"took":3,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]},"aggregations":{"InformationCategories":{"doc_count":0,"Categories":{"doc_count":0,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}},"Publisher":{"doc_count":0,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}},"ResultType":{"doc_count":0,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_no_body.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_no_body.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"f7094bfe-2eb2-45ac-874e-7cf9e4af8bd3","naam":"Frank-Salazar"},"informatie_categorieen":[{"uuid":"ae4c7578-5045-4e60-80bb-42df5a5cb70a","naam":"Resource
-      most loss."}],"officiele_titel":"Decision policy four them carry maybe.","verkorte_titel":"Player
-      keep national.","omschrijving":"Back through very either time. Campaign order
-      religious experience sound after clearly. Its when however.","registratiedatum":"2025-03-23T18:22:40.038551","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"11dca97c-5976-461f-8031-65c775d6b80d","naam":"Rivera-Johnson"},"informatie_categorieen":[{"uuid":"b37c8f8d-2bb8-4449-9ec2-c1ccd3ed9a9d","naam":"Officer
+      matter operation."}],"officiele_titel":"Project energy director another contain
+      its.","verkorte_titel":"Mean development.","omschrijving":"Scene number number
+      sense.","registratiedatum":"2025-03-23T14:58:20.660793","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,11 +33,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publicatie":"fef9dbb4-ae42-47ca-877e-b49da5e44c80","informatie_categorieen":[{"uuid":"12c7517f-8ad5-4150-87ec-5a559f5de56f","naam":"Government
-      tax."}],"publisher":{"uuid":"79b91a80-b55f-469d-912a-10a6f6284a44","naam":"Ellis,
-      Watson and Graham"},"identifier":"identifier-26","officiele_titel":"Provide
-      heart none ability why bag.","verkorte_titel":"But decide control.","omschrijving":"Reflect
-      organization whatever create. Night evidence hear now actually.","creatiedatum":"2025-03-14","registratiedatum":"2025-03-21T11:01:10.798068","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"525747fd-7e58-4005-8efa-59bcf4403385","publicatie":"cd436c08-0510-4ab0-b08a-681912895f08","informatie_categorieen":[{"uuid":"da69ec43-3396-4bd4-a00a-286d1832561a","naam":"Project
+      spring."}],"publisher":{"uuid":"624bca69-8267-41d0-8e9d-38bfc1fc47c1","naam":"Santana-Tucker"},"identifier":"identifier-30","officiele_titel":"Often
+      because six direction.","verkorte_titel":"Common address.","omschrijving":"Machine
+      enjoy significant north material. Analysis fight evening candidate movie. Situation
+      system southern wonder.","creatiedatum":"2025-03-21","registratiedatum":"2025-03-24T02:55:24.051859","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -83,20 +83,17 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","_score":2.0,"_source":{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"f7094bfe-2eb2-45ac-874e-7cf9e4af8bd3","naam":"Frank-Salazar"},"informatie_categorieen":[{"uuid":"ae4c7578-5045-4e60-80bb-42df5a5cb70a","naam":"Resource
-        most loss."}],"officiele_titel":"Decision policy four them carry maybe.","verkorte_titel":"Player
-        keep national.","omschrijving":"Back through very either time. Campaign order
-        religious experience sound after clearly. Its when however.","registratiedatum":"2025-03-23T18:22:40.038551","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[2.0,1767614400000]},{"_index":"document","_id":"525747fd-7e58-4005-8efa-59bcf4403385","_score":1.0,"_source":{"omschrijving":"Reflect
-        organization whatever create. Night evidence hear now actually.","identifier":"identifier-26","publicatie":"fef9dbb4-ae42-47ca-877e-b49da5e44c80","officiele_titel":"Provide
-        heart none ability why bag.","informatie_categorieen":[{"naam":"Government
-        tax.","uuid":"12c7517f-8ad5-4150-87ec-5a559f5de56f"}],"publisher":{"naam":"Ellis,
-        Watson and Graham","uuid":"79b91a80-b55f-469d-912a-10a6f6284a44"},"creatiedatum":"2025-03-14","registratiedatum":"2025-03-21T11:01:10.798068","uuid":"525747fd-7e58-4005-8efa-59bcf4403385","verkorte_titel":"But
-        decide control.","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["12c7517f-8ad5-4150-87ec-5a559f5de56f","Government
-        tax."],"key_as_string":"12c7517f-8ad5-4150-87ec-5a559f5de56f|Government tax.","doc_count":1},{"key":["ae4c7578-5045-4e60-80bb-42df5a5cb70a","Resource
-        most loss."],"key_as_string":"ae4c7578-5045-4e60-80bb-42df5a5cb70a|Resource
-        most loss.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["79b91a80-b55f-469d-912a-10a6f6284a44","Ellis,
-        Watson and Graham"],"key_as_string":"79b91a80-b55f-469d-912a-10a6f6284a44|Ellis,
-        Watson and Graham","doc_count":1},{"key":["f7094bfe-2eb2-45ac-874e-7cf9e4af8bd3","Frank-Salazar"],"key_as_string":"f7094bfe-2eb2-45ac-874e-7cf9e4af8bd3|Frank-Salazar","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
+      string: '{"took":4,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","_score":2.0,"_source":{"uuid":"6dae9be7-4f93-4aad-b56a-10b683b16dcc","publisher":{"uuid":"11dca97c-5976-461f-8031-65c775d6b80d","naam":"Rivera-Johnson"},"informatie_categorieen":[{"uuid":"b37c8f8d-2bb8-4449-9ec2-c1ccd3ed9a9d","naam":"Officer
+        matter operation."}],"officiele_titel":"Project energy director another contain
+        its.","verkorte_titel":"Mean development.","omschrijving":"Scene number number
+        sense.","registratiedatum":"2025-03-23T14:58:20.660793","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[2.0,1767614400000]},{"_index":"document","_id":"525747fd-7e58-4005-8efa-59bcf4403385","_score":1.0,"_source":{"omschrijving":"Machine
+        enjoy significant north material. Analysis fight evening candidate movie.
+        Situation system southern wonder.","identifier":"identifier-30","publicatie":"cd436c08-0510-4ab0-b08a-681912895f08","officiele_titel":"Often
+        because six direction.","informatie_categorieen":[{"naam":"Project spring.","uuid":"da69ec43-3396-4bd4-a00a-286d1832561a"}],"publisher":{"naam":"Santana-Tucker","uuid":"624bca69-8267-41d0-8e9d-38bfc1fc47c1"},"creatiedatum":"2025-03-21","registratiedatum":"2025-03-24T02:55:24.051859","uuid":"525747fd-7e58-4005-8efa-59bcf4403385","verkorte_titel":"Common
+        address.","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["b37c8f8d-2bb8-4449-9ec2-c1ccd3ed9a9d","Officer
+        matter operation."],"key_as_string":"b37c8f8d-2bb8-4449-9ec2-c1ccd3ed9a9d|Officer
+        matter operation.","doc_count":1},{"key":["da69ec43-3396-4bd4-a00a-286d1832561a","Project
+        spring."],"key_as_string":"da69ec43-3396-4bd4-a00a-286d1832561a|Project spring.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["11dca97c-5976-461f-8031-65c775d6b80d","Rivera-Johnson"],"key_as_string":"11dca97c-5976-461f-8031-65c775d6b80d|Rivera-Johnson","doc_count":1},{"key":["624bca69-8267-41d0-8e9d-38bfc1fc47c1","Santana-Tucker"],"key_as_string":"624bca69-8267-41d0-8e9d-38bfc1fc47c1|Santana-Tucker","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_pagination_next_and_page_size.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_pagination_next_and_page_size.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"1aa78d62-0cc7-4273-86b4-8c6bf4f28a98","publisher":{"uuid":"74fa07da-53bc-4791-bf3f-3ebe36afaa38","naam":"Brandt,
-      Soto and Sandoval"},"informatie_categorieen":[{"uuid":"92f45697-00c3-40ab-a62b-f5c0dda2b990","naam":"Safe
-      kind."}],"officiele_titel":"While as word.","verkorte_titel":"Sell during camera.","omschrijving":"Soldier
-      face special power if seat section message. Imagine religious market watch.","registratiedatum":"2025-03-20T22:23:00.434464","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"1aa78d62-0cc7-4273-86b4-8c6bf4f28a98","publisher":{"uuid":"372643f2-625d-48a2-9f58-08e351989c74","naam":"Duke-Williams"},"informatie_categorieen":[{"uuid":"bbb2b379-7085-45cb-afb0-1b00c072764b","naam":"Argue
+      read."}],"officiele_titel":"Fast much keep city man too.","verkorte_titel":"Yourself
+      receive because.","omschrijving":"East very week well opportunity. Compare tend
+      take theory challenge old director.","registratiedatum":"2025-03-24T13:42:43.906708","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,11 +33,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"85a095ea-e1fa-438c-9e05-1862874f57a0","publicatie":"f0dd21b4-44a8-4f5c-b3a8-b19ca543034c","informatie_categorieen":[{"uuid":"d214e5f9-d040-4a92-aa23-ff40737dea64","naam":"Best
-      sing."}],"publisher":{"uuid":"2b8c57cf-6e40-4159-ad73-7f22cb18852a","naam":"Saunders-Melton"},"identifier":"identifier-27","officiele_titel":"Half
-      full man should many action probably.","verkorte_titel":"Bed control.","omschrijving":"Significant
-      type only former. Fill energy TV attack create total federal. Middle main cause
-      toward drug.","creatiedatum":"2025-03-02","registratiedatum":"2025-03-22T05:51:04.385214","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"85a095ea-e1fa-438c-9e05-1862874f57a0","publicatie":"335daa0d-4d66-475b-9b60-778c74675dd7","informatie_categorieen":[{"uuid":"7e7117a9-c17e-4717-ba0a-97a654a0e736","naam":"Learn
+      decide deep."}],"publisher":{"uuid":"b110f4e6-6875-44f8-9586-08de53991b0a","naam":"Abbott-Boone"},"identifier":"identifier-31","officiele_titel":"Plan
+      shake sign month former second work.","verkorte_titel":"Type your by image.","omschrijving":"Future
+      military college subject. Whose analysis nothing total. Fight land seven policy
+      dog surface spend.","creatiedatum":"2025-03-05","registratiedatum":"2025-03-21T02:08:46.158956","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -83,15 +83,13 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"1aa78d62-0cc7-4273-86b4-8c6bf4f28a98","_score":2.0,"_source":{"uuid":"1aa78d62-0cc7-4273-86b4-8c6bf4f28a98","publisher":{"uuid":"74fa07da-53bc-4791-bf3f-3ebe36afaa38","naam":"Brandt,
-        Soto and Sandoval"},"informatie_categorieen":[{"uuid":"92f45697-00c3-40ab-a62b-f5c0dda2b990","naam":"Safe
-        kind."}],"officiele_titel":"While as word.","verkorte_titel":"Sell during
-        camera.","omschrijving":"Soldier face special power if seat section message.
-        Imagine religious market watch.","registratiedatum":"2025-03-20T22:23:00.434464","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[2.0,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["92f45697-00c3-40ab-a62b-f5c0dda2b990","Safe
-        kind."],"key_as_string":"92f45697-00c3-40ab-a62b-f5c0dda2b990|Safe kind.","doc_count":1},{"key":["d214e5f9-d040-4a92-aa23-ff40737dea64","Best
-        sing."],"key_as_string":"d214e5f9-d040-4a92-aa23-ff40737dea64|Best sing.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2b8c57cf-6e40-4159-ad73-7f22cb18852a","Saunders-Melton"],"key_as_string":"2b8c57cf-6e40-4159-ad73-7f22cb18852a|Saunders-Melton","doc_count":1},{"key":["74fa07da-53bc-4791-bf3f-3ebe36afaa38","Brandt,
-        Soto and Sandoval"],"key_as_string":"74fa07da-53bc-4791-bf3f-3ebe36afaa38|Brandt,
-        Soto and Sandoval","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
+      string: '{"took":4,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"publication","_id":"1aa78d62-0cc7-4273-86b4-8c6bf4f28a98","_score":2.0,"_source":{"uuid":"1aa78d62-0cc7-4273-86b4-8c6bf4f28a98","publisher":{"uuid":"372643f2-625d-48a2-9f58-08e351989c74","naam":"Duke-Williams"},"informatie_categorieen":[{"uuid":"bbb2b379-7085-45cb-afb0-1b00c072764b","naam":"Argue
+        read."}],"officiele_titel":"Fast much keep city man too.","verkorte_titel":"Yourself
+        receive because.","omschrijving":"East very week well opportunity. Compare
+        tend take theory challenge old director.","registratiedatum":"2025-03-24T13:42:43.906708","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[2.0,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["7e7117a9-c17e-4717-ba0a-97a654a0e736","Learn
+        decide deep."],"key_as_string":"7e7117a9-c17e-4717-ba0a-97a654a0e736|Learn
+        decide deep.","doc_count":1},{"key":["bbb2b379-7085-45cb-afb0-1b00c072764b","Argue
+        read."],"key_as_string":"bbb2b379-7085-45cb-afb0-1b00c072764b|Argue read.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["372643f2-625d-48a2-9f58-08e351989c74","Duke-Williams"],"key_as_string":"372643f2-625d-48a2-9f58-08e351989c74|Duke-Williams","doc_count":1},{"key":["b110f4e6-6875-44f8-9586-08de53991b0a","Abbott-Boone"],"key_as_string":"b110f4e6-6875-44f8-9586-08de53991b0a|Abbott-Boone","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_pagination_previous.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_pagination_previous.yaml
@@ -1,10 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"80485d67-0b97-4ed5-8483-f2d03d012e19","publisher":{"uuid":"29817a28-4920-486d-baca-b279364303c4","naam":"Phillips
-      Group"},"informatie_categorieen":[{"uuid":"e3b0f21a-dd0a-48d7-b679-299c772ee894","naam":"Other
-      soon material weight."}],"officiele_titel":"Suddenly method their economy than
-      cover.","verkorte_titel":"They fine.","omschrijving":"Push I director voice
-      position right. Certainly art sort environmental trip.","registratiedatum":"2025-03-21T13:51:15.413386","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"80485d67-0b97-4ed5-8483-f2d03d012e19","publisher":{"uuid":"008cc792-a7ad-46b6-86de-b972eb599670","naam":"Johnson
+      Group"},"informatie_categorieen":[{"uuid":"23219aae-a033-4e94-aec1-3a79197938f1","naam":"Past
+      group experience."}],"officiele_titel":"Like grow note shake.","verkorte_titel":"Kid
+      safe music.","omschrijving":"Central month technology hold hand. Door goal picture
+      tend mean view. Develop approach establish citizen soon life identify ready.","registratiedatum":"2025-03-20T23:51:31.154290","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -34,11 +34,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"48981334-b480-4e7d-8c8d-925bbc67a969","publicatie":"0aefc759-10d0-42d9-8a5d-95657a779032","informatie_categorieen":[{"uuid":"73515d83-ddd2-43de-863e-1c171209c1fe","naam":"Light
-      camera."}],"publisher":{"uuid":"878f209b-d021-4f06-a1c1-e1de527c6221","naam":"Miller-Wright"},"identifier":"identifier-28","officiele_titel":"Claim
-      teach knowledge book listen.","verkorte_titel":"Environment language.","omschrijving":"View
-      start scene government together food reach word. Attorney beyond culture lay
-      analysis name consumer.","creatiedatum":"2025-02-26","registratiedatum":"2025-03-22T13:30:12.251387","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"48981334-b480-4e7d-8c8d-925bbc67a969","publicatie":"8f803a70-14e0-4e3a-85b3-fac45d7617ef","informatie_categorieen":[{"uuid":"38e81da4-1f1c-4a70-a2e4-c0d3e8e12421","naam":"Top
+      send."}],"publisher":{"uuid":"7e23429d-6f3b-4f58-9f05-2f064c34bfa0","naam":"Nelson-Ruiz"},"identifier":"identifier-32","officiele_titel":"Man
+      ability miss staff nor white throughout.","verkorte_titel":"Word.","omschrijving":"Particularly
+      recently tell floor. Determine instead card term carry within yeah. Ahead how
+      task.","creatiedatum":"2025-03-04","registratiedatum":"2025-03-22T19:45:54.626147","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -84,15 +84,15 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"48981334-b480-4e7d-8c8d-925bbc67a969","_score":1.0,"_source":{"omschrijving":"View
-        start scene government together food reach word. Attorney beyond culture lay
-        analysis name consumer.","identifier":"identifier-28","publicatie":"0aefc759-10d0-42d9-8a5d-95657a779032","officiele_titel":"Claim
-        teach knowledge book listen.","informatie_categorieen":[{"naam":"Light camera.","uuid":"73515d83-ddd2-43de-863e-1c171209c1fe"}],"publisher":{"naam":"Miller-Wright","uuid":"878f209b-d021-4f06-a1c1-e1de527c6221"},"creatiedatum":"2025-02-26","registratiedatum":"2025-03-22T13:30:12.251387","uuid":"48981334-b480-4e7d-8c8d-925bbc67a969","verkorte_titel":"Environment
-        language.","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["73515d83-ddd2-43de-863e-1c171209c1fe","Light
-        camera."],"key_as_string":"73515d83-ddd2-43de-863e-1c171209c1fe|Light camera.","doc_count":1},{"key":["e3b0f21a-dd0a-48d7-b679-299c772ee894","Other
-        soon material weight."],"key_as_string":"e3b0f21a-dd0a-48d7-b679-299c772ee894|Other
-        soon material weight.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["29817a28-4920-486d-baca-b279364303c4","Phillips
-        Group"],"key_as_string":"29817a28-4920-486d-baca-b279364303c4|Phillips Group","doc_count":1},{"key":["878f209b-d021-4f06-a1c1-e1de527c6221","Miller-Wright"],"key_as_string":"878f209b-d021-4f06-a1c1-e1de527c6221|Miller-Wright","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
+      string: '{"took":3,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"48981334-b480-4e7d-8c8d-925bbc67a969","_score":1.0,"_source":{"omschrijving":"Particularly
+        recently tell floor. Determine instead card term carry within yeah. Ahead
+        how task.","identifier":"identifier-32","publicatie":"8f803a70-14e0-4e3a-85b3-fac45d7617ef","officiele_titel":"Man
+        ability miss staff nor white throughout.","informatie_categorieen":[{"naam":"Top
+        send.","uuid":"38e81da4-1f1c-4a70-a2e4-c0d3e8e12421"}],"publisher":{"naam":"Nelson-Ruiz","uuid":"7e23429d-6f3b-4f58-9f05-2f064c34bfa0"},"creatiedatum":"2025-03-04","registratiedatum":"2025-03-22T19:45:54.626147","uuid":"48981334-b480-4e7d-8c8d-925bbc67a969","verkorte_titel":"Word.","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1.0,1767614400000]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["23219aae-a033-4e94-aec1-3a79197938f1","Past
+        group experience."],"key_as_string":"23219aae-a033-4e94-aec1-3a79197938f1|Past
+        group experience.","doc_count":1},{"key":["38e81da4-1f1c-4a70-a2e4-c0d3e8e12421","Top
+        send."],"key_as_string":"38e81da4-1f1c-4a70-a2e4-c0d3e8e12421|Top send.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["008cc792-a7ad-46b6-86de-b972eb599670","Johnson
+        Group"],"key_as_string":"008cc792-a7ad-46b6-86de-b972eb599670|Johnson Group","doc_count":1},{"key":["7e23429d-6f3b-4f58-9f05-2f064c34bfa0","Nelson-Ruiz"],"key_as_string":"7e23429d-6f3b-4f58-9f05-2f064c34bfa0|Nelson-Ruiz","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query.yaml
@@ -1,11 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"50e32c44-515e-4c48-ae57-3aae82fc9cf1","publisher":{"uuid":"e583d01f-fee3-43a1-9db1-73b6a6a90e32","naam":"Day
-      Group"},"informatie_categorieen":[{"uuid":"d38a74cb-28e7-42cf-b9ac-a956a9e367c0","naam":"Sit
-      window design term."}],"officiele_titel":"Trade high future boy.","verkorte_titel":"Country
-      specific.","omschrijving":"Full job clear expert chair company. See ability
-      job economy think window. See staff itself stock true. Meet single several collection
-      baby glass.","registratiedatum":"2025-03-20T12:44:21.319667","laatst_gewijzigd_datum":"2025-03-18T14:49:24.233548"}'
+    body: '{"uuid":"50e32c44-515e-4c48-ae57-3aae82fc9cf1","publisher":{"uuid":"55f4a110-c0de-4866-a051-b058ecd04565","naam":"Gregory-Nguyen"},"informatie_categorieen":[{"uuid":"578f24e9-ef80-4fd5-b8cc-7aae1cc6bfd6","naam":"Discussion
+      reason arm second."}],"officiele_titel":"Simple black yes as.","verkorte_titel":"Court
+      message.","omschrijving":"Sit include common join study. Determine much guy
+      serious grow.","registratiedatum":"2025-03-22T23:11:48.633844","laatst_gewijzigd_datum":"2025-02-22T19:34:38.996489"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -35,11 +33,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","publicatie":"7b1aa1a3-054e-49d6-9417-91ec7c30a69a","informatie_categorieen":[{"uuid":"44588a16-8b74-4725-b353-1543a9d9bb0d","naam":"Tend
-      modern mission."}],"publisher":{"uuid":"e23659cc-a1ba-4931-ac28-24d457988dcd","naam":"Cherry-Smith"},"identifier":"document1","officiele_titel":"Else
-      example really a candidate onto service.","verkorte_titel":"Research cell condition.","omschrijving":"Once
-      international heart sure on relate. Near personal bad person camera imagine.
-      Share southern security final read physical few choose.","creatiedatum":"2025-03-01","registratiedatum":"2025-03-21T10:48:43.386576","laatst_gewijzigd_datum":"2025-03-19T04:33:33.969726"}'
+    body: '{"uuid":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","publicatie":"c971989e-a432-42cc-a823-eb9cec30b450","informatie_categorieen":[{"uuid":"af52f811-22ff-4029-8ebd-fbca7b208bea","naam":"During
+      finally foreign."}],"publisher":{"uuid":"47da5fc8-e181-46a2-b15c-a3229b580204","naam":"Rivera,
+      Barton and Boone"},"identifier":"document1","officiele_titel":"Break everything
+      it power new court prepare would.","verkorte_titel":"Air local process.","omschrijving":"Action
+      example camera responsibility heart. After dog building prepare high.","creatiedatum":"2025-03-13","registratiedatum":"2025-03-21T06:54:39.535073","laatst_gewijzigd_datum":"2025-03-10T19:37:39.484065"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -85,14 +83,16 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","_score":5.08308,"_source":{"omschrijving":"Once
-        international heart sure on relate. Near personal bad person camera imagine.
-        Share southern security final read physical few choose.","identifier":"document1","publicatie":"7b1aa1a3-054e-49d6-9417-91ec7c30a69a","officiele_titel":"Else
-        example really a candidate onto service.","informatie_categorieen":[{"naam":"Tend
-        modern mission.","uuid":"44588a16-8b74-4725-b353-1543a9d9bb0d"}],"publisher":{"naam":"Cherry-Smith","uuid":"e23659cc-a1ba-4931-ac28-24d457988dcd"},"creatiedatum":"2025-03-01","registratiedatum":"2025-03-21T10:48:43.386576","uuid":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","verkorte_titel":"Research
-        cell condition.","laatst_gewijzigd_datum":"2025-03-19T04:33:33.969726"},"sort":[5.08308,1742358813969]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["44588a16-8b74-4725-b353-1543a9d9bb0d","Tend
-        modern mission."],"key_as_string":"44588a16-8b74-4725-b353-1543a9d9bb0d|Tend
-        modern mission.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["e23659cc-a1ba-4931-ac28-24d457988dcd","Cherry-Smith"],"key_as_string":"e23659cc-a1ba-4931-ac28-24d457988dcd|Cherry-Smith","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
+      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","_score":5.08308,"_source":{"omschrijving":"Action
+        example camera responsibility heart. After dog building prepare high.","identifier":"document1","publicatie":"c971989e-a432-42cc-a823-eb9cec30b450","officiele_titel":"Break
+        everything it power new court prepare would.","informatie_categorieen":[{"naam":"During
+        finally foreign.","uuid":"af52f811-22ff-4029-8ebd-fbca7b208bea"}],"publisher":{"naam":"Rivera,
+        Barton and Boone","uuid":"47da5fc8-e181-46a2-b15c-a3229b580204"},"creatiedatum":"2025-03-13","registratiedatum":"2025-03-21T06:54:39.535073","uuid":"6dd95a10-cc97-4f19-b7e4-2c85358acb98","verkorte_titel":"Air
+        local process.","laatst_gewijzigd_datum":"2025-03-10T19:37:39.484065"},"sort":[5.08308,1741635459484]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["af52f811-22ff-4029-8ebd-fbca7b208bea","During
+        finally foreign."],"key_as_string":"af52f811-22ff-4029-8ebd-fbca7b208bea|During
+        finally foreign.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["47da5fc8-e181-46a2-b15c-a3229b580204","Rivera,
+        Barton and Boone"],"key_as_string":"47da5fc8-e181-46a2-b15c-a3229b580204|Rivera,
+        Barton and Boone","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query_boolean_operators.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query_boolean_operators.yaml
@@ -1,8 +1,8 @@
 interactions:
 - request:
-    body: '{"uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","publicatie":"8e37b755-c3ca-4a35-848b-9ad5f83a8dd2","informatie_categorieen":[{"uuid":"1a120dfb-b1df-46ff-8b69-df7fe000eb26","naam":"Course
-      fast."}],"publisher":{"uuid":"53e63aeb-93f0-40f8-8cb2-9d5e9c118add","naam":"Rodriguez
-      Inc"},"identifier":"Document one","officiele_titel":"","verkorte_titel":"","omschrijving":"snowflake1","creatiedatum":"2025-02-25","registratiedatum":"2025-03-22T12:38:26.076259","laatst_gewijzigd_datum":"2025-02-26T06:52:37.935310"}'
+    body: '{"uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","publicatie":"554acef8-2a50-451b-853d-4bb3730fbc11","informatie_categorieen":[{"uuid":"3ec31eb4-ead5-4e1e-8efd-75cc7f330659","naam":"Finish
+      community leave."}],"publisher":{"uuid":"d139e8f5-b8b6-4caf-8735-a13469f340fb","naam":"Rios-Williams"},"identifier":"Document
+      one","officiele_titel":"","verkorte_titel":"","omschrijving":"snowflake1","creatiedatum":"2025-02-27","registratiedatum":"2025-03-20T09:51:57.479691","laatst_gewijzigd_datum":"2025-03-14T04:30:35.018976"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -32,9 +32,9 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","publicatie":"dfafa801-5a2f-4455-b42e-30a1d7773bd9","informatie_categorieen":[{"uuid":"c826fec8-5186-463f-8c88-ce7de6a1a832","naam":"Fire
-      owner may."}],"publisher":{"uuid":"ebffcdca-d383-41e2-b814-7e53c3a1c711","naam":"Carr-Campbell"},"identifier":"Document
-      two","officiele_titel":"","verkorte_titel":"","omschrijving":"snowflake2","creatiedatum":"2025-03-07","registratiedatum":"2025-03-24T12:17:41.212217","laatst_gewijzigd_datum":"2025-03-02T02:24:05.649341"}'
+    body: '{"uuid":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","publicatie":"fc276b22-afab-4e6a-afc4-3d399604039e","informatie_categorieen":[{"uuid":"80c109ca-bb46-43bf-adf0-eb77dd74c66b","naam":"Investment
+      garden rather tonight."}],"publisher":{"uuid":"cb43dcb3-bc57-4c58-bb06-6e7e795418b3","naam":"Lewis,
+      Gentry and Chase"},"identifier":"Document two","officiele_titel":"","verkorte_titel":"","omschrijving":"snowflake2","creatiedatum":"2025-03-21","registratiedatum":"2025-03-22T03:08:27.241097","laatst_gewijzigd_datum":"2025-03-17T06:24:07.982346"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -81,12 +81,11 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"d6eacab4-cb9f-42f7-abdf-719b358da923","_score":8.251713,"_source":{"omschrijving":"snowflake1","identifier":"Document
-        one","publicatie":"8e37b755-c3ca-4a35-848b-9ad5f83a8dd2","officiele_titel":"","informatie_categorieen":[{"naam":"Course
-        fast.","uuid":"1a120dfb-b1df-46ff-8b69-df7fe000eb26"}],"publisher":{"naam":"Rodriguez
-        Inc","uuid":"53e63aeb-93f0-40f8-8cb2-9d5e9c118add"},"creatiedatum":"2025-02-25","registratiedatum":"2025-03-22T12:38:26.076259","uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","verkorte_titel":"","laatst_gewijzigd_datum":"2025-02-26T06:52:37.935310"},"sort":[8.251713,1740552757935]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["1a120dfb-b1df-46ff-8b69-df7fe000eb26","Course
-        fast."],"key_as_string":"1a120dfb-b1df-46ff-8b69-df7fe000eb26|Course fast.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["53e63aeb-93f0-40f8-8cb2-9d5e9c118add","Rodriguez
-        Inc"],"key_as_string":"53e63aeb-93f0-40f8-8cb2-9d5e9c118add|Rodriguez Inc","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
+      string: '{"took":4,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"d6eacab4-cb9f-42f7-abdf-719b358da923","_score":8.251713,"_source":{"omschrijving":"snowflake1","identifier":"Document
+        one","publicatie":"554acef8-2a50-451b-853d-4bb3730fbc11","officiele_titel":"","informatie_categorieen":[{"naam":"Finish
+        community leave.","uuid":"3ec31eb4-ead5-4e1e-8efd-75cc7f330659"}],"publisher":{"naam":"Rios-Williams","uuid":"d139e8f5-b8b6-4caf-8735-a13469f340fb"},"creatiedatum":"2025-02-27","registratiedatum":"2025-03-20T09:51:57.479691","uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","verkorte_titel":"","laatst_gewijzigd_datum":"2025-03-14T04:30:35.018976"},"sort":[8.251713,1741926635018]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3ec31eb4-ead5-4e1e-8efd-75cc7f330659","Finish
+        community leave."],"key_as_string":"3ec31eb4-ead5-4e1e-8efd-75cc7f330659|Finish
+        community leave.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["d139e8f5-b8b6-4caf-8735-a13469f340fb","Rios-Williams"],"key_as_string":"d139e8f5-b8b6-4caf-8735-a13469f340fb|Rios-Williams","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -115,12 +114,11 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"d6eacab4-cb9f-42f7-abdf-719b358da923","_score":8.251713,"_source":{"omschrijving":"snowflake1","identifier":"Document
-        one","publicatie":"8e37b755-c3ca-4a35-848b-9ad5f83a8dd2","officiele_titel":"","informatie_categorieen":[{"naam":"Course
-        fast.","uuid":"1a120dfb-b1df-46ff-8b69-df7fe000eb26"}],"publisher":{"naam":"Rodriguez
-        Inc","uuid":"53e63aeb-93f0-40f8-8cb2-9d5e9c118add"},"creatiedatum":"2025-02-25","registratiedatum":"2025-03-22T12:38:26.076259","uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","verkorte_titel":"","laatst_gewijzigd_datum":"2025-02-26T06:52:37.935310"},"sort":[8.251713,1740552757935]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["1a120dfb-b1df-46ff-8b69-df7fe000eb26","Course
-        fast."],"key_as_string":"1a120dfb-b1df-46ff-8b69-df7fe000eb26|Course fast.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["53e63aeb-93f0-40f8-8cb2-9d5e9c118add","Rodriguez
-        Inc"],"key_as_string":"53e63aeb-93f0-40f8-8cb2-9d5e9c118add|Rodriguez Inc","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
+      string: '{"took":4,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"d6eacab4-cb9f-42f7-abdf-719b358da923","_score":8.251713,"_source":{"omschrijving":"snowflake1","identifier":"Document
+        one","publicatie":"554acef8-2a50-451b-853d-4bb3730fbc11","officiele_titel":"","informatie_categorieen":[{"naam":"Finish
+        community leave.","uuid":"3ec31eb4-ead5-4e1e-8efd-75cc7f330659"}],"publisher":{"naam":"Rios-Williams","uuid":"d139e8f5-b8b6-4caf-8735-a13469f340fb"},"creatiedatum":"2025-02-27","registratiedatum":"2025-03-20T09:51:57.479691","uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","verkorte_titel":"","laatst_gewijzigd_datum":"2025-03-14T04:30:35.018976"},"sort":[8.251713,1741926635018]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3ec31eb4-ead5-4e1e-8efd-75cc7f330659","Finish
+        community leave."],"key_as_string":"3ec31eb4-ead5-4e1e-8efd-75cc7f330659|Finish
+        community leave.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["d139e8f5-b8b6-4caf-8735-a13469f340fb","Rios-Williams"],"key_as_string":"d139e8f5-b8b6-4caf-8735-a13469f340fb|Rios-Williams","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -149,16 +147,18 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","_score":4.868718,"_source":{"omschrijving":"snowflake2","identifier":"Document
-        two","publicatie":"dfafa801-5a2f-4455-b42e-30a1d7773bd9","officiele_titel":"","informatie_categorieen":[{"naam":"Fire
-        owner may.","uuid":"c826fec8-5186-463f-8c88-ce7de6a1a832"}],"publisher":{"naam":"Carr-Campbell","uuid":"ebffcdca-d383-41e2-b814-7e53c3a1c711"},"creatiedatum":"2025-03-07","registratiedatum":"2025-03-24T12:17:41.212217","uuid":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","verkorte_titel":"","laatst_gewijzigd_datum":"2025-03-02T02:24:05.649341"},"sort":[4.868718,1740882245649]},{"_index":"document","_id":"d6eacab4-cb9f-42f7-abdf-719b358da923","_score":4.868718,"_source":{"omschrijving":"snowflake1","identifier":"Document
-        one","publicatie":"8e37b755-c3ca-4a35-848b-9ad5f83a8dd2","officiele_titel":"","informatie_categorieen":[{"naam":"Course
-        fast.","uuid":"1a120dfb-b1df-46ff-8b69-df7fe000eb26"}],"publisher":{"naam":"Rodriguez
-        Inc","uuid":"53e63aeb-93f0-40f8-8cb2-9d5e9c118add"},"creatiedatum":"2025-02-25","registratiedatum":"2025-03-22T12:38:26.076259","uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","verkorte_titel":"","laatst_gewijzigd_datum":"2025-02-26T06:52:37.935310"},"sort":[4.868718,1740552757935]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["1a120dfb-b1df-46ff-8b69-df7fe000eb26","Course
-        fast."],"key_as_string":"1a120dfb-b1df-46ff-8b69-df7fe000eb26|Course fast.","doc_count":1},{"key":["c826fec8-5186-463f-8c88-ce7de6a1a832","Fire
-        owner may."],"key_as_string":"c826fec8-5186-463f-8c88-ce7de6a1a832|Fire owner
-        may.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["53e63aeb-93f0-40f8-8cb2-9d5e9c118add","Rodriguez
-        Inc"],"key_as_string":"53e63aeb-93f0-40f8-8cb2-9d5e9c118add|Rodriguez Inc","doc_count":1},{"key":["ebffcdca-d383-41e2-b814-7e53c3a1c711","Carr-Campbell"],"key_as_string":"ebffcdca-d383-41e2-b814-7e53c3a1c711|Carr-Campbell","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}}'
+      string: '{"took":6,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","_score":4.868718,"_source":{"omschrijving":"snowflake2","identifier":"Document
+        two","publicatie":"fc276b22-afab-4e6a-afc4-3d399604039e","officiele_titel":"","informatie_categorieen":[{"naam":"Investment
+        garden rather tonight.","uuid":"80c109ca-bb46-43bf-adf0-eb77dd74c66b"}],"publisher":{"naam":"Lewis,
+        Gentry and Chase","uuid":"cb43dcb3-bc57-4c58-bb06-6e7e795418b3"},"creatiedatum":"2025-03-21","registratiedatum":"2025-03-22T03:08:27.241097","uuid":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","verkorte_titel":"","laatst_gewijzigd_datum":"2025-03-17T06:24:07.982346"},"sort":[4.868718,1742192647982]},{"_index":"document","_id":"d6eacab4-cb9f-42f7-abdf-719b358da923","_score":4.868718,"_source":{"omschrijving":"snowflake1","identifier":"Document
+        one","publicatie":"554acef8-2a50-451b-853d-4bb3730fbc11","officiele_titel":"","informatie_categorieen":[{"naam":"Finish
+        community leave.","uuid":"3ec31eb4-ead5-4e1e-8efd-75cc7f330659"}],"publisher":{"naam":"Rios-Williams","uuid":"d139e8f5-b8b6-4caf-8735-a13469f340fb"},"creatiedatum":"2025-02-27","registratiedatum":"2025-03-20T09:51:57.479691","uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","verkorte_titel":"","laatst_gewijzigd_datum":"2025-03-14T04:30:35.018976"},"sort":[4.868718,1741926635018]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3ec31eb4-ead5-4e1e-8efd-75cc7f330659","Finish
+        community leave."],"key_as_string":"3ec31eb4-ead5-4e1e-8efd-75cc7f330659|Finish
+        community leave.","doc_count":1},{"key":["80c109ca-bb46-43bf-adf0-eb77dd74c66b","Investment
+        garden rather tonight."],"key_as_string":"80c109ca-bb46-43bf-adf0-eb77dd74c66b|Investment
+        garden rather tonight.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["cb43dcb3-bc57-4c58-bb06-6e7e795418b3","Lewis,
+        Gentry and Chase"],"key_as_string":"cb43dcb3-bc57-4c58-bb06-6e7e795418b3|Lewis,
+        Gentry and Chase","doc_count":1},{"key":["d139e8f5-b8b6-4caf-8735-a13469f340fb","Rios-Williams"],"key_as_string":"d139e8f5-b8b6-4caf-8735-a13469f340fb|Rios-Williams","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -187,16 +187,18 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":11,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","_score":4.868718,"_source":{"omschrijving":"snowflake2","identifier":"Document
-        two","publicatie":"dfafa801-5a2f-4455-b42e-30a1d7773bd9","officiele_titel":"","informatie_categorieen":[{"naam":"Fire
-        owner may.","uuid":"c826fec8-5186-463f-8c88-ce7de6a1a832"}],"publisher":{"naam":"Carr-Campbell","uuid":"ebffcdca-d383-41e2-b814-7e53c3a1c711"},"creatiedatum":"2025-03-07","registratiedatum":"2025-03-24T12:17:41.212217","uuid":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","verkorte_titel":"","laatst_gewijzigd_datum":"2025-03-02T02:24:05.649341"},"sort":[4.868718,1740882245649]},{"_index":"document","_id":"d6eacab4-cb9f-42f7-abdf-719b358da923","_score":4.868718,"_source":{"omschrijving":"snowflake1","identifier":"Document
-        one","publicatie":"8e37b755-c3ca-4a35-848b-9ad5f83a8dd2","officiele_titel":"","informatie_categorieen":[{"naam":"Course
-        fast.","uuid":"1a120dfb-b1df-46ff-8b69-df7fe000eb26"}],"publisher":{"naam":"Rodriguez
-        Inc","uuid":"53e63aeb-93f0-40f8-8cb2-9d5e9c118add"},"creatiedatum":"2025-02-25","registratiedatum":"2025-03-22T12:38:26.076259","uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","verkorte_titel":"","laatst_gewijzigd_datum":"2025-02-26T06:52:37.935310"},"sort":[4.868718,1740552757935]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["1a120dfb-b1df-46ff-8b69-df7fe000eb26","Course
-        fast."],"key_as_string":"1a120dfb-b1df-46ff-8b69-df7fe000eb26|Course fast.","doc_count":1},{"key":["c826fec8-5186-463f-8c88-ce7de6a1a832","Fire
-        owner may."],"key_as_string":"c826fec8-5186-463f-8c88-ce7de6a1a832|Fire owner
-        may.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["53e63aeb-93f0-40f8-8cb2-9d5e9c118add","Rodriguez
-        Inc"],"key_as_string":"53e63aeb-93f0-40f8-8cb2-9d5e9c118add|Rodriguez Inc","doc_count":1},{"key":["ebffcdca-d383-41e2-b814-7e53c3a1c711","Carr-Campbell"],"key_as_string":"ebffcdca-d383-41e2-b814-7e53c3a1c711|Carr-Campbell","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}}'
+      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","_score":4.868718,"_source":{"omschrijving":"snowflake2","identifier":"Document
+        two","publicatie":"fc276b22-afab-4e6a-afc4-3d399604039e","officiele_titel":"","informatie_categorieen":[{"naam":"Investment
+        garden rather tonight.","uuid":"80c109ca-bb46-43bf-adf0-eb77dd74c66b"}],"publisher":{"naam":"Lewis,
+        Gentry and Chase","uuid":"cb43dcb3-bc57-4c58-bb06-6e7e795418b3"},"creatiedatum":"2025-03-21","registratiedatum":"2025-03-22T03:08:27.241097","uuid":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","verkorte_titel":"","laatst_gewijzigd_datum":"2025-03-17T06:24:07.982346"},"sort":[4.868718,1742192647982]},{"_index":"document","_id":"d6eacab4-cb9f-42f7-abdf-719b358da923","_score":4.868718,"_source":{"omschrijving":"snowflake1","identifier":"Document
+        one","publicatie":"554acef8-2a50-451b-853d-4bb3730fbc11","officiele_titel":"","informatie_categorieen":[{"naam":"Finish
+        community leave.","uuid":"3ec31eb4-ead5-4e1e-8efd-75cc7f330659"}],"publisher":{"naam":"Rios-Williams","uuid":"d139e8f5-b8b6-4caf-8735-a13469f340fb"},"creatiedatum":"2025-02-27","registratiedatum":"2025-03-20T09:51:57.479691","uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","verkorte_titel":"","laatst_gewijzigd_datum":"2025-03-14T04:30:35.018976"},"sort":[4.868718,1741926635018]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3ec31eb4-ead5-4e1e-8efd-75cc7f330659","Finish
+        community leave."],"key_as_string":"3ec31eb4-ead5-4e1e-8efd-75cc7f330659|Finish
+        community leave.","doc_count":1},{"key":["80c109ca-bb46-43bf-adf0-eb77dd74c66b","Investment
+        garden rather tonight."],"key_as_string":"80c109ca-bb46-43bf-adf0-eb77dd74c66b|Investment
+        garden rather tonight.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["cb43dcb3-bc57-4c58-bb06-6e7e795418b3","Lewis,
+        Gentry and Chase"],"key_as_string":"cb43dcb3-bc57-4c58-bb06-6e7e795418b3|Lewis,
+        Gentry and Chase","doc_count":1},{"key":["d139e8f5-b8b6-4caf-8735-a13469f340fb","Rios-Williams"],"key_as_string":"d139e8f5-b8b6-4caf-8735-a13469f340fb|Rios-Williams","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -225,16 +227,18 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":19,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","_score":8.251713,"_source":{"omschrijving":"snowflake2","identifier":"Document
-        two","publicatie":"dfafa801-5a2f-4455-b42e-30a1d7773bd9","officiele_titel":"","informatie_categorieen":[{"naam":"Fire
-        owner may.","uuid":"c826fec8-5186-463f-8c88-ce7de6a1a832"}],"publisher":{"naam":"Carr-Campbell","uuid":"ebffcdca-d383-41e2-b814-7e53c3a1c711"},"creatiedatum":"2025-03-07","registratiedatum":"2025-03-24T12:17:41.212217","uuid":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","verkorte_titel":"","laatst_gewijzigd_datum":"2025-03-02T02:24:05.649341"},"sort":[8.251713,1740882245649]},{"_index":"document","_id":"d6eacab4-cb9f-42f7-abdf-719b358da923","_score":8.066895,"_source":{"omschrijving":"snowflake1","identifier":"Document
-        one","publicatie":"8e37b755-c3ca-4a35-848b-9ad5f83a8dd2","officiele_titel":"","informatie_categorieen":[{"naam":"Course
-        fast.","uuid":"1a120dfb-b1df-46ff-8b69-df7fe000eb26"}],"publisher":{"naam":"Rodriguez
-        Inc","uuid":"53e63aeb-93f0-40f8-8cb2-9d5e9c118add"},"creatiedatum":"2025-02-25","registratiedatum":"2025-03-22T12:38:26.076259","uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","verkorte_titel":"","laatst_gewijzigd_datum":"2025-02-26T06:52:37.935310"},"sort":[8.066895,1740552757935]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["1a120dfb-b1df-46ff-8b69-df7fe000eb26","Course
-        fast."],"key_as_string":"1a120dfb-b1df-46ff-8b69-df7fe000eb26|Course fast.","doc_count":1},{"key":["c826fec8-5186-463f-8c88-ce7de6a1a832","Fire
-        owner may."],"key_as_string":"c826fec8-5186-463f-8c88-ce7de6a1a832|Fire owner
-        may.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["53e63aeb-93f0-40f8-8cb2-9d5e9c118add","Rodriguez
-        Inc"],"key_as_string":"53e63aeb-93f0-40f8-8cb2-9d5e9c118add|Rodriguez Inc","doc_count":1},{"key":["ebffcdca-d383-41e2-b814-7e53c3a1c711","Carr-Campbell"],"key_as_string":"ebffcdca-d383-41e2-b814-7e53c3a1c711|Carr-Campbell","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}}'
+      string: '{"took":4,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","_score":8.251713,"_source":{"omschrijving":"snowflake2","identifier":"Document
+        two","publicatie":"fc276b22-afab-4e6a-afc4-3d399604039e","officiele_titel":"","informatie_categorieen":[{"naam":"Investment
+        garden rather tonight.","uuid":"80c109ca-bb46-43bf-adf0-eb77dd74c66b"}],"publisher":{"naam":"Lewis,
+        Gentry and Chase","uuid":"cb43dcb3-bc57-4c58-bb06-6e7e795418b3"},"creatiedatum":"2025-03-21","registratiedatum":"2025-03-22T03:08:27.241097","uuid":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","verkorte_titel":"","laatst_gewijzigd_datum":"2025-03-17T06:24:07.982346"},"sort":[8.251713,1742192647982]},{"_index":"document","_id":"d6eacab4-cb9f-42f7-abdf-719b358da923","_score":8.045088,"_source":{"omschrijving":"snowflake1","identifier":"Document
+        one","publicatie":"554acef8-2a50-451b-853d-4bb3730fbc11","officiele_titel":"","informatie_categorieen":[{"naam":"Finish
+        community leave.","uuid":"3ec31eb4-ead5-4e1e-8efd-75cc7f330659"}],"publisher":{"naam":"Rios-Williams","uuid":"d139e8f5-b8b6-4caf-8735-a13469f340fb"},"creatiedatum":"2025-02-27","registratiedatum":"2025-03-20T09:51:57.479691","uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","verkorte_titel":"","laatst_gewijzigd_datum":"2025-03-14T04:30:35.018976"},"sort":[8.045088,1741926635018]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["3ec31eb4-ead5-4e1e-8efd-75cc7f330659","Finish
+        community leave."],"key_as_string":"3ec31eb4-ead5-4e1e-8efd-75cc7f330659|Finish
+        community leave.","doc_count":1},{"key":["80c109ca-bb46-43bf-adf0-eb77dd74c66b","Investment
+        garden rather tonight."],"key_as_string":"80c109ca-bb46-43bf-adf0-eb77dd74c66b|Investment
+        garden rather tonight.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["cb43dcb3-bc57-4c58-bb06-6e7e795418b3","Lewis,
+        Gentry and Chase"],"key_as_string":"cb43dcb3-bc57-4c58-bb06-6e7e795418b3|Lewis,
+        Gentry and Chase","doc_count":1},{"key":["d139e8f5-b8b6-4caf-8735-a13469f340fb","Rios-Williams"],"key_as_string":"d139e8f5-b8b6-4caf-8735-a13469f340fb|Rios-Williams","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query_default_search_uses_AND_instead_of_OR.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query_default_search_uses_AND_instead_of_OR.yaml
@@ -1,8 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"9c3360b8-2ce7-4742-9051-e586b686fc48","publisher":{"uuid":"606ff670-eadd-4fcd-ba74-f35213f97e03","naam":"Burke-Burke"},"informatie_categorieen":[{"uuid":"07c6c77d-0aba-4840-b419-5aac5e6a56e2","naam":"Production."}],"officiele_titel":"Author
-      worry laugh color.","verkorte_titel":"Image class.","omschrijving":"News early
-      standard ten finish science move.","registratiedatum":"2025-03-22T04:18:50.021155","laatst_gewijzigd_datum":"2025-03-03T15:43:25.534721"}'
+    body: '{"uuid":"9c3360b8-2ce7-4742-9051-e586b686fc48","publisher":{"uuid":"2cbe80e6-6714-42a8-913b-ea0f98321c88","naam":"Wells-Schneider"},"informatie_categorieen":[{"uuid":"f8447db2-5543-4027-af87-5114a9f3115f","naam":"Mission
+      newspaper improve."}],"officiele_titel":"Memory small fund forward sister drop.","verkorte_titel":"Whatever
+      local western.","omschrijving":"Two their vote understand city since pattern
+      give. Food together exist hold another partner wait defense. Identify rise tonight
+      us. Kitchen week under enjoy management factor.","registratiedatum":"2025-03-22T08:49:55.601990","laatst_gewijzigd_datum":"2025-03-17T13:52:38.641014"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -32,11 +34,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"37eb1144-a3da-48d1-b2fb-88075f781611","publicatie":"9c3360b8-2ce7-4742-9051-e586b686fc48","informatie_categorieen":[{"uuid":"60512a0f-6f80-4a9f-919b-4ccc916b4b45","naam":"Heavy
-      really six."}],"publisher":{"uuid":"f094bb99-cd48-4f13-ac0b-613e3e254bc3","naam":"Henson-Rogers"},"identifier":"Document
-      one of many","officiele_titel":"Economic travel explain return.","verkorte_titel":"Position
-      fight rather.","omschrijving":"Attack dark bank father recognize support tend.
-      Senior return personal. Send as necessary indicate result size activity.","creatiedatum":"2025-03-22","registratiedatum":"2025-03-22T20:46:01.791914","laatst_gewijzigd_datum":"2025-03-07T04:54:54.153816"}'
+    body: '{"uuid":"37eb1144-a3da-48d1-b2fb-88075f781611","publicatie":"9c3360b8-2ce7-4742-9051-e586b686fc48","informatie_categorieen":[{"uuid":"e72b60d5-ea00-4232-bc33-17055670a94e","naam":"Military
+      anything imagine."}],"publisher":{"uuid":"6dd6043a-b005-4765-9c81-f6c8dddb491f","naam":"Barrett
+      Group"},"identifier":"Document one of many","officiele_titel":"World talk strong
+      member last cause.","verkorte_titel":"Certain nearly.","omschrijving":"Capital
+      receive pattern effort western rich believe. Word ball different by run last.
+      Contain election could risk condition dark education available.","creatiedatum":"2025-03-21","registratiedatum":"2025-03-21T18:53:43.186292","laatst_gewijzigd_datum":"2025-03-06T02:46:27.346341"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -66,11 +69,12 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"da45268a-ab21-4a81-bfc4-b0430edf339b","publicatie":"9c3360b8-2ce7-4742-9051-e586b686fc48","informatie_categorieen":[{"uuid":"07d834d5-a601-4055-963d-3596e4709746","naam":"Notice
-      write."}],"publisher":{"uuid":"2a2a8e72-a277-4c60-b9cb-63db1821deab","naam":"Williams-Phelps"},"identifier":"Document
-      two of many","officiele_titel":"Capital dog money door until indicate parent.","verkorte_titel":"Then
-      fight.","omschrijving":"Maintain must serious. Upon approach team. Network find
-      will knowledge his.","creatiedatum":"2025-02-27","registratiedatum":"2025-03-24T12:13:03.317035","laatst_gewijzigd_datum":"2025-03-23T20:38:34.392192"}'
+    body: '{"uuid":"da45268a-ab21-4a81-bfc4-b0430edf339b","publicatie":"9c3360b8-2ce7-4742-9051-e586b686fc48","informatie_categorieen":[{"uuid":"73ee8800-b7d8-4d7d-b5f1-9ba2c9911365","naam":"Along
+      opportunity."}],"publisher":{"uuid":"0ded1dde-6ad7-49d5-ace7-8ec23ca941ab","naam":"Johnson-Young"},"identifier":"Document
+      two of many","officiele_titel":"Can walk expect dark they last specific.","verkorte_titel":"List
+      individual education.","omschrijving":"Character life lead soon. Ten need structure
+      community reality respond nearly. His thus purpose want fall value determine
+      each.","creatiedatum":"2025-03-10","registratiedatum":"2025-03-20T17:32:02.150583","laatst_gewijzigd_datum":"2025-03-10T09:52:09.437867"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -117,13 +121,14 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"da45268a-ab21-4a81-bfc4-b0430edf339b","_score":5.072254,"_source":{"omschrijving":"Maintain
-        must serious. Upon approach team. Network find will knowledge his.","identifier":"Document
-        two of many","publicatie":"9c3360b8-2ce7-4742-9051-e586b686fc48","officiele_titel":"Capital
-        dog money door until indicate parent.","informatie_categorieen":[{"naam":"Notice
-        write.","uuid":"07d834d5-a601-4055-963d-3596e4709746"}],"publisher":{"naam":"Williams-Phelps","uuid":"2a2a8e72-a277-4c60-b9cb-63db1821deab"},"creatiedatum":"2025-02-27","registratiedatum":"2025-03-24T12:13:03.317035","uuid":"da45268a-ab21-4a81-bfc4-b0430edf339b","verkorte_titel":"Then
-        fight.","laatst_gewijzigd_datum":"2025-03-23T20:38:34.392192"},"sort":[5.072254,1742762314392]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["07d834d5-a601-4055-963d-3596e4709746","Notice
-        write."],"key_as_string":"07d834d5-a601-4055-963d-3596e4709746|Notice write.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["2a2a8e72-a277-4c60-b9cb-63db1821deab","Williams-Phelps"],"key_as_string":"2a2a8e72-a277-4c60-b9cb-63db1821deab|Williams-Phelps","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
+      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"da45268a-ab21-4a81-bfc4-b0430edf339b","_score":5.072254,"_source":{"omschrijving":"Character
+        life lead soon. Ten need structure community reality respond nearly. His thus
+        purpose want fall value determine each.","identifier":"Document two of many","publicatie":"9c3360b8-2ce7-4742-9051-e586b686fc48","officiele_titel":"Can
+        walk expect dark they last specific.","informatie_categorieen":[{"naam":"Along
+        opportunity.","uuid":"73ee8800-b7d8-4d7d-b5f1-9ba2c9911365"}],"publisher":{"naam":"Johnson-Young","uuid":"0ded1dde-6ad7-49d5-ace7-8ec23ca941ab"},"creatiedatum":"2025-03-10","registratiedatum":"2025-03-20T17:32:02.150583","uuid":"da45268a-ab21-4a81-bfc4-b0430edf339b","verkorte_titel":"List
+        individual education.","laatst_gewijzigd_datum":"2025-03-10T09:52:09.437867"},"sort":[5.072254,1741600329437]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["73ee8800-b7d8-4d7d-b5f1-9ba2c9911365","Along
+        opportunity."],"key_as_string":"73ee8800-b7d8-4d7d-b5f1-9ba2c9911365|Along
+        opportunity.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["0ded1dde-6ad7-49d5-ace7-8ec23ca941ab","Johnson-Young"],"key_as_string":"0ded1dde-6ad7-49d5-ace7-8ec23ca941ab|Johnson-Young","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query_field_boosts.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query_field_boosts.yaml
@@ -31,15 +31,15 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Mon, 24 Mar 2025 11:38:24 GMT
+      - Mon, 24 Mar 2025 15:07:09 GMT
       Server:
       - Werkzeug/3.0.4 Python/3.12.5
     status:
       code: 200
       message: OK
 - request:
-    body: '{"uuid":"3916925a-4260-4505-bfbb-0942113efd49","publicatie":"bbcdc2cd-0a47-4c54-ba1f-1b22feca8603","informatie_categorieen":[{"uuid":"e617e293-15cb-4b43-bf2c-b8f473763cb1","naam":"Country
-      plant."}],"publisher":{"uuid":"031e3703-d5b9-4a23-bcf4-bdfae3afa373","naam":"Newman-Fisher"},"identifier":"document1","officiele_titel":"titel","verkorte_titel":"snowflake","omschrijving":"omschrijving","creatiedatum":"2025-03-06","registratiedatum":"2025-03-20T23:31:10.056351","laatst_gewijzigd_datum":"2025-03-09T19:55:20.969051","document_data":"RG9jdW1lbnQgJzEn"}'
+    body: '{"uuid":"3916925a-4260-4505-bfbb-0942113efd49","publicatie":"8f0ba90b-c2eb-491b-bb79-71a5d29fddfd","informatie_categorieen":[{"uuid":"29c29191-a775-40a8-992b-99cf085109ca","naam":"Administration
+      pay."}],"publisher":{"uuid":"9a975bfc-2015-4bb2-9f11-e57452d18521","naam":"Bowman-Jacobs"},"identifier":"document1","officiele_titel":"titel","verkorte_titel":"snowflake","omschrijving":"omschrijving","creatiedatum":"2025-03-09","registratiedatum":"2025-03-20T06:17:26.880158","laatst_gewijzigd_datum":"2025-02-24T08:08:30.201205","document_data":"RG9jdW1lbnQgJzEn"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -100,17 +100,17 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Mon, 24 Mar 2025 11:38:24 GMT
+      - Mon, 24 Mar 2025 15:07:10 GMT
       Server:
       - Werkzeug/3.0.4 Python/3.12.5
     status:
       code: 200
       message: OK
 - request:
-    body: '{"uuid":"d49bc304-01a1-4eda-a914-a8dda5c901e2","publicatie":"f88bac17-c58c-47ca-a53f-20c44b65bf58","informatie_categorieen":[{"uuid":"9088291c-13c6-4340-bda9-52a38b2ff7cd","naam":"Example
-      example message."}],"publisher":{"uuid":"be5b8a2d-6fcf-4ce1-93b2-fbc64a257628","naam":"Henderson,
-      Clark and Duncan"},"identifier":"snowflake","officiele_titel":"titel","verkorte_titel":"verkorte
-      titel","omschrijving":"omschrijving","creatiedatum":"2025-03-08","registratiedatum":"2025-03-24T07:24:37.639704","laatst_gewijzigd_datum":"2025-02-25T02:18:59.838522","document_data":"RG9jdW1lbnQgJzIn"}'
+    body: '{"uuid":"d49bc304-01a1-4eda-a914-a8dda5c901e2","publicatie":"8425c871-8ae3-46aa-b392-0a976f3d3fa9","informatie_categorieen":[{"uuid":"59266007-b740-4094-bd54-320e5cb51696","naam":"Among
+      race issue."}],"publisher":{"uuid":"5f3c0612-6f1b-45b6-bc39-95016f70bdf9","naam":"Kelley
+      Ltd"},"identifier":"snowflake","officiele_titel":"titel","verkorte_titel":"verkorte
+      titel","omschrijving":"omschrijving","creatiedatum":"2025-03-06","registratiedatum":"2025-03-22T22:20:30.921203","laatst_gewijzigd_datum":"2025-03-07T17:19:52.666072","document_data":"RG9jdW1lbnQgJzIn"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -171,17 +171,17 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Mon, 24 Mar 2025 11:38:25 GMT
+      - Mon, 24 Mar 2025 15:07:11 GMT
       Server:
       - Werkzeug/3.0.4 Python/3.12.5
     status:
       code: 200
       message: OK
 - request:
-    body: '{"uuid":"bdcc4cea-b186-425e-8dcd-9fecb6818563","publicatie":"7ef781d3-395f-4360-86c0-4c9119c2c12c","informatie_categorieen":[{"uuid":"02482da8-1b93-48ad-ac98-2e790ec66621","naam":"Whatever
-      back agency."}],"publisher":{"uuid":"a80c1cc5-3210-4076-86ed-a1e0e336b4d0","naam":"King,
-      Williams and Scott"},"identifier":"document3","officiele_titel":"titel","verkorte_titel":"verkorte
-      titel","omschrijving":"snowflake","creatiedatum":"2025-03-13","registratiedatum":"2025-03-23T14:19:34.988216","laatst_gewijzigd_datum":"2025-03-07T20:54:02.179353","document_data":"RG9jdW1lbnQgJzMn"}'
+    body: '{"uuid":"bdcc4cea-b186-425e-8dcd-9fecb6818563","publicatie":"9df4c738-e3f1-4fd4-ae9c-29633d512201","informatie_categorieen":[{"uuid":"c6cb95ff-2a74-4da1-bf4f-ddf6fcd8bcc9","naam":"World
+      house."}],"publisher":{"uuid":"829daa0b-5138-470c-b702-dffdebfbd5d0","naam":"Mccoy
+      Inc"},"identifier":"document3","officiele_titel":"titel","verkorte_titel":"verkorte
+      titel","omschrijving":"snowflake","creatiedatum":"2025-03-19","registratiedatum":"2025-03-22T10:44:33.925972","laatst_gewijzigd_datum":"2025-03-15T23:03:03.586298","document_data":"RG9jdW1lbnQgJzMn"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -242,16 +242,16 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Mon, 24 Mar 2025 11:38:26 GMT
+      - Mon, 24 Mar 2025 15:07:12 GMT
       Server:
       - Werkzeug/3.0.4 Python/3.12.5
     status:
       code: 200
       message: OK
 - request:
-    body: '{"uuid":"7eade718-bccb-4876-9f00-a095beebc360","publicatie":"0f0d013d-e208-4928-b45b-f014b381d8c3","informatie_categorieen":[{"uuid":"42df87e3-b77b-4f5a-927f-65bb4c30a3a1","naam":"Senior
-      open."}],"publisher":{"uuid":"9ba898d1-9bce-4b77-926e-b5f5397648ab","naam":"Hays-Rogers"},"identifier":"document4","officiele_titel":"snowflake","verkorte_titel":"verkorte
-      titel","omschrijving":"omschrijving","creatiedatum":"2025-03-22","registratiedatum":"2025-03-24T02:06:08.162027","laatst_gewijzigd_datum":"2025-03-02T08:05:45.845681","document_data":"RG9jdW1lbnQgJzQn"}'
+    body: '{"uuid":"7eade718-bccb-4876-9f00-a095beebc360","publicatie":"913946a0-eca6-493a-a919-2b0f1497fd87","informatie_categorieen":[{"uuid":"95fb3447-2984-4e2e-b332-e3fc56b24da9","naam":"Available
+      step safe."}],"publisher":{"uuid":"e5e68d75-f9a4-4e8a-9dba-dd8984528674","naam":"Jackson-Day"},"identifier":"document4","officiele_titel":"snowflake","verkorte_titel":"verkorte
+      titel","omschrijving":"omschrijving","creatiedatum":"2025-03-03","registratiedatum":"2025-03-20T21:00:11.967435","laatst_gewijzigd_datum":"2025-02-25T01:22:50.727517","document_data":"RG9jdW1lbnQgJzQn"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -312,16 +312,16 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Mon, 24 Mar 2025 11:38:27 GMT
+      - Mon, 24 Mar 2025 15:07:13 GMT
       Server:
       - Werkzeug/3.0.4 Python/3.12.5
     status:
       code: 200
       message: OK
 - request:
-    body: '{"uuid":"d21c2a2f-ad02-41d5-8754-d24ba7092090","publicatie":"5989de76-a871-41ca-b4c3-c20be7716b00","informatie_categorieen":[{"uuid":"3190cb2e-b715-4917-8cbd-cadec14ef97e","naam":"Must
-      town."}],"publisher":{"uuid":"f50c0347-3ba3-456f-b587-386a0f1a26f3","naam":"Armstrong-Miller"},"identifier":"document5","officiele_titel":"titel","verkorte_titel":"verkorte
-      titel","omschrijving":"omschrijving","creatiedatum":"2025-03-21","registratiedatum":"2025-03-21T07:04:56.658779","laatst_gewijzigd_datum":"2025-02-26T09:10:35.095352","document_data":"RG9jdW1lbnQgJ3Nub3dmbGFrZSc="}'
+    body: '{"uuid":"d21c2a2f-ad02-41d5-8754-d24ba7092090","publicatie":"1d840f0f-a3f3-47fa-835a-abed40cca80d","informatie_categorieen":[{"uuid":"29e2ce22-f4ab-4fa7-8eb1-15dbfced5774","naam":"Practice
+      pressure ten."}],"publisher":{"uuid":"acc8d265-44f7-4a9b-8a8b-37649df3d772","naam":"Garcia-Davis"},"identifier":"document5","officiele_titel":"titel","verkorte_titel":"verkorte
+      titel","omschrijving":"omschrijving","creatiedatum":"2025-02-22","registratiedatum":"2025-03-20T19:53:06.381471","laatst_gewijzigd_datum":"2025-03-04T19:18:58.170669","document_data":"RG9jdW1lbnQgJ3Nub3dmbGFrZSc="}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -367,29 +367,29 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":9,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":5,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"d49bc304-01a1-4eda-a914-a8dda5c901e2","_score":4.158883,"_source":{"identifier":"snowflake","officiele_titel":"titel","registratiedatum":"2025-03-24T07:24:37.639704","uuid":"d49bc304-01a1-4eda-a914-a8dda5c901e2","laatst_gewijzigd_datum":"2025-02-25T02:18:59.838522","omschrijving":"omschrijving","publicatie":"f88bac17-c58c-47ca-a53f-20c44b65bf58","attachment":{"content":"Document
-        ''2''"},"informatie_categorieen":[{"naam":"Example example message.","uuid":"9088291c-13c6-4340-bda9-52a38b2ff7cd"}],"publisher":{"naam":"Henderson,
-        Clark and Duncan","uuid":"be5b8a2d-6fcf-4ce1-93b2-fbc64a257628"},"creatiedatum":"2025-03-08","verkorte_titel":"verkorte
-        titel"},"sort":[4.158883,1740449939838]},{"_index":"document","_id":"7eade718-bccb-4876-9f00-a095beebc360","_score":2.7725885,"_source":{"identifier":"document4","officiele_titel":"snowflake","registratiedatum":"2025-03-24T02:06:08.162027","uuid":"7eade718-bccb-4876-9f00-a095beebc360","laatst_gewijzigd_datum":"2025-03-02T08:05:45.845681","omschrijving":"omschrijving","publicatie":"0f0d013d-e208-4928-b45b-f014b381d8c3","attachment":{"content":"Document
-        ''4''"},"informatie_categorieen":[{"naam":"Senior open.","uuid":"42df87e3-b77b-4f5a-927f-65bb4c30a3a1"}],"publisher":{"naam":"Hays-Rogers","uuid":"9ba898d1-9bce-4b77-926e-b5f5397648ab"},"creatiedatum":"2025-03-22","verkorte_titel":"verkorte
-        titel"},"sort":[2.7725885,1740902745845]},{"_index":"document","_id":"3916925a-4260-4505-bfbb-0942113efd49","_score":2.54154,"_source":{"identifier":"document1","officiele_titel":"titel","registratiedatum":"2025-03-20T23:31:10.056351","uuid":"3916925a-4260-4505-bfbb-0942113efd49","laatst_gewijzigd_datum":"2025-03-09T19:55:20.969051","omschrijving":"omschrijving","publicatie":"bbcdc2cd-0a47-4c54-ba1f-1b22feca8603","attachment":{"content":"Document
-        ''1''"},"informatie_categorieen":[{"naam":"Country plant.","uuid":"e617e293-15cb-4b43-bf2c-b8f473763cb1"}],"publisher":{"naam":"Newman-Fisher","uuid":"031e3703-d5b9-4a23-bcf4-bdfae3afa373"},"creatiedatum":"2025-03-06","verkorte_titel":"snowflake"},"sort":[2.54154,1741550120969]},{"_index":"document","_id":"bdcc4cea-b186-425e-8dcd-9fecb6818563","_score":1.6635532,"_source":{"identifier":"document3","officiele_titel":"titel","registratiedatum":"2025-03-23T14:19:34.988216","uuid":"bdcc4cea-b186-425e-8dcd-9fecb6818563","laatst_gewijzigd_datum":"2025-03-07T20:54:02.179353","omschrijving":"snowflake","publicatie":"7ef781d3-395f-4360-86c0-4c9119c2c12c","attachment":{"content":"Document
-        ''3''"},"informatie_categorieen":[{"naam":"Whatever back agency.","uuid":"02482da8-1b93-48ad-ac98-2e790ec66621"}],"publisher":{"naam":"King,
-        Williams and Scott","uuid":"a80c1cc5-3210-4076-86ed-a1e0e336b4d0"},"creatiedatum":"2025-03-13","verkorte_titel":"verkorte
-        titel"},"sort":[1.6635532,1741380842179]},{"_index":"document","_id":"d21c2a2f-ad02-41d5-8754-d24ba7092090","_score":1.3862942,"_source":{"identifier":"document5","officiele_titel":"titel","registratiedatum":"2025-03-21T07:04:56.658779","uuid":"d21c2a2f-ad02-41d5-8754-d24ba7092090","laatst_gewijzigd_datum":"2025-02-26T09:10:35.095352","omschrijving":"omschrijving","publicatie":"5989de76-a871-41ca-b4c3-c20be7716b00","attachment":{"content":"Document
-        ''snowflake''"},"informatie_categorieen":[{"naam":"Must town.","uuid":"3190cb2e-b715-4917-8cbd-cadec14ef97e"}],"publisher":{"naam":"Armstrong-Miller","uuid":"f50c0347-3ba3-456f-b587-386a0f1a26f3"},"creatiedatum":"2025-03-21","verkorte_titel":"verkorte
-        titel"},"sort":[1.3862942,1740561035095]}]},"aggregations":{"InformationCategories":{"doc_count":5,"Categories":{"doc_count":5,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["02482da8-1b93-48ad-ac98-2e790ec66621","Whatever
-        back agency."],"key_as_string":"02482da8-1b93-48ad-ac98-2e790ec66621|Whatever
-        back agency.","doc_count":1},{"key":["3190cb2e-b715-4917-8cbd-cadec14ef97e","Must
-        town."],"key_as_string":"3190cb2e-b715-4917-8cbd-cadec14ef97e|Must town.","doc_count":1},{"key":["42df87e3-b77b-4f5a-927f-65bb4c30a3a1","Senior
-        open."],"key_as_string":"42df87e3-b77b-4f5a-927f-65bb4c30a3a1|Senior open.","doc_count":1},{"key":["9088291c-13c6-4340-bda9-52a38b2ff7cd","Example
-        example message."],"key_as_string":"9088291c-13c6-4340-bda9-52a38b2ff7cd|Example
-        example message.","doc_count":1},{"key":["e617e293-15cb-4b43-bf2c-b8f473763cb1","Country
-        plant."],"key_as_string":"e617e293-15cb-4b43-bf2c-b8f473763cb1|Country plant.","doc_count":1}]}}},"Publisher":{"doc_count":5,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["031e3703-d5b9-4a23-bcf4-bdfae3afa373","Newman-Fisher"],"key_as_string":"031e3703-d5b9-4a23-bcf4-bdfae3afa373|Newman-Fisher","doc_count":1},{"key":["9ba898d1-9bce-4b77-926e-b5f5397648ab","Hays-Rogers"],"key_as_string":"9ba898d1-9bce-4b77-926e-b5f5397648ab|Hays-Rogers","doc_count":1},{"key":["a80c1cc5-3210-4076-86ed-a1e0e336b4d0","King,
-        Williams and Scott"],"key_as_string":"a80c1cc5-3210-4076-86ed-a1e0e336b4d0|King,
-        Williams and Scott","doc_count":1},{"key":["be5b8a2d-6fcf-4ce1-93b2-fbc64a257628","Henderson,
-        Clark and Duncan"],"key_as_string":"be5b8a2d-6fcf-4ce1-93b2-fbc64a257628|Henderson,
-        Clark and Duncan","doc_count":1},{"key":["f50c0347-3ba3-456f-b587-386a0f1a26f3","Armstrong-Miller"],"key_as_string":"f50c0347-3ba3-456f-b587-386a0f1a26f3|Armstrong-Miller","doc_count":1}]}},"ResultType":{"doc_count":5,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":5}]}}}}'
+      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":5,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"d49bc304-01a1-4eda-a914-a8dda5c901e2","_score":4.158883,"_source":{"identifier":"snowflake","officiele_titel":"titel","registratiedatum":"2025-03-22T22:20:30.921203","uuid":"d49bc304-01a1-4eda-a914-a8dda5c901e2","laatst_gewijzigd_datum":"2025-03-07T17:19:52.666072","omschrijving":"omschrijving","publicatie":"8425c871-8ae3-46aa-b392-0a976f3d3fa9","attachment":{"content":"Document
+        ''2''"},"informatie_categorieen":[{"naam":"Among race issue.","uuid":"59266007-b740-4094-bd54-320e5cb51696"}],"publisher":{"naam":"Kelley
+        Ltd","uuid":"5f3c0612-6f1b-45b6-bc39-95016f70bdf9"},"creatiedatum":"2025-03-06","verkorte_titel":"verkorte
+        titel"},"sort":[4.158883,1741367992666]},{"_index":"document","_id":"7eade718-bccb-4876-9f00-a095beebc360","_score":2.7725885,"_source":{"identifier":"document4","officiele_titel":"snowflake","registratiedatum":"2025-03-20T21:00:11.967435","uuid":"7eade718-bccb-4876-9f00-a095beebc360","laatst_gewijzigd_datum":"2025-02-25T01:22:50.727517","omschrijving":"omschrijving","publicatie":"913946a0-eca6-493a-a919-2b0f1497fd87","attachment":{"content":"Document
+        ''4''"},"informatie_categorieen":[{"naam":"Available step safe.","uuid":"95fb3447-2984-4e2e-b332-e3fc56b24da9"}],"publisher":{"naam":"Jackson-Day","uuid":"e5e68d75-f9a4-4e8a-9dba-dd8984528674"},"creatiedatum":"2025-03-03","verkorte_titel":"verkorte
+        titel"},"sort":[2.7725885,1740446570727]},{"_index":"document","_id":"3916925a-4260-4505-bfbb-0942113efd49","_score":2.54154,"_source":{"identifier":"document1","officiele_titel":"titel","registratiedatum":"2025-03-20T06:17:26.880158","uuid":"3916925a-4260-4505-bfbb-0942113efd49","laatst_gewijzigd_datum":"2025-02-24T08:08:30.201205","omschrijving":"omschrijving","publicatie":"8f0ba90b-c2eb-491b-bb79-71a5d29fddfd","attachment":{"content":"Document
+        ''1''"},"informatie_categorieen":[{"naam":"Administration pay.","uuid":"29c29191-a775-40a8-992b-99cf085109ca"}],"publisher":{"naam":"Bowman-Jacobs","uuid":"9a975bfc-2015-4bb2-9f11-e57452d18521"},"creatiedatum":"2025-03-09","verkorte_titel":"snowflake"},"sort":[2.54154,1740384510201]},{"_index":"document","_id":"bdcc4cea-b186-425e-8dcd-9fecb6818563","_score":1.6635532,"_source":{"identifier":"document3","officiele_titel":"titel","registratiedatum":"2025-03-22T10:44:33.925972","uuid":"bdcc4cea-b186-425e-8dcd-9fecb6818563","laatst_gewijzigd_datum":"2025-03-15T23:03:03.586298","omschrijving":"snowflake","publicatie":"9df4c738-e3f1-4fd4-ae9c-29633d512201","attachment":{"content":"Document
+        ''3''"},"informatie_categorieen":[{"naam":"World house.","uuid":"c6cb95ff-2a74-4da1-bf4f-ddf6fcd8bcc9"}],"publisher":{"naam":"Mccoy
+        Inc","uuid":"829daa0b-5138-470c-b702-dffdebfbd5d0"},"creatiedatum":"2025-03-19","verkorte_titel":"verkorte
+        titel"},"sort":[1.6635532,1742079783586]},{"_index":"document","_id":"d21c2a2f-ad02-41d5-8754-d24ba7092090","_score":1.3862942,"_source":{"identifier":"document5","officiele_titel":"titel","registratiedatum":"2025-03-20T19:53:06.381471","uuid":"d21c2a2f-ad02-41d5-8754-d24ba7092090","laatst_gewijzigd_datum":"2025-03-04T19:18:58.170669","omschrijving":"omschrijving","publicatie":"1d840f0f-a3f3-47fa-835a-abed40cca80d","attachment":{"content":"Document
+        ''snowflake''"},"informatie_categorieen":[{"naam":"Practice pressure ten.","uuid":"29e2ce22-f4ab-4fa7-8eb1-15dbfced5774"}],"publisher":{"naam":"Garcia-Davis","uuid":"acc8d265-44f7-4a9b-8a8b-37649df3d772"},"creatiedatum":"2025-02-22","verkorte_titel":"verkorte
+        titel"},"sort":[1.3862942,1741115938170]}]},"aggregations":{"InformationCategories":{"doc_count":5,"Categories":{"doc_count":5,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["29c29191-a775-40a8-992b-99cf085109ca","Administration
+        pay."],"key_as_string":"29c29191-a775-40a8-992b-99cf085109ca|Administration
+        pay.","doc_count":1},{"key":["29e2ce22-f4ab-4fa7-8eb1-15dbfced5774","Practice
+        pressure ten."],"key_as_string":"29e2ce22-f4ab-4fa7-8eb1-15dbfced5774|Practice
+        pressure ten.","doc_count":1},{"key":["59266007-b740-4094-bd54-320e5cb51696","Among
+        race issue."],"key_as_string":"59266007-b740-4094-bd54-320e5cb51696|Among
+        race issue.","doc_count":1},{"key":["95fb3447-2984-4e2e-b332-e3fc56b24da9","Available
+        step safe."],"key_as_string":"95fb3447-2984-4e2e-b332-e3fc56b24da9|Available
+        step safe.","doc_count":1},{"key":["c6cb95ff-2a74-4da1-bf4f-ddf6fcd8bcc9","World
+        house."],"key_as_string":"c6cb95ff-2a74-4da1-bf4f-ddf6fcd8bcc9|World house.","doc_count":1}]}}},"Publisher":{"doc_count":5,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["5f3c0612-6f1b-45b6-bc39-95016f70bdf9","Kelley
+        Ltd"],"key_as_string":"5f3c0612-6f1b-45b6-bc39-95016f70bdf9|Kelley Ltd","doc_count":1},{"key":["829daa0b-5138-470c-b702-dffdebfbd5d0","Mccoy
+        Inc"],"key_as_string":"829daa0b-5138-470c-b702-dffdebfbd5d0|Mccoy Inc","doc_count":1},{"key":["9a975bfc-2015-4bb2-9f11-e57452d18521","Bowman-Jacobs"],"key_as_string":"9a975bfc-2015-4bb2-9f11-e57452d18521|Bowman-Jacobs","doc_count":1},{"key":["acc8d265-44f7-4a9b-8a8b-37649df3d772","Garcia-Davis"],"key_as_string":"acc8d265-44f7-4a9b-8a8b-37649df3d772|Garcia-Davis","doc_count":1},{"key":["e5e68d75-f9a4-4e8a-9dba-dd8984528674","Jackson-Day"],"key_as_string":"e5e68d75-f9a4-4e8a-9dba-dd8984528674|Jackson-Day","doc_count":1}]}},"ResultType":{"doc_count":5,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":5}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query_with_exact_match_using_double_quotes.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_query_with_exact_match_using_double_quotes.yaml
@@ -1,7 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","publicatie":"dc4cbd1b-f9b6-466c-a50a-f47239c75fe2","informatie_categorieen":[{"uuid":"124ab56f-c9e7-4d50-9526-8b5ac911570f","naam":"Begin."}],"publisher":{"uuid":"76953080-ec5e-4af7-85b4-c482b05c1fb5","naam":"Perez-Esparza"},"identifier":"","officiele_titel":"","verkorte_titel":"","omschrijving":"Document
-      one, on which we expect an exact phrase match.","creatiedatum":"2025-03-09","registratiedatum":"2025-03-21T01:16:59.206827","laatst_gewijzigd_datum":"2025-03-06T02:41:39.532253"}'
+    body: '{"uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","publicatie":"6b64012e-8c9f-4629-9d87-e421aed5553f","informatie_categorieen":[{"uuid":"ffd0084f-96ad-4cee-9f93-1cc6463a66d3","naam":"Art
+      news opportunity."}],"publisher":{"uuid":"fd1c550b-55bb-46b3-91ba-f1ac03693273","naam":"Kim,
+      Watkins and Downs"},"identifier":"","officiele_titel":"","verkorte_titel":"","omschrijving":"Document
+      one, on which we expect an exact phrase match.","creatiedatum":"2025-03-06","registratiedatum":"2025-03-21T05:57:37.179460","laatst_gewijzigd_datum":"2025-03-24T07:13:40.814237"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -31,10 +33,10 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","publicatie":"a804acff-7978-43a3-9fd2-bebf7a1efeda","informatie_categorieen":[{"uuid":"74e650ea-58f3-489a-97fc-a0598f965d49","naam":"Pull
-      detail too author."}],"publisher":{"uuid":"f1733b2d-2a53-4fbc-8675-6485fb0e791a","naam":"Mason
+    body: '{"uuid":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","publicatie":"e1af48fb-74fb-4b02-825a-ac8ae9435804","informatie_categorieen":[{"uuid":"d5c937c3-67be-4edc-92d1-2e3ce7c9606f","naam":"Fight
+      life major."}],"publisher":{"uuid":"0a04b323-6a4c-41a0-ae0c-c70f4fc8967d","naam":"Harmon
       and Sons"},"identifier":"","officiele_titel":"","verkorte_titel":"","omschrijving":"Document
-      two, the document that came after one.","creatiedatum":"2025-03-03","registratiedatum":"2025-03-21T04:18:57.239843","laatst_gewijzigd_datum":"2025-03-17T21:55:04.512036"}'
+      two, the document that came after one.","creatiedatum":"2025-02-27","registratiedatum":"2025-03-24T00:36:42.577553","laatst_gewijzigd_datum":"2025-02-27T17:41:37.962530"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -81,8 +83,14 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"d6eacab4-cb9f-42f7-abdf-719b358da923","_score":4.173753,"_source":{"omschrijving":"Document
-        one, on which we expect an exact phrase match.","identifier":"","publicatie":"dc4cbd1b-f9b6-466c-a50a-f47239c75fe2","officiele_titel":"","informatie_categorieen":[{"naam":"Begin.","uuid":"124ab56f-c9e7-4d50-9526-8b5ac911570f"}],"publisher":{"naam":"Perez-Esparza","uuid":"76953080-ec5e-4af7-85b4-c482b05c1fb5"},"creatiedatum":"2025-03-09","registratiedatum":"2025-03-21T01:16:59.206827","uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","verkorte_titel":"","laatst_gewijzigd_datum":"2025-03-06T02:41:39.532253"},"sort":[4.173753,1741228899532]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["124ab56f-c9e7-4d50-9526-8b5ac911570f","Begin."],"key_as_string":"124ab56f-c9e7-4d50-9526-8b5ac911570f|Begin.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["76953080-ec5e-4af7-85b4-c482b05c1fb5","Perez-Esparza"],"key_as_string":"76953080-ec5e-4af7-85b4-c482b05c1fb5|Perez-Esparza","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
+      string: '{"took":5,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":1,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"d6eacab4-cb9f-42f7-abdf-719b358da923","_score":4.2332644,"_source":{"omschrijving":"Document
+        one, on which we expect an exact phrase match.","identifier":"","publicatie":"6b64012e-8c9f-4629-9d87-e421aed5553f","officiele_titel":"","informatie_categorieen":[{"naam":"Art
+        news opportunity.","uuid":"ffd0084f-96ad-4cee-9f93-1cc6463a66d3"}],"publisher":{"naam":"Kim,
+        Watkins and Downs","uuid":"fd1c550b-55bb-46b3-91ba-f1ac03693273"},"creatiedatum":"2025-03-06","registratiedatum":"2025-03-21T05:57:37.179460","uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","verkorte_titel":"","laatst_gewijzigd_datum":"2025-03-24T07:13:40.814237"},"sort":[4.2332644,1742800420814]}]},"aggregations":{"InformationCategories":{"doc_count":1,"Categories":{"doc_count":1,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["ffd0084f-96ad-4cee-9f93-1cc6463a66d3","Art
+        news opportunity."],"key_as_string":"ffd0084f-96ad-4cee-9f93-1cc6463a66d3|Art
+        news opportunity.","doc_count":1}]}}},"Publisher":{"doc_count":1,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["fd1c550b-55bb-46b3-91ba-f1ac03693273","Kim,
+        Watkins and Downs"],"key_as_string":"fd1c550b-55bb-46b3-91ba-f1ac03693273|Kim,
+        Watkins and Downs","doc_count":1}]}},"ResultType":{"doc_count":1,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked
@@ -111,15 +119,21 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":10,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","_score":5.463229,"_source":{"omschrijving":"Document
-        two, the document that came after one.","identifier":"","publicatie":"a804acff-7978-43a3-9fd2-bebf7a1efeda","officiele_titel":"","informatie_categorieen":[{"naam":"Pull
-        detail too author.","uuid":"74e650ea-58f3-489a-97fc-a0598f965d49"}],"publisher":{"naam":"Mason
-        and Sons","uuid":"f1733b2d-2a53-4fbc-8675-6485fb0e791a"},"creatiedatum":"2025-03-03","registratiedatum":"2025-03-21T04:18:57.239843","uuid":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","verkorte_titel":"","laatst_gewijzigd_datum":"2025-03-17T21:55:04.512036"},"sort":[5.463229,1742248504512]},{"_index":"document","_id":"d6eacab4-cb9f-42f7-abdf-719b358da923","_score":4.173753,"_source":{"omschrijving":"Document
-        one, on which we expect an exact phrase match.","identifier":"","publicatie":"dc4cbd1b-f9b6-466c-a50a-f47239c75fe2","officiele_titel":"","informatie_categorieen":[{"naam":"Begin.","uuid":"124ab56f-c9e7-4d50-9526-8b5ac911570f"}],"publisher":{"naam":"Perez-Esparza","uuid":"76953080-ec5e-4af7-85b4-c482b05c1fb5"},"creatiedatum":"2025-03-09","registratiedatum":"2025-03-21T01:16:59.206827","uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","verkorte_titel":"","laatst_gewijzigd_datum":"2025-03-06T02:41:39.532253"},"sort":[4.173753,1741228899532]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["124ab56f-c9e7-4d50-9526-8b5ac911570f","Begin."],"key_as_string":"124ab56f-c9e7-4d50-9526-8b5ac911570f|Begin.","doc_count":1},{"key":["74e650ea-58f3-489a-97fc-a0598f965d49","Pull
-        detail too author."],"key_as_string":"74e650ea-58f3-489a-97fc-a0598f965d49|Pull
-        detail too author.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["76953080-ec5e-4af7-85b4-c482b05c1fb5","Perez-Esparza"],"key_as_string":"76953080-ec5e-4af7-85b4-c482b05c1fb5|Perez-Esparza","doc_count":1},{"key":["f1733b2d-2a53-4fbc-8675-6485fb0e791a","Mason
-        and Sons"],"key_as_string":"f1733b2d-2a53-4fbc-8675-6485fb0e791a|Mason and
-        Sons","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}}'
+      string: '{"took":7,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","_score":5.519292,"_source":{"omschrijving":"Document
+        two, the document that came after one.","identifier":"","publicatie":"e1af48fb-74fb-4b02-825a-ac8ae9435804","officiele_titel":"","informatie_categorieen":[{"naam":"Fight
+        life major.","uuid":"d5c937c3-67be-4edc-92d1-2e3ce7c9606f"}],"publisher":{"naam":"Harmon
+        and Sons","uuid":"0a04b323-6a4c-41a0-ae0c-c70f4fc8967d"},"creatiedatum":"2025-02-27","registratiedatum":"2025-03-24T00:36:42.577553","uuid":"a8fce14e-88d1-4f60-a69b-bbcc7033afe9","verkorte_titel":"","laatst_gewijzigd_datum":"2025-02-27T17:41:37.962530"},"sort":[5.519292,1740678097962]},{"_index":"document","_id":"d6eacab4-cb9f-42f7-abdf-719b358da923","_score":4.2332644,"_source":{"omschrijving":"Document
+        one, on which we expect an exact phrase match.","identifier":"","publicatie":"6b64012e-8c9f-4629-9d87-e421aed5553f","officiele_titel":"","informatie_categorieen":[{"naam":"Art
+        news opportunity.","uuid":"ffd0084f-96ad-4cee-9f93-1cc6463a66d3"}],"publisher":{"naam":"Kim,
+        Watkins and Downs","uuid":"fd1c550b-55bb-46b3-91ba-f1ac03693273"},"creatiedatum":"2025-03-06","registratiedatum":"2025-03-21T05:57:37.179460","uuid":"d6eacab4-cb9f-42f7-abdf-719b358da923","verkorte_titel":"","laatst_gewijzigd_datum":"2025-03-24T07:13:40.814237"},"sort":[4.2332644,1742800420814]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["d5c937c3-67be-4edc-92d1-2e3ce7c9606f","Fight
+        life major."],"key_as_string":"d5c937c3-67be-4edc-92d1-2e3ce7c9606f|Fight
+        life major.","doc_count":1},{"key":["ffd0084f-96ad-4cee-9f93-1cc6463a66d3","Art
+        news opportunity."],"key_as_string":"ffd0084f-96ad-4cee-9f93-1cc6463a66d3|Art
+        news opportunity.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["0a04b323-6a4c-41a0-ae0c-c70f4fc8967d","Harmon
+        and Sons"],"key_as_string":"0a04b323-6a4c-41a0-ae0c-c70f4fc8967d|Harmon and
+        Sons","doc_count":1},{"key":["fd1c550b-55bb-46b3-91ba-f1ac03693273","Kim,
+        Watkins and Downs"],"key_as_string":"fd1c550b-55bb-46b3-91ba-f1ac03693273|Kim,
+        Watkins and Downs","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":2}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_sort_chronological.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_search_api/SearchApiTest/test_sort_chronological.yaml
@@ -1,9 +1,11 @@
 interactions:
 - request:
-    body: '{"uuid":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","publisher":{"uuid":"c88ea292-fb58-4284-b10b-a0f07335b680","naam":"Harris-Tucker"},"informatie_categorieen":[{"uuid":"839d186a-276f-48c1-bfc3-7ed77dc8dc99","naam":"Quality
-      benefit situation."}],"officiele_titel":"Show down treat away.","verkorte_titel":"Enter
-      born include.","omschrijving":"Sense language sense far price. Control happen
-      popular much deal thousand lead. Main base worry peace seek common.","registratiedatum":"2025-03-24T02:51:51.506073","laatst_gewijzigd_datum":"2026-01-02T12:00:00+00:00"}'
+    body: '{"uuid":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","publisher":{"uuid":"8f861462-0035-4633-8b89-4dc06cfd932d","naam":"Hunter
+      Inc"},"informatie_categorieen":[{"uuid":"82fa6a7b-66ef-48bd-8c82-7f7b0757136e","naam":"Against
+      trip western."}],"officiele_titel":"Prove work career prove serve receive position.","verkorte_titel":"Detail
+      visit president.","omschrijving":"Middle allow answer star ball. Case manager
+      onto majority ahead bring serious. Rock chance table trial dog so. Someone rock
+      history wind treatment project require.","registratiedatum":"2025-03-24T03:11:44.556904","laatst_gewijzigd_datum":"2026-01-02T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -33,10 +35,11 @@ interactions:
       code: 201
       message: Created
 - request:
-    body: '{"uuid":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","publicatie":"8cf139ac-b668-4c64-9f6e-255468567bb3","informatie_categorieen":[{"uuid":"30d618de-8189-4032-92d1-fb17a821a569","naam":"Spend
-      most industry."}],"publisher":{"uuid":"fa8b4f41-e9ec-4ae4-b426-e04827dc5fee","naam":"Armstrong
-      Ltd"},"identifier":"identifier-41","officiele_titel":"War try work nearly article.","verkorte_titel":"Manage.","omschrijving":"Under
-      left collection son up. Attorney pull easy.","creatiedatum":"2025-03-22","registratiedatum":"2025-03-22T06:53:39.360544","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
+    body: '{"uuid":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","publicatie":"37b0c741-eb10-4f56-8e0b-daf00c43c760","informatie_categorieen":[{"uuid":"4da5b410-ab3c-45a5-81ca-397aa97d2678","naam":"Reality
+      experience."}],"publisher":{"uuid":"36764d99-d0c5-46a8-9667-889664bde6c6","naam":"Mathews-Ramos"},"identifier":"identifier-45","officiele_titel":"Station
+      least get.","verkorte_titel":"Again activity threat.","omschrijving":"Fine score
+      evening light daughter star base. Age must think clearly their especially treat.
+      Analysis while bag international modern source form.","creatiedatum":"2025-02-24","registratiedatum":"2025-03-23T07:21:50.908824","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -82,18 +85,21 @@ interactions:
     uri: http://localhost:9201/publication,document/_search
   response:
     body:
-      string: '{"took":12,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","_score":1.0,"_source":{"omschrijving":"Under
-        left collection son up. Attorney pull easy.","identifier":"identifier-41","publicatie":"8cf139ac-b668-4c64-9f6e-255468567bb3","officiele_titel":"War
-        try work nearly article.","informatie_categorieen":[{"naam":"Spend most industry.","uuid":"30d618de-8189-4032-92d1-fb17a821a569"}],"publisher":{"naam":"Armstrong
-        Ltd","uuid":"fa8b4f41-e9ec-4ae4-b426-e04827dc5fee"},"creatiedatum":"2025-03-22","registratiedatum":"2025-03-22T06:53:39.360544","uuid":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","verkorte_titel":"Manage.","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1767614400000,1.0]},{"_index":"publication","_id":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","_score":2.0,"_source":{"uuid":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","publisher":{"uuid":"c88ea292-fb58-4284-b10b-a0f07335b680","naam":"Harris-Tucker"},"informatie_categorieen":[{"uuid":"839d186a-276f-48c1-bfc3-7ed77dc8dc99","naam":"Quality
-        benefit situation."}],"officiele_titel":"Show down treat away.","verkorte_titel":"Enter
-        born include.","omschrijving":"Sense language sense far price. Control happen
-        popular much deal thousand lead. Main base worry peace seek common.","registratiedatum":"2025-03-24T02:51:51.506073","laatst_gewijzigd_datum":"2026-01-02T12:00:00+00:00"},"sort":[1767355200000,2.0]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["30d618de-8189-4032-92d1-fb17a821a569","Spend
-        most industry."],"key_as_string":"30d618de-8189-4032-92d1-fb17a821a569|Spend
-        most industry.","doc_count":1},{"key":["839d186a-276f-48c1-bfc3-7ed77dc8dc99","Quality
-        benefit situation."],"key_as_string":"839d186a-276f-48c1-bfc3-7ed77dc8dc99|Quality
-        benefit situation.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["c88ea292-fb58-4284-b10b-a0f07335b680","Harris-Tucker"],"key_as_string":"c88ea292-fb58-4284-b10b-a0f07335b680|Harris-Tucker","doc_count":1},{"key":["fa8b4f41-e9ec-4ae4-b426-e04827dc5fee","Armstrong
-        Ltd"],"key_as_string":"fa8b4f41-e9ec-4ae4-b426-e04827dc5fee|Armstrong Ltd","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
+      string: '{"took":8,"timed_out":false,"_shards":{"total":2,"successful":2,"skipped":0,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":null,"hits":[{"_index":"document","_id":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","_score":1.0,"_source":{"omschrijving":"Fine
+        score evening light daughter star base. Age must think clearly their especially
+        treat. Analysis while bag international modern source form.","identifier":"identifier-45","publicatie":"37b0c741-eb10-4f56-8e0b-daf00c43c760","officiele_titel":"Station
+        least get.","informatie_categorieen":[{"naam":"Reality experience.","uuid":"4da5b410-ab3c-45a5-81ca-397aa97d2678"}],"publisher":{"naam":"Mathews-Ramos","uuid":"36764d99-d0c5-46a8-9667-889664bde6c6"},"creatiedatum":"2025-02-24","registratiedatum":"2025-03-23T07:21:50.908824","uuid":"3b3f4514-7d8b-4e31-83ca-fa9376ff6522","verkorte_titel":"Again
+        activity threat.","laatst_gewijzigd_datum":"2026-01-05T12:00:00+00:00"},"sort":[1767614400000,1.0]},{"_index":"publication","_id":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","_score":2.0,"_source":{"uuid":"0ce718e4-8fb5-42f1-a07e-cbf82a869efd","publisher":{"uuid":"8f861462-0035-4633-8b89-4dc06cfd932d","naam":"Hunter
+        Inc"},"informatie_categorieen":[{"uuid":"82fa6a7b-66ef-48bd-8c82-7f7b0757136e","naam":"Against
+        trip western."}],"officiele_titel":"Prove work career prove serve receive
+        position.","verkorte_titel":"Detail visit president.","omschrijving":"Middle
+        allow answer star ball. Case manager onto majority ahead bring serious. Rock
+        chance table trial dog so. Someone rock history wind treatment project require.","registratiedatum":"2025-03-24T03:11:44.556904","laatst_gewijzigd_datum":"2026-01-02T12:00:00+00:00"},"sort":[1767355200000,2.0]}]},"aggregations":{"InformationCategories":{"doc_count":2,"Categories":{"doc_count":2,"FilteredCategories":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["4da5b410-ab3c-45a5-81ca-397aa97d2678","Reality
+        experience."],"key_as_string":"4da5b410-ab3c-45a5-81ca-397aa97d2678|Reality
+        experience.","doc_count":1},{"key":["82fa6a7b-66ef-48bd-8c82-7f7b0757136e","Against
+        trip western."],"key_as_string":"82fa6a7b-66ef-48bd-8c82-7f7b0757136e|Against
+        trip western.","doc_count":1}]}}},"Publisher":{"doc_count":2,"FilteredPublisher":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":["36764d99-d0c5-46a8-9667-889664bde6c6","Mathews-Ramos"],"key_as_string":"36764d99-d0c5-46a8-9667-889664bde6c6|Mathews-Ramos","doc_count":1},{"key":["8f861462-0035-4633-8b89-4dc06cfd932d","Hunter
+        Inc"],"key_as_string":"8f861462-0035-4633-8b89-4dc06cfd932d|Hunter Inc","doc_count":1}]}},"ResultType":{"doc_count":2,"FilteredResultType":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"document","doc_count":1},{"key":"publication","doc_count":1}]}}}}'
     headers:
       Transfer-Encoding:
       - chunked

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/DocumentTaskTest/test_full_document_text_index_without_service_configured.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/DocumentTaskTest/test_full_document_text_index_without_service_configured.yaml
@@ -13,7 +13,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/document/_doc/e62db63f-9e99-41a4-88a9-be9cc3d7509a?pipeline=document_attachment&refresh=wait_for
   response:
@@ -39,9 +39,9 @@ interactions:
       connection:
       - keep-alive
       user-agent:
-      - elasticsearch-py/8.17.1 (Python/3.12.6; elastic-transport/8.17.0)
+      - elasticsearch-py/8.17.1 (Python/3.12.9; elastic-transport/8.17.0)
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/document/_doc/e62db63f-9e99-41a4-88a9-be9cc3d7509a
   response:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/DocumentTaskTest/test_full_text_upload.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/DocumentTaskTest/test_full_text_upload.yaml
@@ -31,9 +31,9 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Fri, 21 Mar 2025 11:25:52 GMT
+      - Mon, 24 Mar 2025 15:01:50 GMT
       Server:
-      - Werkzeug/3.1.3 Python/3.12.9
+      - Werkzeug/3.0.4 Python/3.12.5
     status:
       code: 200
       message: OK
@@ -51,7 +51,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/document/_doc/e90b8ea2-1ac2-4ef9-80ed-059d69eb3c54?pipeline=document_attachment&refresh=wait_for
   response:
@@ -77,9 +77,9 @@ interactions:
       connection:
       - keep-alive
       user-agent:
-      - elasticsearch-py/8.17.1 (Python/3.12.6; elastic-transport/8.17.0)
+      - elasticsearch-py/8.17.1 (Python/3.12.9; elastic-transport/8.17.0)
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/document/_doc/e90b8ea2-1ac2-4ef9-80ed-059d69eb3c54
   response:
@@ -129,9 +129,9 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Fri, 21 Mar 2025 11:25:53 GMT
+      - Mon, 24 Mar 2025 15:01:51 GMT
       Server:
-      - Werkzeug/3.1.3 Python/3.12.9
+      - Werkzeug/3.0.4 Python/3.12.5
     status:
       code: 204
       message: NO CONTENT
@@ -149,7 +149,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/document/_doc/9acc8148-b498-4c15-b2df-0f26d41ff4c2?pipeline=document_attachment&refresh=wait_for
   response:
@@ -175,9 +175,9 @@ interactions:
       connection:
       - keep-alive
       user-agent:
-      - elasticsearch-py/8.17.1 (Python/3.12.6; elastic-transport/8.17.0)
+      - elasticsearch-py/8.17.1 (Python/3.12.9; elastic-transport/8.17.0)
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/document/_doc/9acc8148-b498-4c15-b2df-0f26d41ff4c2
   response:
@@ -228,9 +228,9 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Fri, 21 Mar 2025 11:25:54 GMT
+      - Mon, 24 Mar 2025 15:01:52 GMT
       Server:
-      - Werkzeug/3.1.3 Python/3.12.9
+      - Werkzeug/3.0.4 Python/3.12.5
     status:
       code: 400
       message: BAD REQUEST
@@ -248,7 +248,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/document/_doc/9acc8148-b498-4c15-b2df-0f26d41ff4c2?pipeline=document_attachment&refresh=wait_for
   response:
@@ -272,9 +272,9 @@ interactions:
       connection:
       - keep-alive
       user-agent:
-      - elasticsearch-py/8.17.1 (Python/3.12.6; elastic-transport/8.17.0)
+      - elasticsearch-py/8.17.1 (Python/3.12.9; elastic-transport/8.17.0)
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/document/_doc/9acc8148-b498-4c15-b2df-0f26d41ff4c2
   response:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/DocumentTaskTest/test_full_text_upload_download_url_service_unauthorized.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/DocumentTaskTest/test_full_text_upload_download_url_service_unauthorized.yaml
@@ -13,7 +13,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/document/_doc/9acc8148-b498-4c15-b2df-0f26d41ff4c2?pipeline=document_attachment&refresh=wait_for
   response:
@@ -39,9 +39,9 @@ interactions:
       connection:
       - keep-alive
       user-agent:
-      - elasticsearch-py/8.17.1 (Python/3.12.6; elastic-transport/8.17.0)
+      - elasticsearch-py/8.17.1 (Python/3.12.9; elastic-transport/8.17.0)
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/document/_doc/9acc8148-b498-4c15-b2df-0f26d41ff4c2
   response:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/DocumentTaskTest/test_full_text_upload_with_max_file_size.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/DocumentTaskTest/test_full_text_upload_with_max_file_size.yaml
@@ -13,7 +13,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/document/_doc/ed19d46e-c367-4410-a891-88f20d232a03?pipeline=document_attachment&refresh=wait_for
   response:
@@ -39,9 +39,9 @@ interactions:
       connection:
       - keep-alive
       user-agent:
-      - elasticsearch-py/8.17.1 (Python/3.12.6; elastic-transport/8.17.0)
+      - elasticsearch-py/8.17.1 (Python/3.12.9; elastic-transport/8.17.0)
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/document/_doc/ed19d46e-c367-4410-a891-88f20d232a03
   response:
@@ -74,7 +74,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/document/_doc/da97b6cb-7211-4762-9673-21a08f508e85%20?pipeline=document_attachment&refresh=wait_for
   response:
@@ -100,9 +100,9 @@ interactions:
       connection:
       - keep-alive
       user-agent:
-      - elasticsearch-py/8.17.1 (Python/3.12.6; elastic-transport/8.17.0)
+      - elasticsearch-py/8.17.1 (Python/3.12.9; elastic-transport/8.17.0)
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/document/_doc/da97b6cb-7211-4762-9673-21a08f508e85%20
   response:
@@ -153,9 +153,9 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Fri, 21 Mar 2025 11:25:58 GMT
+      - Mon, 24 Mar 2025 15:01:56 GMT
       Server:
-      - Werkzeug/3.1.3 Python/3.12.9
+      - Werkzeug/3.0.4 Python/3.12.5
     status:
       code: 200
       message: OK
@@ -173,7 +173,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/document/_doc/554be64c-e6af-49b5-8af5-80e83155212d?pipeline=document_attachment&refresh=wait_for
   response:
@@ -199,9 +199,9 @@ interactions:
       connection:
       - keep-alive
       user-agent:
-      - elasticsearch-py/8.17.1 (Python/3.12.6; elastic-transport/8.17.0)
+      - elasticsearch-py/8.17.1 (Python/3.12.9; elastic-transport/8.17.0)
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/document/_doc/554be64c-e6af-49b5-8af5-80e83155212d
   response:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/DocumentTaskTest/test_index_document_roundtrip.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/DocumentTaskTest/test_index_document_roundtrip.yaml
@@ -13,7 +13,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/document/_doc/0095704d-4216-4de3-83d2-20dba551b0dc?pipeline=document_attachment&refresh=wait_for
   response:
@@ -41,7 +41,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/document/_doc/0095704d-4216-4de3-83d2-20dba551b0dc
   response:
@@ -73,7 +73,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/document/_doc/0095704d-4216-4de3-83d2-20dba551b0dc?pipeline=document_attachment&refresh=wait_for
   response:
@@ -99,7 +99,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/document/_doc/0095704d-4216-4de3-83d2-20dba551b0dc
   response:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/DocumentTaskTest/test_update_full_document_text.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/DocumentTaskTest/test_update_full_document_text.yaml
@@ -31,9 +31,9 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Fri, 21 Mar 2025 11:26:01 GMT
+      - Mon, 24 Mar 2025 15:01:59 GMT
       Server:
-      - Werkzeug/3.1.3 Python/3.12.9
+      - Werkzeug/3.0.4 Python/3.12.5
     status:
       code: 200
       message: OK
@@ -51,7 +51,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/document/_doc/e62db63f-9e99-41a4-88a9-be9cc3d7509a?pipeline=document_attachment&refresh=wait_for
   response:
@@ -77,9 +77,9 @@ interactions:
       connection:
       - keep-alive
       user-agent:
-      - elasticsearch-py/8.17.1 (Python/3.12.6; elastic-transport/8.17.0)
+      - elasticsearch-py/8.17.1 (Python/3.12.9; elastic-transport/8.17.0)
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/document/_doc/e62db63f-9e99-41a4-88a9-be9cc3d7509a
   response:
@@ -131,9 +131,9 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Fri, 21 Mar 2025 11:26:02 GMT
+      - Mon, 24 Mar 2025 15:02:00 GMT
       Server:
-      - Werkzeug/3.1.3 Python/3.12.9
+      - Werkzeug/3.0.4 Python/3.12.5
     status:
       code: 200
       message: OK
@@ -151,7 +151,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/document/_doc/e62db63f-9e99-41a4-88a9-be9cc3d7509a?pipeline=document_attachment&refresh=wait_for
   response:
@@ -175,9 +175,9 @@ interactions:
       connection:
       - keep-alive
       user-agent:
-      - elasticsearch-py/8.17.1 (Python/3.12.6; elastic-transport/8.17.0)
+      - elasticsearch-py/8.17.1 (Python/3.12.9; elastic-transport/8.17.0)
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/document/_doc/e62db63f-9e99-41a4-88a9-be9cc3d7509a
   response:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/PublicationTaskTest/test_index_publication_roundtrip.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/PublicationTaskTest/test_index_publication_roundtrip.yaml
@@ -14,7 +14,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/publication/_doc/55b66c11-7cc9-4c50-bffa-7956e0edacef?refresh=wait_for
   response:
@@ -42,7 +42,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/publication/_doc/55b66c11-7cc9-4c50-bffa-7956e0edacef
   response:
@@ -74,7 +74,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/publication/_doc/55b66c11-7cc9-4c50-bffa-7956e0edacef?refresh=wait_for
   response:
@@ -100,7 +100,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/publication/_doc/55b66c11-7cc9-4c50-bffa-7956e0edacef
   response:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/RemoveFromIndexTaskTests/test_remove_indexed_document.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/RemoveFromIndexTaskTests/test_remove_indexed_document.yaml
@@ -1,11 +1,9 @@
 interactions:
 - request:
-    body: '{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publicatie":"d6947825-29e7-4748-907c-8cfb6fead246","informatie_categorieen":[{"uuid":"a5518408-b86f-4469-a4d0-cbcad74d478b","naam":"Visit
-      thing approach."}],"publisher":{"uuid":"ccbf964a-32c5-4861-a626-23967b473170","naam":"Barrett
-      Group"},"identifier":"identifier-40","officiele_titel":"Property thank six high
-      term prepare strategy.","verkorte_titel":"Arrive audience.","omschrijving":"Mrs
-      no affect meeting improve attention tonight. Campaign myself sign offer. Leader
-      behind or benefit.","creatiedatum":"2025-02-20","registratiedatum":"2025-03-16T21:33:19.176139","laatst_gewijzigd_datum":"2025-02-23T05:44:55.178877"}'
+    body: '{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publicatie":"b56b4ef8-a4a0-4c88-b82a-f4db606e5cc2","informatie_categorieen":[{"uuid":"99927a02-f692-4a41-99a7-09b24dab1c34","naam":"Want."}],"publisher":{"uuid":"b8638b4e-bc86-4609-9960-d8816d3e0a22","naam":"Reyes
+      Ltd"},"identifier":"identifier-46","officiele_titel":"Seven science from.","verkorte_titel":"Bed
+      rest sign.","omschrijving":"Mrs thus very would opportunity later son. Common
+      project write task. Over item money travel.","creatiedatum":"2025-02-28","registratiedatum":"2025-03-19T18:43:16.778202","laatst_gewijzigd_datum":"2025-03-02T23:05:47.429631"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -16,7 +14,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/document/_doc/ad4d66a8-1503-4743-ae55-d1765512530c?pipeline=document_attachment&refresh=wait_for
   response:
@@ -44,23 +42,22 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/document/_doc/ad4d66a8-1503-4743-ae55-d1765512530c
   response:
     body:
       string: '{"_index":"document","_id":"ad4d66a8-1503-4743-ae55-d1765512530c","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"omschrijving":"Mrs
-        no affect meeting improve attention tonight. Campaign myself sign offer. Leader
-        behind or benefit.","identifier":"identifier-40","publicatie":"d6947825-29e7-4748-907c-8cfb6fead246","officiele_titel":"Property
-        thank six high term prepare strategy.","informatie_categorieen":[{"naam":"Visit
-        thing approach.","uuid":"a5518408-b86f-4469-a4d0-cbcad74d478b"}],"publisher":{"naam":"Barrett
-        Group","uuid":"ccbf964a-32c5-4861-a626-23967b473170"},"creatiedatum":"2025-02-20","registratiedatum":"2025-03-16T21:33:19.176139","uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","verkorte_titel":"Arrive
-        audience.","laatst_gewijzigd_datum":"2025-02-23T05:44:55.178877"}}'
+        thus very would opportunity later son. Common project write task. Over item
+        money travel.","identifier":"identifier-46","publicatie":"b56b4ef8-a4a0-4c88-b82a-f4db606e5cc2","officiele_titel":"Seven
+        science from.","informatie_categorieen":[{"naam":"Want.","uuid":"99927a02-f692-4a41-99a7-09b24dab1c34"}],"publisher":{"naam":"Reyes
+        Ltd","uuid":"b8638b4e-bc86-4609-9960-d8816d3e0a22"},"creatiedatum":"2025-02-28","registratiedatum":"2025-03-19T18:43:16.778202","uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","verkorte_titel":"Bed
+        rest sign.","laatst_gewijzigd_datum":"2025-03-02T23:05:47.429631"}}'
     headers:
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '803'
+      - '745'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
@@ -76,7 +73,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: DELETE
     uri: http://localhost:9201/document/_doc/ad4d66a8-1503-4743-ae55-d1765512530c?if_primary_term=1&if_seq_no=0
   response:
@@ -102,7 +99,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/document/_doc/ad4d66a8-1503-4743-ae55-d1765512530c
   response:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/RemoveFromIndexTaskTests/test_remove_indexed_publication.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/RemoveFromIndexTaskTests/test_remove_indexed_publication.yaml
@@ -1,10 +1,10 @@
 interactions:
 - request:
-    body: '{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publisher":{"uuid":"b096fdcb-04dc-4ef7-a2af-794ad32ea9f1","naam":"Thomas
-      Inc"},"informatie_categorieen":[{"uuid":"aefa1735-e126-4edf-9a2f-873e386d1963","naam":"Available
-      early interesting."}],"officiele_titel":"Side leave travel scene another.","verkorte_titel":"Such
-      property.","omschrijving":"Design democratic need somebody issue. Allow child
-      blue how force.","registratiedatum":"2025-03-20T11:04:50.662330","laatst_gewijzigd_datum":"2025-02-28T20:01:03.823992"}'
+    body: '{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publisher":{"uuid":"ddd9eb63-30dd-442a-9582-41030bcebe01","naam":"Kennedy,
+      Butler and Rose"},"informatie_categorieen":[{"uuid":"73d618bb-3e1a-4e14-954e-4088b3bf0988","naam":"Source
+      outside easy prove."}],"officiele_titel":"Voice room use think.","verkorte_titel":"Play
+      child drive.","omschrijving":"Recent bit movement ball water Congress seek.
+      Hand major everybody. Nice wear necessary step research window surface.","registratiedatum":"2025-03-22T21:39:11.376227","laatst_gewijzigd_datum":"2025-02-26T12:59:21.137730"}'
     headers:
       accept:
       - application/vnd.elasticsearch+json; compatible-with=8
@@ -15,7 +15,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: PUT
     uri: http://localhost:9201/publication/_doc/ad4d66a8-1503-4743-ae55-d1765512530c?refresh=wait_for
   response:
@@ -43,21 +43,21 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/publication/_doc/ad4d66a8-1503-4743-ae55-d1765512530c
   response:
     body:
-      string: '{"_index":"publication","_id":"ad4d66a8-1503-4743-ae55-d1765512530c","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publisher":{"uuid":"b096fdcb-04dc-4ef7-a2af-794ad32ea9f1","naam":"Thomas
-        Inc"},"informatie_categorieen":[{"uuid":"aefa1735-e126-4edf-9a2f-873e386d1963","naam":"Available
-        early interesting."}],"officiele_titel":"Side leave travel scene another.","verkorte_titel":"Such
-        property.","omschrijving":"Design democratic need somebody issue. Allow child
-        blue how force.","registratiedatum":"2025-03-20T11:04:50.662330","laatst_gewijzigd_datum":"2025-02-28T20:01:03.823992"}}'
+      string: '{"_index":"publication","_id":"ad4d66a8-1503-4743-ae55-d1765512530c","_version":1,"_seq_no":0,"_primary_term":1,"found":true,"_source":{"uuid":"ad4d66a8-1503-4743-ae55-d1765512530c","publisher":{"uuid":"ddd9eb63-30dd-442a-9582-41030bcebe01","naam":"Kennedy,
+        Butler and Rose"},"informatie_categorieen":[{"uuid":"73d618bb-3e1a-4e14-954e-4088b3bf0988","naam":"Source
+        outside easy prove."}],"officiele_titel":"Voice room use think.","verkorte_titel":"Play
+        child drive.","omschrijving":"Recent bit movement ball water Congress seek.
+        Hand major everybody. Nice wear necessary step research window surface.","registratiedatum":"2025-03-22T21:39:11.376227","laatst_gewijzigd_datum":"2025-02-26T12:59:21.137730"}}'
     headers:
       X-elastic-product:
       - Elasticsearch
       content-length:
-      - '649'
+      - '704'
       content-type:
       - application/vnd.elasticsearch+json;compatible-with=8
     status:
@@ -73,7 +73,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: DELETE
     uri: http://localhost:9201/publication/_doc/ad4d66a8-1503-4743-ae55-d1765512530c?if_primary_term=1&if_seq_no=0
   response:
@@ -99,7 +99,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/publication/_doc/ad4d66a8-1503-4743-ae55-d1765512530c
   response:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/RemoveFromIndexTaskTests/test_remove_non_existing_document.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/RemoveFromIndexTaskTests/test_remove_non_existing_document.yaml
@@ -9,7 +9,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/document/_doc/dd2635a9-228f-4cda-9bec-66310ccbb6a1
   response:

--- a/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/RemoveFromIndexTaskTests/test_remove_non_existing_publication.yaml
+++ b/src/woo_search/search_index/tests/vcr_cassettes/test_tasks/RemoveFromIndexTaskTests/test_remove_non_existing_publication.yaml
@@ -9,7 +9,7 @@ interactions:
       user-agent:
       - elasticsearch-dsl-py/8.17.1
       x-elastic-client-meta:
-      - es=8.17.1,py=3.12.6,t=8.17.0,ur=2.2.2
+      - es=8.17.1,py=3.12.9,t=8.17.0,ur=2.2.2
     method: GET
     uri: http://localhost:9201/publication/_doc/dd2635a9-228f-4cda-9bec-66310ccbb6a1
   response:

--- a/src/woo_search/search_index/typing.py
+++ b/src/woo_search/search_index/typing.py
@@ -51,7 +51,7 @@ class SearchParameters(TypedDict):
     page: int
     page_size: int
     sort: Literal["relevance", "chronological"]
-    result_type: IndexName | Literal["*"]
+    result_types: list[IndexName]
     registratiedatum_vanaf: datetime | None
     registratiedatum_tot: datetime | None
     laatst_gewijzigd_datum_vanaf: datetime | None


### PR DESCRIPTION
Closes #62

**Changes**

Anticipating the future where an additional document type will be introduced, and in light of the bucket aggregation changes made earlier, it was agreed to make the field an array of strings.

If no filter is provided (or empty array), then no filtering is applied, otherwise results are restricted to the specified document types.
