### PR TITLE
Local dev: disable seccomp for Elasticsearch

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,7 @@
+# Local override: Docker Desktop's default seccomp profile makes ES 8.17
+# misdetect the kernel as lacking CONFIG_SECCOMP and abort at boot.
+# Disabling the profile for ES lets it install its own syscall filter.
+services:
+  es:
+    security_opt:
+      - seccomp=unconfined


### PR DESCRIPTION
## What

- **`docker-compose.override.yml`** (new) — sets `security_opt: seccomp=unconfined` on the Elasticsearch (`es`) service for local runs.

## Why

Under Docker Desktop’\s default seccomp profile, Elasticsearch 8.17 misdetects the kernel as lacking `CONFIG_SECCOMP` and aborts at boot. Disabling the seccomp profile for the `es` container lets ES install its own syscall filter and start normally. Scoped to a local `override` file so it does not affect production compose. This unblocks bringing up GPP-zoeken locally for the integrated stack / E2E tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)