### PR TITLE
Set up django-upgrade-check

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -10,6 +10,7 @@ django-capture-tag
 django-hijack
 django-rosetta
 django-timeline-logger
+django-upgrade-check
 
 # DRF & other API tooling
 open-api-framework

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -99,6 +99,7 @@ django==4.2.20
     #   django-solo
     #   django-timeline-logger
     #   django-two-factor-auth
+    #   django-upgrade-check
     #   djangorestframework
     #   djangorestframework-inclusions
     #   drf-nested-routers
@@ -182,6 +183,8 @@ django-timeline-logger==4.0.0
     # via -r requirements/base.in
 django-two-factor-auth==1.17.0
     # via maykin-2fa
+django-upgrade-check==1.1.0
+    # via -r requirements/base.in
 djangorestframework==3.15.2
     # via
     #   commonground-api-common
@@ -378,6 +381,8 @@ rpds-py==0.20.0
     #   referencing
 self-certifi==1.0.0
     # via -r requirements/base.in
+semantic-version==2.10.0
+    # via django-upgrade-check
 sentry-sdk==2.14.0
     # via open-api-framework
 six==1.16.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -170,6 +170,7 @@ django==4.2.20
     #   django-solo
     #   django-timeline-logger
     #   django-two-factor-auth
+    #   django-upgrade-check
     #   djangorestframework
     #   djangorestframework-inclusions
     #   drf-nested-routers
@@ -328,6 +329,10 @@ django-two-factor-auth==1.17.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   maykin-2fa
+django-upgrade-check==1.1.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
 django-webtest==1.9.12
     # via -r requirements/test-tools.in
 djangorestframework==3.15.2
@@ -767,6 +772,11 @@ self-certifi==1.0.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
+semantic-version==2.10.0
+    # via
+    #   -c requirements/base.txt
+    #   -r requirements/base.txt
+    #   django-upgrade-check
 sentry-sdk==2.14.0
     # via
     #   -c requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -197,6 +197,7 @@ django==4.2.20
     #   django-solo
     #   django-timeline-logger
     #   django-two-factor-auth
+    #   django-upgrade-check
     #   djangorestframework
     #   djangorestframework-inclusions
     #   drf-nested-routers
@@ -359,6 +360,10 @@ django-two-factor-auth==1.17.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   maykin-2fa
+django-upgrade-check==1.1.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 django-webtest==1.9.12
     # via
     #   -c requirements/ci.txt
@@ -852,6 +857,11 @@ self-certifi==1.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+semantic-version==2.10.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   django-upgrade-check
 sentry-sdk==2.14.0
     # via
     #   -c requirements/ci.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -189,6 +189,7 @@ django==4.2.20
     #   django-stubs-ext
     #   django-timeline-logger
     #   django-two-factor-auth
+    #   django-upgrade-check
     #   djangorestframework
     #   djangorestframework-inclusions
     #   drf-nested-routers
@@ -357,6 +358,10 @@ django-two-factor-auth==1.17.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   maykin-2fa
+django-upgrade-check==1.1.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
 django-webtest==1.9.12
     # via
     #   -c requirements/ci.txt
@@ -822,6 +827,11 @@ self-certifi==1.0.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
+semantic-version==2.10.0
+    # via
+    #   -c requirements/ci.txt
+    #   -r requirements/ci.txt
+    #   django-upgrade-check
 sentry-sdk==2.14.0
     # via
     #   -c requirements/ci.txt

--- a/src/woo_search/conf/base.py
+++ b/src/woo_search/conf/base.py
@@ -3,6 +3,7 @@ from django.utils.translation import gettext_lazy as _
 
 from open_api_framework.conf.base import *  # noqa
 from self_certifi import EXTRA_CERTS_ENVVAR as _EXTRA_CERTS_ENVVAR
+from upgrade_check import UpgradeCheck, VersionRange
 from vng_api_common.conf.api import BASE_REST_FRAMEWORK
 
 from .utils import config
@@ -23,6 +24,7 @@ INSTALLED_APPS = INSTALLED_APPS + [
     "hijack.contrib.admin",
     "timeline_logger",
     "drf_polymorphic",
+    "upgrade_check",
     # Project applications.
     "woo_search.accounts",
     "woo_search.api",
@@ -321,3 +323,10 @@ config(
         "'REQUESTS_CA_BUNDLE' is (already) defined."
     ),
 )
+
+#
+# DJANGO-UPGRADE-CHECK
+#
+UPGRADE_CHECK_PATHS = {
+    "2.0.0": UpgradeCheck(VersionRange(minimum="0.1.0")),
+}


### PR DESCRIPTION
So that we're prepared for when we need to gate certain upgrade paths in the future. This now records 'version deploys'.