### PR TITLE
Fix broken documentation CI

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -26,7 +26,7 @@ You need the following libraries and/or programs:
 
 .. _Python: https://www.python.org/
 .. _Virtualenv: https://virtualenv.pypa.io/en/stable/
-.. _Pip: https://packaging.python.org/tutorials/installing-packages/#ensure-pip-setuptools-and-wheel-are-up-to-date
+.. _Pip: https://packaging.python.org/en/latest/tutorials/installing-packages/#ensure-pip-is-up-to-date
 .. _PostgreSQL: https://www.postgresql.org
 .. _Node.js: http://nodejs.org/
 .. _npm: https://www.npmjs.com/


### PR DESCRIPTION
Replaced removed link with a similar one.

Replaced:
https://web.archive.org/web/20260106192642/https://packaging.python.org/en/latest/tutorials/installing-packages/#ensure-pip-setuptools-and-wheel-are-up-to-date

With:
https://packaging.python.org/en/latest/tutorials/installing-packages/#ensure-pip-is-up-to-date