### PR TITLE
Fixes #132 -- make hardcoded uwsgi flags overridable via environment variables

### DIFF
--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -10,8 +10,16 @@ export PGPORT=${DB_PORT:-5432}
 fixtures_dir=${FIXTURES_DIR:-/app/fixtures}
 
 uwsgi_port=${UWSGI_PORT:-8000}
-uwsgi_processes=${UWSGI_PROCESSES:-4}
-uwsgi_threads=${UWSGI_THREADS:-1}
+
+# uwsgi reads UWSGI_* environment variables natively, but explicit CLI flags take
+# precedence over them - so export defaults instead of passing flags, allowing the
+# infra-layer to override any of these without code changes.
+# processes & threads are needed for concurrency without nginx sitting inbetween.
+export UWSGI_PROCESSES=${UWSGI_PROCESSES:-4}
+export UWSGI_THREADS=${UWSGI_THREADS:-1}
+export UWSGI_HARAKIRI=${UWSGI_HARAKIRI:-1800}
+export UWSGI_POST_BUFFERING=${UWSGI_POST_BUFFERING:-8192}
+export UWSGI_BUFFER_SIZE=${UWSGI_BUFFER_SIZE:-65535}
 
 mountpoint=${SUBPATH:-/}
 
@@ -73,10 +81,4 @@ exec uwsgi \
     --static-map /static=/app/static \
     --static-map /media=/app/media  \
     --chdir src \
-    --enable-threads \
-    --processes $uwsgi_processes \
-    --threads $uwsgi_threads \
-    --post-buffering=8192 \
-    --buffer-size=65535 \
-    --harakiri=1800
-    # processes & threads are needed for concurrency without nginx sitting inbetween
+    --enable-threads


### PR DESCRIPTION
Fixes #132

**Changes**

`bin/docker_start.sh`: export `UWSGI_PROCESSES`, `UWSGI_THREADS`, `UWSGI_HARAKIRI`, `UWSGI_POST_BUFFERING` and `UWSGI_BUFFER_SIZE` with the previous values as defaults, and drop the matching explicit CLI flags — uwsgi picks the env vars up natively, so the infra-layer can override any of them without code changes. Effective defaults are unchanged.

Same fix as GPP-Woo/GPP-publicatiebank#450. Unlike publicatiebank there is no `--http-timeout` flag here, so no `UWSGI_HTTP_TIMEOUT` default is introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)